### PR TITLE
Fix Generator3 test

### DIFF
--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -1580,7 +1580,6 @@ class C:
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/43")]
         public async Task GeneratorComprehensions() {
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 var text = @"

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -2104,14 +2104,14 @@ class CInheritedInit(CNewStyleInit):
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/41")]
+        //[Ignore("https://github.com/Microsoft/python-language-server/issues/41")]
         public async Task Ellipsis() {
             using (var server = await CreateServerAsync(PythonVersions.EarliestAvailable3X)) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(@"
 x = ...
             ");
 
-                analysis.Should().HaveVariable("x").OfType("ellipsis");
+                analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Ellipsis);
             }
         }
 


### PR DESCRIPTION
Value (type) of 'x' is not changed in the definition and holds original type. Actual value of x = is evaluated dynamically.

Includes fix for #41