### PR TITLE
Fix CompletionAfterLoad test

### DIFF
--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -598,7 +598,6 @@ mc
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/54")]
         public async Task CompletionAfterLoad() {
             var s = await CreateServer();
             var mod1 = await AddModule(s, "import mod2\n\nmod2.", "mod1");


### PR DESCRIPTION
Actually looks like product bug. When adding/removing files, for dependent files we should be going through normal chain via `EnqueueItem` which does many useful things and not directly calling `AnalysisQueue.Enqueue`. We do can save on not parsing, but events should be fired and diagnostics should be updated.