### PR TITLE
Better progress reporting

### DIFF
--- a/src/Analysis/Engine/Impl/ProjectEntry.cs
+++ b/src/Analysis/Engine/Impl/ProjectEntry.cs
@@ -159,6 +159,7 @@ namespace Microsoft.PythonTools.Analysis {
             lock (this) {
                 _analysisTcs.TrySetResult(Analysis);
             }
+            RaiseNewAnalysis();
         }
 
         internal void ResetCompleteAnalysis() {
@@ -216,7 +217,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
         }
 
-        internal void RaiseNewAnalysis() => NewAnalysis?.Invoke(this, EventArgs.Empty);
+        private void RaiseNewAnalysis() => NewAnalysis?.Invoke(this, EventArgs.Empty);
 
         public int AnalysisVersion { get; private set; }
 

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -925,7 +925,6 @@ namespace Microsoft.PythonTools.Analysis {
             ddg.Analyze(Queue, cancel, _reportQueueSize, _reportQueueInterval);
             foreach (ProjectEntry entry in ddg.AnalyzedEntries) {
                 entry.SetCompleteAnalysis();
-                entry.RaiseNewAnalysis();
             }
         }
 

--- a/src/Analysis/Engine/Impl/Values/Definitions/IAnalysisIterableValue.cs
+++ b/src/Analysis/Engine/Impl/Values/Definitions/IAnalysisIterableValue.cs
@@ -17,7 +17,7 @@
 using System.Collections.Generic;
 
 namespace Microsoft.PythonTools.Analysis.Values {
-    interface IAnalysisIterableValue: IAnalysisValue {
+    public interface IAnalysisIterableValue: IAnalysisValue {
         IEnumerable<IVariableDefinition> IndexTypes { get; }
     }
 }

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -3211,7 +3211,6 @@ f(a=1)
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/51")]
         public async Task ReferencesCrossModule() {
             var fobText = @"
 from oar import abc
@@ -3238,7 +3237,6 @@ abc()
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/53")]
         public async Task SuperclassMemberReferencesCrossModule() {
             // https://github.com/Microsoft/PTVS/issues/2271
 

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -684,7 +684,6 @@ import nt,
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/49")]
         public async Task ImportStarCorrectRefs() {
             var text1 = @"
 from mod2 import *

--- a/src/LanguageServer/Impl/Definitions/ILanguageServerExtensionProvider.cs
+++ b/src/LanguageServer/Impl/Definitions/ILanguageServerExtensionProvider.cs
@@ -17,9 +17,8 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Python.LanguageServer.Extensions;
 
-namespace Microsoft.Python.LanguageServer {
+namespace Microsoft.Python.LanguageServer.Extensions {
     /// <summary>
     /// Implemented on a class that can create a language server extension.
     /// This class must have a default constructor.

--- a/src/LanguageServer/Impl/Definitions/ILogger.cs
+++ b/src/LanguageServer/Impl/Definitions/ILogger.cs
@@ -19,5 +19,6 @@ using System;
 namespace Microsoft.Python.LanguageServer {
     public interface ILogger {
         void TraceMessage(IFormattable message);
+        void TraceMessage(string message);
     }
 }

--- a/src/LanguageServer/Impl/Definitions/ILogger.cs
+++ b/src/LanguageServer/Impl/Definitions/ILogger.cs
@@ -19,6 +19,5 @@ using System;
 namespace Microsoft.Python.LanguageServer {
     public interface ILogger {
         void TraceMessage(IFormattable message);
-        void TraceMessage(string message);
     }
 }

--- a/src/LanguageServer/Impl/Implementation/AnalysisProgressReporter.cs
+++ b/src/LanguageServer/Impl/Implementation/AnalysisProgressReporter.cs
@@ -1,0 +1,85 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PythonTools.Analysis.Infrastructure;
+
+namespace Microsoft.Python.LanguageServer.Implementation {
+    sealed class AnalysisProgressReporter : IDisposable {
+        private readonly DisposableBag _disposables = new DisposableBag(nameof(AnalysisProgressReporter));
+        private readonly Dictionary<Uri, int> _activeAnalysis = new Dictionary<Uri, int>();
+        private readonly IProgressService _progressService;
+        private readonly ILogger _logger;
+        private readonly Server _server;
+        private readonly object _lock = new object();
+        private IProgress _progress;
+
+        public AnalysisProgressReporter(Server server, IProgressService progressService, ILogger logger) {
+            _progressService = progressService;
+            _logger = logger;
+
+            _server = server;
+            _server.OnAnalysisQueued += OnAnalysisQueued;
+            _server.OnAnalysisComplete += OnAnalysisComplete;
+            _disposables
+                .Add(() => _server.OnAnalysisQueued -= OnAnalysisQueued)
+                .Add(() => _server.OnAnalysisComplete -= OnAnalysisComplete)
+                .Add(() => _progress?.Dispose());
+        }
+
+        public void Dispose() {
+            _disposables.TryDispose();
+        }
+
+        private void OnAnalysisQueued(object sender, AnalysisQueuedEventArgs e) {
+            lock (_lock) {
+                if (_activeAnalysis.ContainsKey(e.uri)) {
+                    _activeAnalysis[e.uri]++;
+                } else {
+                    _activeAnalysis[e.uri] = 1;
+                }
+                UpdateProgressMessage();
+            }
+        }
+        private void OnAnalysisComplete(object sender, AnalysisCompleteEventArgs e) {
+            lock (_lock) {
+                if (_activeAnalysis.TryGetValue(e.uri, out var count)) {
+                    if (count > 1) {
+                        _activeAnalysis[e.uri]--;
+                    } else {
+                        _activeAnalysis.Remove(e.uri);
+                    }
+                } else {
+                    _logger.TraceMessage($"Analysis completed for {e.uri} that is not in the dictionary.");
+                }
+                UpdateProgressMessage();
+            }
+        }
+
+        private void UpdateProgressMessage() {
+            if(_activeAnalysis.Count > 0) {
+                _progress = _progress ?? _progressService.BeginProgress();
+                _progress.Report(_activeAnalysis.Count == 1
+                    ? Resources.AnalysisProgress_SingleItemRemaining
+                    : Resources.AnalysisProgress_MultipleItemsRemaining.FormatInvariant(_activeAnalysis.Count)).DoNotWait();
+            } else {
+                _progress?.Dispose();
+                _progress = null;
+            }
+        }
+    }
+}

--- a/src/LanguageServer/Impl/Implementation/Server.Extensions.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Extensions.cs
@@ -77,8 +77,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                         break;
                     }
                     await action(ext.Value, cancellationToken);
-                } catch (Exception ex) when (!ex.IsCriticalException()) {
-                    // We do not replace res in this case.
+                } catch (Exception ex) when (!ex.IsCriticalException() && !(ex is OperationCanceledException)) {
                     LogMessage(MessageType.Error, $"Error invoking extension '{ext.Key}': {ex}");
                 }
             }

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -124,10 +124,9 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         public void Dispose() => _disposableBag.TryDispose();
 
         #region ILogger
-        public void TraceMessage(IFormattable message) => TraceMessage(message.ToString());
-        public void TraceMessage(string message) {
+        public void TraceMessage(IFormattable message) {
             if (_traceLogging) {
-                LogMessage(MessageType.Log, message);
+                LogMessage(MessageType.Log, message.ToString());
             }
         }
         #endregion

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -123,11 +123,14 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         public void Dispose() => _disposableBag.TryDispose();
 
-        public void TraceMessage(IFormattable message) {
+        #region ILogger
+        public void TraceMessage(IFormattable message) => TraceMessage(message.ToString());
+        public void TraceMessage(string message) {
             if (_traceLogging) {
-                LogMessage(MessageType.Log, message.ToString());
+                LogMessage(MessageType.Log, message);
             }
         }
+        #endregion
 
         #region Client message handling
         internal InitializeResult GetInitializeResult() => new InitializeResult {

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         private JsonRpc _rpc;
         private bool _filesLoaded;
-        private Task _progressReportingTask;
         private PathsWatcher _pathsWatcher;
         private IdleTimeTracker _idleTimeTracker;
         private AnalysisProgressReporter _analysisProgressReporter;

--- a/src/LanguageServer/Impl/Resources.Designer.cs
+++ b/src/LanguageServer/Impl/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Microsoft.Python.LanguageServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Analyzing workspace, {0} items remaining....
+        /// </summary>
+        internal static string AnalysisProgress_MultipleItemsRemaining {
+            get {
+                return ResourceManager.GetString("AnalysisProgress_MultipleItemsRemaining", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyzing workspace, 1 item remaining....
+        /// </summary>
+        internal static string AnalysisProgress_SingleItemRemaining {
+            get {
+                return ResourceManager.GetString("AnalysisProgress_SingleItemRemaining", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot rename.
         /// </summary>
         internal static string RenameVariable_CannotRename {

--- a/src/LanguageServer/Impl/Resources.resx
+++ b/src/LanguageServer/Impl/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AnalysisProgress_MultipleItemsRemaining" xml:space="preserve">
+    <value>Analyzing workspace, {0} items remaining...</value>
+  </data>
+  <data name="AnalysisProgress_SingleItemRemaining" xml:space="preserve">
+    <value>Analyzing workspace, 1 item remaining...</value>
+  </data>
   <data name="RenameVariable_CannotRename" xml:space="preserve">
     <value>Cannot rename</value>
   </data>

--- a/src/LanguageServer/Impl/Services/UIService.cs
+++ b/src/LanguageServer/Impl/Services/UIService.cs
@@ -63,7 +63,8 @@ namespace Microsoft.Python.LanguageServer.Services {
         public Task SetStatusBarMessage(string message) 
             => _rpc.NotifyWithParameterObjectAsync("window/setStatusBarMessage", message);
 
-        public void TraceMessage(IFormattable message) => LogMessage(message.ToString(), MessageType.Info);
+        public void TraceMessage(string message) => LogMessage(message.ToString(), MessageType.Info);
+        public void TraceMessage(IFormattable message) => TraceMessage(message.ToString());
 
         public void SetLogLevel(MessageType logLevel) => _logLevel = logLevel;
     }


### PR DESCRIPTION
Fixes #94 

- Make separate class for progress reporting
- Do not use 'estimate work' and rather track specific events
- Make reporting thread safe so we don't end up with multiple competing reporting tasks