### PR TITLE
Fix ListSubclassSignatures test

### DIFF
--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -2002,7 +2002,6 @@ class H(object):
         /// http://pytools.codeplex.com/workitem/798
         /// </summary>
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/45")]
         public async Task ListSubclassSignatures() {
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 var uri = TestData.GetDefaultModuleUri();

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -2017,7 +2017,7 @@ a.count(");
 
                 analysis.Should().HaveVariable("a").OfType("C");
                 signatures.Should().HaveSingleSignature()
-                    .Which.Should().HaveNoParameters();
+                    .Which.Should().OnlyHaveParameterLabels("x");
             }
         }
 

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -1998,9 +1998,6 @@ class H(object):
             }
         }
 
-        /// <summary>
-        /// http://pytools.codeplex.com/workitem/798
-        /// </summary>
         [TestMethod, Priority(0)]
         public async Task ListSubclassSignatures() {
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {


### PR DESCRIPTION
Changed to match PTVS and PyCharm does show single parameter for `count`