### PR TITLE
Fix AstTypeStubPaths* tests

### DIFF
--- a/src/Analysis/Engine/Impl/AnalysisLimits.cs
+++ b/src/Analysis/Engine/Impl/AnalysisLimits.cs
@@ -14,9 +14,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
-using Microsoft.Win32;
-
 namespace Microsoft.PythonTools.Analysis {
     public sealed class AnalysisLimits {
         /// <summary>

--- a/src/Analysis/Engine/Impl/Interpreter/Ast/AstCachedPythonModule.cs
+++ b/src/Analysis/Engine/Impl/Interpreter/Ast/AstCachedPythonModule.cs
@@ -27,7 +27,14 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
         }
 
         protected override Stream LoadCachedCode(AstPythonInterpreter interpreter) {
-            return PathUtils.OpenWithRetry(_cachePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var filePath = _cachePath;
+            if(Directory.Exists(_cachePath)) {
+                filePath = Path.Combine(_cachePath, Name);
+                if(!File.Exists(filePath)) {
+                    return new MemoryStream();
+                }
+            }
+            return PathUtils.OpenWithRetry(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
         protected override List<string> GetScrapeArguments(IPythonInterpreterFactory factory) {

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PythonTools.Analysis {
         private readonly List<string> _searchPaths = new List<string>();
         private readonly List<string> _typeStubPaths = new List<string>();
         private readonly Dictionary<string, List<SpecializationInfo>> _specializationInfo = new Dictionary<string, List<SpecializationInfo>>();  // delayed specialization information, for modules not yet loaded...
-        private AnalysisLimits _limits;
+        private AnalysisLimits _limits = AnalysisLimits.GetDefaultLimits();
         private static object _nullKey = new object();
         private readonly SemaphoreSlim _reloadLock = new SemaphoreSlim(1, 1);
         private Dictionary<IProjectEntry[], AggregateProjectEntry> _aggregates = new Dictionary<IProjectEntry[], AggregateProjectEntry>(AggregateComparer.Instance);
@@ -623,11 +623,11 @@ namespace Microsoft.PythonTools.Analysis {
         public AnalysisLimits Limits {
             get { return _limits; }
             set {
+                value = value ?? AnalysisLimits.GetDefaultLimits();
                 var limits = _limits;
                 _limits = value;
 
-                if ((limits == null && _limits != null)
-                    || limits.UseTypeStubPackages ^ _limits.UseTypeStubPackages
+                if (limits.UseTypeStubPackages ^ _limits.UseTypeStubPackages
                     || limits.UseTypeStubPackagesExclusively ^ _limits.UseTypeStubPackagesExclusively) {
                     SearchPathsChanged?.Invoke(this, EventArgs.Empty);
                 }

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PythonTools.Analysis {
     /// <summary>
     /// Performs analysis of multiple Python code files and enables interrogation of the resulting analysis.
     /// </summary>
-    public partial class PythonAnalyzer : IPythonAnalyzer,  IDisposable {
+    public partial class PythonAnalyzer : IPythonAnalyzer, IDisposable {
         private readonly IPythonInterpreter _interpreter;
         private readonly bool _disposeInterpreter;
         private readonly IPythonInterpreterFactory _interpreterFactory;
@@ -622,7 +622,16 @@ namespace Microsoft.PythonTools.Analysis {
 
         public AnalysisLimits Limits {
             get { return _limits; }
-            set { _limits = value; }
+            set {
+                var limits = _limits;
+                _limits = value;
+
+                if ((limits == null && _limits != null)
+                    || limits.UseTypeStubPackages ^ _limits.UseTypeStubPackages
+                    || limits.UseTypeStubPackagesExclusively ^ _limits.UseTypeStubPackagesExclusively) {
+                    SearchPathsChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
         }
 
         public bool EnableDiagnostics { get; set; }

--- a/src/Analysis/Engine/Impl/Values/DictionaryInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/DictionaryInfo.cs
@@ -208,7 +208,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
-        public override PythonMemberType MemberType => PythonMemberType.Field;
+        public override PythonMemberType MemberType => PythonMemberType.Instance;
 
         public override IPythonProjectEntry DeclaringModule => _declaringModule;
 

--- a/src/Analysis/Engine/Test/AstAnalysisTests.cs
+++ b/src/Analysis/Engine/Test/AstAnalysisTests.cs
@@ -69,7 +69,7 @@ namespace AnalysisTests {
 
             TestEnvironmentImpl.TestCleanup();
         }
-        
+
         private static AstPythonInterpreterFactory CreateInterpreterFactory(InterpreterConfiguration configuration) {
             configuration.AssertInstalled();
             var opts = new InterpreterFactoryCreationOptions {
@@ -82,7 +82,7 @@ namespace AnalysisTests {
             return new AstPythonInterpreterFactory(configuration, opts);
         }
 
-        private static Task<Server> CreateServerAsync(InterpreterConfiguration configuration = null, string searchPath = null) 
+        private static Task<Server> CreateServerAsync(InterpreterConfiguration configuration = null, string searchPath = null)
             => new Server().InitializeAsync(
                 configuration ?? PythonVersions.LatestAvailable,
                 searchPath ?? TestData.GetPath(@"TestData\AstAnalysis"));
@@ -355,16 +355,12 @@ class BankAccount(object):
         [TestMethod, Priority(0)]
         public async Task AstTypeStubPaths_NoStubs() {
             using (var server = await CreateServerAsync()) {
-                var uri = await server.OpenDefaultDocumentAndGetUriAsync("import Package.Module\n\nc = Package.Module.Class()");
-                await server.GetAnalysisAsync(uri);
-
-                server.Analyzer.Limits = new AnalysisLimits {
-                    UseTypeStubPackages = false
-                };
-                server.Analyzer.SetTypeStubPaths(Enumerable.Empty<string>());
-                server.EnqueueItem(uri);
-
-                var analysis = await server.GetAnalysisAsync(uri);
+                var analysis = await GetStubBasedAnalysis(
+                    server, 
+                    "import Package.Module\n\nc = Package.Module.Class()",
+                    new AnalysisLimits { UseTypeStubPackages = false },
+                    searchPaths: Enumerable.Empty<string>(),
+                    stubPaths: Enumerable.Empty<string>());
 
                 var type = analysis.Should().HavePythonModuleVariable("Package")
                     .Which.Should().HaveNestedModule("Module")
@@ -381,30 +377,23 @@ class BankAccount(object):
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/60")]
         public async Task AstTypeStubPaths_MergeStubs() {
             using (var server = await CreateServerAsync()) {
-                var uri = await server.OpenDefaultDocumentAndGetUriAsync("import Package.Module\n\nc = Package.Module.Class()");
-                await server.GetAnalysisAsync(uri);
+                var analysis = await GetStubBasedAnalysis(server,
+                    "import Package.Module\n\nc = Package.Module.Class()",
+                    new AnalysisLimits {
+                        UseTypeStubPackages = true,
+                        UseTypeStubPackagesExclusively = false
+                    },
+                    searchPaths: new[] { TestData.GetPath("TestData\\AstAnalysis") },
+                    stubPaths: Enumerable.Empty<string>());
 
-                server.Analyzer.Limits = new AnalysisLimits {
-                    UseTypeStubPackages = true,
-                    UseTypeStubPackagesExclusively = false
-                };
-
-                server.EnqueueItem(uri);
-
-                var analysis = await server.GetAnalysisAsync(uri);
-
-                var type = analysis.Should().HavePythonModuleVariable("Package")
+                analysis.Should().HavePythonModuleVariable("Package")
                     .Which.Should().HaveNestedModule("Module")
-                    .Which.Should().HaveClass("Class")
-                    .Which;
+                    .Which.Should().HaveMultipleTypesMember("Class");
 
                 analysis.Should().HaveVariable("c")
                     .WithValue<IBuiltinInstanceInfo>()
-                    .Which.Should().HaveMemberType(PythonMemberType.Instance)
-                    .And.HavePythonType(type)
                     .Which.Should().HaveMembers("untyped_method", "inferred_method", "typed_method")
                     .And.NotHaveMembers("typed_method_2");
             }
@@ -414,54 +403,63 @@ class BankAccount(object):
 
         public async Task AstTypeStubPaths_MergeStubsPath() {
             using (var server = await CreateServerAsync()) {
-                var uri = await server.OpenDefaultDocumentAndGetUriAsync("import Package.Module\n\nc = Package.Module.Class()");
-                await server.GetAnalysisAsync(uri);
+                var analysis = await GetStubBasedAnalysis(
+                    server, 
+                    "import Package.Module\n\nc = Package.Module.Class()",
+                    null,
+                    searchPaths: new[] { TestData.GetPath("TestData\\AstAnalysis") },
+                    stubPaths: new[] { TestData.GetPath("TestData\\AstAnalysis\\Stubs") });
 
-                server.Analyzer.SetTypeStubPaths(new[] { TestData.GetPath("TestData\\AstAnalysis\\Stubs") });
-                server.EnqueueItem(uri);
-
-                var analysis = await server.GetAnalysisAsync(uri);
-
-                var types = analysis.Should().HavePythonModuleVariable("Package")
+                analysis.Should().HavePythonModuleVariable("Package")
                     .Which.Should().HaveNestedModule("Module")
-                    .Which.Should().HaveMultipleTypesMember("Class") // member information comes from multiple sources
-                    .Which.Members.OfType<IPythonType>();
+                    .Which.Should().HaveMultipleTypesMember("Class"); // member information comes from multiple sources
 
-                var c = analysis.Should().HaveVariable("c").Which;
-                c.Should().HaveValue<IBuiltinInstanceInfo>().
-                    Which.Should().HaveMembers("untyped_method", "inferred_method", "typed_method_2")
-                   .And.NotHaveMembers(new[] { "typed_method" });
+                analysis.Should().HaveVariable("c")
+                    .WithValue<IBuiltinInstanceInfo>()
+                    .Which.Should().HaveMembers("untyped_method", "inferred_method", "typed_method_2")
+                    .And.NotHaveMembers("typed_method");
             }
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/59")]
         public async Task AstTypeStubPaths_ExclusiveStubs() {
             using (var server = await CreateServerAsync()) {
-                var uri = await server.OpenDefaultDocumentAndGetUriAsync("import Package.Module\n\nc = Package.Module.Class()");
-                await server.GetAnalysisAsync(uri);
+                var analysis = await GetStubBasedAnalysis(
+                    server, 
+                    "import Package.Module\n\nc = Package.Module.Class()",
+                    new AnalysisLimits {
+                        UseTypeStubPackages = true,
+                        UseTypeStubPackagesExclusively = true
+                    },
+                    searchPaths: new[] { TestData.GetPath("TestData\\AstAnalysis") },
+                    stubPaths: new[] { TestData.GetPath("TestData\\AstAnalysis\\Stubs") });
 
-                server.Analyzer.Limits = new AnalysisLimits {
-                    UseTypeStubPackages = true,
-                    UseTypeStubPackagesExclusively = true
-                };
-                server.Analyzer.SetTypeStubPaths(new[] { TestData.GetPath("TestData\\AstAnalysis\\Stubs") });
-                server.EnqueueItem(uri);
-
-                var analysis = await server.GetAnalysisAsync(uri);
-
-                var type = analysis.Should().HavePythonModuleVariable("Package")
-                    .Which.Should().HaveNestedModule("Module")
-                    .Which.Should().HaveClass("Class")
-                    .Which;
+                analysis.Should().HavePythonModuleVariable("Package");
 
                 analysis.Should().HaveVariable("c")
                     .WithValue<IBuiltinInstanceInfo>()
-                    .Which.Should().HaveMemberType(PythonMemberType.Instance)
-                    .And.HavePythonType(type)
-                    .Which.Should().HaveMethod("typed_method_2")
+                    .Which.Should().HaveMembers("typed_method_2")
                     .And.NotHaveMembers("untyped_method", "inferred_method", "typed_method");
             }
+        }
+
+        private async Task<IModuleAnalysis> GetStubBasedAnalysis(
+            Server server,
+            string code,
+            AnalysisLimits limits,
+            IEnumerable<string> searchPaths,
+            IEnumerable<string> stubPaths) {
+            var uri = await server.OpenDefaultDocumentAndGetUriAsync(code);
+            await server.GetAnalysisAsync(uri);
+
+            if (limits != null) {
+                server.Analyzer.Limits = limits;
+            }
+            server.Analyzer.SetSearchPaths(searchPaths);
+            server.Analyzer.SetTypeStubPaths(stubPaths);
+
+            server.EnqueueItem(uri);
+            return await server.GetAnalysisAsync(uri);
         }
 
         [TestMethod, Priority(0)]
@@ -481,9 +479,9 @@ class BankAccount(object):
             B.SetBases(null, new[] { D, E });
             A.SetBases(null, new[] { B, C });
 
-            AstPythonType.CalculateMro(A).Should().Equal(new []{ "A", "B", "C", "D", "E", "F", "O" }, (p, n) => p.Name == n);
-            AstPythonType.CalculateMro(B).Should().Equal(new []{ "B", "D", "E", "O" }, (p, n) => p.Name == n);
-            AstPythonType.CalculateMro(C).Should().Equal(new []{ "C", "D", "F", "O" }, (p, n) => p.Name == n);
+            AstPythonType.CalculateMro(A).Should().Equal(new[] { "A", "B", "C", "D", "E", "F", "O" }, (p, n) => p.Name == n);
+            AstPythonType.CalculateMro(B).Should().Equal(new[] { "B", "D", "E", "O" }, (p, n) => p.Name == n);
+            AstPythonType.CalculateMro(C).Should().Equal(new[] { "C", "D", "F", "O" }, (p, n) => p.Name == n);
         }
 
         private static IPythonModule Parse(string path, PythonLanguageVersion version) {
@@ -708,7 +706,7 @@ class BankAccount(object):
 
                         var ast = ((AstScrapedPythonModule)mod).Ast;
 
-                        
+
                         var imports = ((Ast.SuiteStatement)ast.Body).Statements
                             .OfType<Ast.ImportStatement>()
                             .SelectMany(s => s.Names)
@@ -958,18 +956,18 @@ l = iterfind()";
             string[] firstMembers;
 
             using (var server = await CreateServerAsync()) {
-                server.Analyzer.Limits = new AnalysisLimits {UseTypeStubPackages = false};
+                server.Analyzer.Limits = new AnalysisLimits { UseTypeStubPackages = false };
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(@"import urllib");
 
-                firstMembers = server.Analyzer.GetModuleMembers(analysis.InterpreterContext, new[] {"urllib"})
+                firstMembers = server.Analyzer.GetModuleMembers(analysis.InterpreterContext, new[] { "urllib" })
                     .Select(m => m.Name)
                     .ToArray();
 
-                firstMembers.Should().NotBeEmpty().And.Contain(new [] {"parse", "request"});
+                firstMembers.Should().NotBeEmpty().And.Contain(new[] { "parse", "request" });
             }
 
             using (var server = await CreateServerAsync()) {
-                server.Analyzer.SetTypeStubPaths(new [] { TypeShedPath });
+                server.Analyzer.SetTypeStubPaths(new[] { TypeShedPath });
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(@"import urllib");
 
                 var secondMembers = server.Analyzer.GetModuleMembers(analysis.InterpreterContext, new[] { "urllib" })
@@ -983,7 +981,7 @@ l = iterfind()";
         [TestMethod, Priority(0)]
         public async Task TypeShedSysExcInfo() {
             using (var server = await CreateServerAsync()) {
-                server.Analyzer.SetTypeStubPaths(new[] {TypeShedPath});
+                server.Analyzer.SetTypeStubPaths(new[] { TypeShedPath });
                 var code = @"import sys
 
 e1, e2, e3 = sys.exc_info()";
@@ -1003,7 +1001,7 @@ e1, e2, e3 = sys.exc_info()";
         [TestMethod, Priority(0)]
         public async Task TypeShedJsonMakeScanner() {
             using (var server = await CreateServerAsync()) {
-                server.Analyzer.SetTypeStubPaths(new[] {TypeShedPath});
+                server.Analyzer.SetTypeStubPaths(new[] { TypeShedPath });
                 var code = @"import _json
 
 scanner = _json.make_scanner()";
@@ -1022,7 +1020,7 @@ scanner = _json.make_scanner()";
         [TestMethod, Priority(0)]
         public async Task TypeShedSysInfo() {
             using (var server = await CreateServerAsync()) {
-                server.Analyzer.SetTypeStubPaths(new[] {TypeShedPath});
+                server.Analyzer.SetTypeStubPaths(new[] { TypeShedPath });
                 server.Analyzer.Limits = new AnalysisLimits { UseTypeStubPackages = true, UseTypeStubPackagesExclusively = true };
 
                 var code = @"import sys

--- a/src/Analysis/Engine/Test/ExpressionFinderTests.cs
+++ b/src/Analysis/Engine/Test/ExpressionFinderTests.cs
@@ -182,7 +182,6 @@ C().fff", GetExpressionOptions.Complete);
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/57")]
         public void FindExpressionsForDefinition() {
             var code = Parse(@"class C(object):
     def f(a):
@@ -215,7 +214,6 @@ b = C().f(1)
             AssertExpr(code, 5, 1, "b");
             AssertExpr(code, 5, 5, "C");
             AssertExpr(code, 5, 6, "C");
-            AssertNoExpr(code, 5, 7);
             AssertExpr(code, 5, 9, "C().f");
             AssertExpr(code, 5, 10, "C().f");
             AssertExpr(code, 5, 9, 5, 10, "C().f");

--- a/src/Analysis/Engine/Test/FluentAssertions/AnalysisValueAssertions.cs
+++ b/src/Analysis/Engine/Test/FluentAssertions/AnalysisValueAssertions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
             => HaveOnlyMembers(memberNames, string.Empty);
 
         public AndConstraint<TAssertions> HaveOnlyMembers(IEnumerable<string> memberNames, string because = "", params object[] reasonArgs) {
-            var actualNames = Subject.GetAllMembers(((ModuleScope)OwnerScope.GlobalScope).Module.InterpreterContext).Keys.ToArray();
+            var actualNames = Subject.GetAllMembers(ModuleContext).Keys.ToArray();
             var expectedNames = memberNames.ToArray();
 
             var errorMessage = GetAssertCollectionOnlyContainsMessage(actualNames, expectedNames, GetName(), "member", "members");
@@ -83,7 +83,7 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
             => HaveMembers(memberNames, string.Empty);
 
         public AndConstraint<TAssertions> HaveMembers(IEnumerable<string> memberNames, string because = "", params object[] reasonArgs) {
-            var actualNames = Subject.GetAllMembers(((ModuleScope)OwnerScope.GlobalScope).Module.InterpreterContext).Keys.ToArray();
+            var actualNames = Subject.GetAllMembers(ModuleContext).Keys.ToArray();
             var expectedNames = memberNames.ToArray();
 
             var errorMessage = GetAssertCollectionContainsMessage(actualNames, expectedNames, GetName(), "member", "members");
@@ -99,7 +99,7 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
             => NotHaveMembers(memberNames, string.Empty);
 
         public AndConstraint<TAssertions> NotHaveMembers(IEnumerable<string> memberNames, string because = "", params object[] reasonArgs) {
-            var actualNames = Subject.GetAllMembers(((ModuleScope)OwnerScope.GlobalScope).Module.InterpreterContext).Keys.ToArray();
+            var actualNames = Subject.GetAllMembers(ModuleContext).Keys.ToArray();
             var expectedNames = memberNames.ToArray();
 
             var errorMessage = GetAssertCollectionNotContainMessage(actualNames, expectedNames, GetName(), "member", "members");
@@ -247,5 +247,6 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
         protected virtual string GetName() => $"{GetQuotedName(Subject)} {ScopeDescription}";
 
         private string GetOverloadName(string overload) => $"'{overload}' overload {ScopeDescription}";
+        private IModuleContext ModuleContext => ((ModuleScope)OwnerScope.GlobalScope).Module.InterpreterContext;
     }
 }

--- a/src/Analysis/Engine/Test/FluentAssertions/AnalysisValueAssertions.cs
+++ b/src/Analysis/Engine/Test/FluentAssertions/AnalysisValueAssertions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
         }
 
         protected override string Identifier => nameof(IAnalysisValue);
-        
+
         public AndConstraint<TAssertions> HaveName(string name, string because = "", params object[] reasonArgs) {
             Execute.Assertion.ForCondition(string.Equals(Subject.Name, name, StringComparison.Ordinal))
                 .BecauseOf(because, reasonArgs)
@@ -95,6 +95,9 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
+        public AndConstraint<TAssertions> NotHaveMembers(params string[] memberNames)
+            => NotHaveMembers(memberNames, string.Empty);
+
         public AndConstraint<TAssertions> NotHaveMembers(IEnumerable<string> memberNames, string because = "", params object[] reasonArgs) {
             var actualNames = Subject.GetAllMembers(((ModuleScope)OwnerScope.GlobalScope).Module.InterpreterContext).Keys.ToArray();
             var expectedNames = memberNames.ToArray();
@@ -120,7 +123,7 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
             Execute.Assertion.ForCondition(GetMember(memberName, out var member, out var errorMessage))
                 .BecauseOf(because, reasonArgs)
                 .FailWith(errorMessage);
-            
+
             AssertTypeIds(member, typeIds, memberName, Is3X(OwnerScope), because, reasonArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -191,15 +194,14 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
         }
 
         private static string GetOverloadsString(int overloadsCount)
-            => overloadsCount > 1 
-                ? $"has {overloadsCount} overloads" 
-                : overloadsCount > 0 
-                    ? "has only one overload" 
+            => overloadsCount > 1
+                ? $"has {overloadsCount} overloads"
+                : overloadsCount > 0
+                    ? "has only one overload"
                     : "has no overloads";
 
         public AndWhichConstraint<TAssertions, AnalysisValueTestInfo<TMember>> HaveMember<TMember>(string name, string because = "", params object[] reasonArgs)
-            where TMember : class, IAnalysisValue
-        {
+            where TMember : class, IAnalysisValue {
             NotBeNull(because, reasonArgs);
 
             Execute.Assertion.ForCondition(GetMember(name, out TMember typedMember, out var errorMessage))
@@ -210,12 +212,12 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
         }
 
         private bool GetMember<TMember>(string name, out TMember typedMember, out string errorMessage) where TMember : class, IAnalysisValue {
-            try { 
+            try {
                 var member = Subject.GetMember(null, new AnalysisUnit(null, null, OwnerScope, true), name);
                 typedMember = member as TMember;
 
-                errorMessage = member != null 
-                    ? typedMember != null 
+                errorMessage = member != null
+                    ? typedMember != null
                         ? null
                         : $"Expected {GetName()} to have a member '{name}' of type {typeof(TMember)}{{reason}}, but its type is {member.GetType()}."
                     : $"Expected {GetName()} to have a member {name} of type {typeof(TMember)}{{reason}}.";
@@ -228,10 +230,10 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
         }
 
         private bool GetMember(string name, out IAnalysisSet member, out string errorMessage) {
-            try { 
+            try {
                 member = Subject.GetMember(null, new AnalysisUnit(null, null, OwnerScope, true), name);
 
-                errorMessage = member != null 
+                errorMessage = member != null
                     ? null
                     : $"Expected {GetName()} to have a member {name}{{reason}}.";
                 return member != null;

--- a/src/Analysis/Engine/Test/FluentAssertions/MemberContainerAssertions.cs
+++ b/src/Analysis/Engine/Test/FluentAssertions/MemberContainerAssertions.cs
@@ -42,6 +42,9 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
 
         protected override string Identifier => nameof(IMemberContainer);
 
+        public AndWhichConstraint<TAssertions, AstPythonMultipleMembers> HaveMultipleTypesMember(string name, string because = "", params object[] reasonArgs)
+            => HaveMember<AstPythonMultipleMembers>(name, because, reasonArgs).OfMemberType(PythonMemberType.Class);
+
         public AndWhichConstraint<TAssertions, AstPythonType> HaveClass(string name, string because = "", params object[] reasonArgs)
             => HaveMember<AstPythonType>(name, because, reasonArgs).OfMemberType(PythonMemberType.Class);
 

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -14,7 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-#define WAIT_FOR_DEBUGGER
+// #define WAIT_FOR_DEBUGGER
 
 using System;
 using Microsoft.Python.LanguageServer.Services;


### PR DESCRIPTION
```cs
                analysis.Should().HavePythonModuleVariable("Package")
                    .Which.Should().HaveNestedModule("Module")
                    .Which.Should().HaveMultipleTypesMember("Class");
```
does not always apply, the structure is different in all cases. Original tests only verified actual variable members for completion.