### PR TITLE
Fix tuple args signature test

### DIFF
--- a/src/Analysis/Engine/Impl/Values/DictionaryInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/DictionaryInfo.cs
@@ -348,7 +348,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
-        public IEnumerable<IVariableDefinition> IndexTypes => new[] { _keyValueTupleVariable };
+        public IEnumerable<IVariableDefinition> IndexTypes => new[] { KeyValueTupleVariable };
 
         internal IAnalysisSet GetItemsView(AnalysisUnit unit) {
             return DictionaryIterItems(null, unit, null, null);

--- a/src/Analysis/Engine/Impl/Values/DictionaryInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/DictionaryInfo.cs
@@ -25,7 +25,7 @@ using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis.Values {
-    internal class DictionaryInfo : BuiltinInstanceInfo {
+    internal class DictionaryInfo : BuiltinInstanceInfo, IAnalysisIterableValue {
         private SequenceInfo _keyValueTuple;
         private readonly Node _node;
         private VariableDef _keysVariable, _valuesVariable, _keyValueTupleVariable;
@@ -347,6 +347,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 return _valuesVariable;
             }
         }
+
+        public IEnumerable<IVariableDefinition> IndexTypes => new[] { _keyValueTupleVariable };
 
         internal IAnalysisSet GetItemsView(AnalysisUnit unit) {
             return DictionaryIterItems(null, unit, null, null);

--- a/src/Analysis/Engine/Impl/Values/IterableInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/IterableInfo.cs
@@ -291,6 +291,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
             if (indexTypes == null || indexTypes.Length == 0) {
                 yield break;
             }
+            if (indexTypes.Length == 1 && !indexTypes[0].HasTypes) {
+                yield break;
+            }
 
             yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Misc, "[");
             if (indexTypes.Length < 6) {

--- a/src/Analysis/Engine/Impl/Values/IterableInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/IterableInfo.cs
@@ -288,10 +288,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         public override IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             yield return new KeyValuePair<string, string>(WellKnownRichDescriptionKinds.Type, TypeName);
             var indexTypes = IndexTypes;
-            if (indexTypes == null || indexTypes.Length == 0) {
-                yield break;
-            }
-            if (indexTypes.Length == 1 && !indexTypes[0].HasTypes) {
+            if (indexTypes == null || indexTypes.Length == 0 || indexTypes.All(x => !x.HasTypes)) {
                 yield break;
             }
 

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -672,7 +672,6 @@ mc
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/56")]
         public async Task SignatureHelp() {
             var s = await CreateServer();
             var mod = await AddModule(s, @"f()


### PR DESCRIPTION
It was broken with https://github.com/Microsoft/PTVS/pull/4684 that introduced argument types to tuples. However, for basic typeless case we don't need '[]'. Alternatively, we can instead show `[]` that is base enumerable since `*a` accepts both tuples and lists.