### PR TITLE
Fix wait for analysis complete, fix tests and avoid reload on all config changes

### DIFF
--- a/src/Analysis/Engine/Impl/Definitions/IModuleAnalysis.cs
+++ b/src/Analysis/Engine/Impl/Definitions/IModuleAnalysis.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// <param name="location">
         /// The location in the file where the available members should be looked up.
         /// </param>
-        IEnumerable<IMemberResult> GetAllAvailableMembers(SourceLocation location, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults);
+        IEnumerable<IMemberResult> GetAllMembers(SourceLocation location, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults);
 
         /// <summary>
         /// Gets the AST for the given text as if it appeared at the specified location.

--- a/src/Analysis/Engine/Impl/Definitions/IModuleAnalysis.cs
+++ b/src/Analysis/Engine/Impl/Definitions/IModuleAnalysis.cs
@@ -20,6 +20,7 @@ using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis {
     public interface IModuleAnalysis {
+        int Version { get; }
         IModuleContext InterpreterContext { get; }
         PythonAnalyzer ProjectState { get; }
         IScope Scope { get; }

--- a/src/Analysis/Engine/Impl/ModuleAnalysis.cs
+++ b/src/Analysis/Engine/Impl/ModuleAnalysis.cs
@@ -34,20 +34,21 @@ namespace Microsoft.PythonTools.Analysis {
     /// 
     /// Can be queried for various information about the resulting analysis.
     /// </summary>
-    public sealed class ModuleAnalysis: IModuleAnalysis {
+    public sealed class ModuleAnalysis : IModuleAnalysis {
         private readonly AnalysisUnit _unit;
         private static Regex _otherPrivateRegex = new Regex("^_[a-zA-Z_]\\w*__[a-zA-Z_]\\w*$");
 
         private static readonly IEnumerable<IOverloadResult> GetSignaturesError =
             new[] { new OverloadResult(new ParameterResult[0], "Unknown", "IntellisenseError_Sigs", null) };
 
-        internal ModuleAnalysis(AnalysisUnit unit, InterpreterScope scope) {
+        internal ModuleAnalysis(AnalysisUnit unit, InterpreterScope scope, int version) {
             _unit = unit;
             Scope = scope;
+            Version = version;
         }
 
         #region Public API
-
+        public int Version { get; }
         /// <summary>
         /// Evaluates the given expression in at the provided line number and returns the values
         /// that the expression can evaluate to.
@@ -526,7 +527,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// specified location.
         /// </summary>
         /// <param name="index">The 0-based absolute index into the file.</param>
-        internal IEnumerable<IMemberResult> GetDefinitionTreeByIndex(int index) 
+        internal IEnumerable<IMemberResult> GetDefinitionTreeByIndex(int index)
             => GetDefinitionTree(_unit.Tree.IndexToLocation(index));
 
         /// <summary>
@@ -989,9 +990,9 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             return function.Parameters.Any(p => {
-                    var paramName = p.GetVerbatimImage(tree) ?? p.Name;
-                    return index >= p.StartIndex && index <= p.StartIndex + paramName.Length;
-                });
+                var paramName = p.GetVerbatimImage(tree) ?? p.Name;
+                return index >= p.StartIndex && index <= p.StartIndex + paramName.Length;
+            });
         }
 
         private static int GetParentScopeIndent(InterpreterScope scope, PythonAst tree) {

--- a/src/Analysis/Engine/Impl/ModuleAnalysis.cs
+++ b/src/Analysis/Engine/Impl/ModuleAnalysis.cs
@@ -351,7 +351,7 @@ namespace Microsoft.PythonTools.Analysis {
             GetMemberOptions options = GetMemberOptions.IntersectMultipleResults
         ) {
             if (string.IsNullOrEmpty(exprText)) {
-                return GetAllAvailableMembers(location, options);
+                return GetAllMembers(location, options);
             }
 
             var expr = GetExpressionForText(exprText, location, out var scope, out var ast);
@@ -631,7 +631,11 @@ namespace Microsoft.PythonTools.Analysis {
         internal IEnumerable<IMemberResult> GetAllAvailableMembersByIndex(
             int index,
             GetMemberOptions options = GetMemberOptions.IntersectMultipleResults
-        ) => GetAllAvailableMembers(_unit.Tree.IndexToLocation(index), options);
+        ) => GetAllMembers(_unit.Tree.IndexToLocation(index), options);
+
+        [Obsolete]
+        public IEnumerable<MemberResult> GetAllAvailableMembers(SourceLocation location, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults)
+            => GetAllMembers(location, options).OfType<MemberResult>();
 
         /// <summary>
         /// Gets the available names at the given location.  This includes
@@ -642,7 +646,7 @@ namespace Microsoft.PythonTools.Analysis {
         /// looked up.
         /// </param>
         /// <remarks>New in 2.2</remarks>
-        public IEnumerable<IMemberResult> GetAllAvailableMembers(SourceLocation location, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults) {
+        public IEnumerable<IMemberResult> GetAllMembers(SourceLocation location, GetMemberOptions options = GetMemberOptions.IntersectMultipleResults) {
             var result = new Dictionary<string, IEnumerable<AnalysisValue>>();
 
             // collect builtins

--- a/src/Analysis/Engine/Impl/ProjectEntry.cs
+++ b/src/Analysis/Engine/Impl/ProjectEntry.cs
@@ -157,9 +157,13 @@ namespace Microsoft.PythonTools.Analysis {
 
         internal void SetCompleteAnalysis() {
             lock (this) {
-                _analysisTcs.TrySetResult(Analysis);
+                if (AnalysisVersion == _expectedParse) {
+                    _analysisTcs.TrySetResult(Analysis);
+                }
             }
-            RaiseNewAnalysis();
+            if (AnalysisVersion == _expectedParse) {
+                RaiseNewAnalysis();
+            }
         }
 
         internal void ResetCompleteAnalysis() {

--- a/src/Analysis/Engine/Impl/ProjectEntry.cs
+++ b/src/Analysis/Engine/Impl/ProjectEntry.cs
@@ -41,11 +41,15 @@ namespace Microsoft.PythonTools.Analysis {
     [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
         Justification = "Unclear ownership makes it unlikely this object will be disposed correctly")]
     internal sealed class ProjectEntry : IPythonProjectEntry, IAggregateableProjectEntry, IDocument {
-        private AnalysisUnit _unit;
-        private TaskCompletionSource<IModuleAnalysis> _analysisTcs = new TaskCompletionSource<IModuleAnalysis>();
         private readonly SortedDictionary<int, DocumentBuffer> _buffers;
         private readonly ConcurrentQueue<WeakReference<ReferenceDict>> _backReferences = new ConcurrentQueue<WeakReference<ReferenceDict>>();
-        internal readonly HashSet<AggregateProjectEntry> _aggregates = new HashSet<AggregateProjectEntry>();
+        private readonly HashSet<AggregateProjectEntry> _aggregates = new HashSet<AggregateProjectEntry>();
+
+        private TaskCompletionSource<IModuleAnalysis> _analysisTcs = new TaskCompletionSource<IModuleAnalysis>();
+        private AnalysisUnit _unit;
+        private readonly ManualResetEventSlim _pendingParse = new ManualResetEventSlim(true);
+        private long _expectedParseVersion;
+        private long _expectedAnalysisVersion;
 
         internal ProjectEntry(
             PythonAnalyzer state,
@@ -84,17 +88,14 @@ namespace Microsoft.PythonTools.Analysis {
         public event EventHandler<EventArgs> NewParseTree;
         public event EventHandler<EventArgs> NewAnalysis;
 
-        private readonly ManualResetEventSlim _pendingParse = new ManualResetEventSlim(true);
-        private long _expectedParse;
-
         private class ActivePythonParse : IPythonParse {
             private readonly ProjectEntry _entry;
-            private readonly long _expected;
+            private readonly long _expectedVersion;
             private bool _completed;
 
-            public ActivePythonParse(ProjectEntry entry, long expected) {
+            public ActivePythonParse(ProjectEntry entry, long expectedVersion) {
                 _entry = entry;
-                _expected = expected;
+                _expectedVersion = expectedVersion;
             }
 
             public PythonAst Tree { get; set; }
@@ -105,7 +106,7 @@ namespace Microsoft.PythonTools.Analysis {
                     return;
                 }
                 lock (_entry) {
-                    if (_entry._expectedParse == _expected) {
+                    if (_entry._expectedParseVersion == _expectedVersion) {
                         _entry._pendingParse.Set();
                     }
                 }
@@ -114,7 +115,7 @@ namespace Microsoft.PythonTools.Analysis {
             public void Complete() {
                 _completed = true;
                 lock (_entry) {
-                    if (_entry._expectedParse == _expected) {
+                    if (_entry._expectedParseVersion == _expectedVersion) {
                         _entry.SetCurrentParse(Tree, Cookie);
                         _entry._pendingParse.Set();
                     }
@@ -125,8 +126,8 @@ namespace Microsoft.PythonTools.Analysis {
         public IPythonParse BeginParse() {
             _pendingParse.Reset();
             lock (this) {
-                _expectedParse += 1;
-                return new ActivePythonParse(this, _expectedParse);
+                _expectedParseVersion += 1;
+                return new ActivePythonParse(this, _expectedParseVersion);
             }
         }
 
@@ -157,7 +158,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         internal void SetCompleteAnalysis() {
             lock (this) {
-                if (AnalysisVersion < _expectedParse) {
+                if (_expectedAnalysisVersion != Analysis.Version) {
                     return;
                 }
                 _analysisTcs.TrySetResult(Analysis);
@@ -166,8 +167,9 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         internal void ResetCompleteAnalysis() {
-            TaskCompletionSource<IModuleAnalysis> analysisTcs;
+            TaskCompletionSource<IModuleAnalysis> analysisTcs = null;
             lock (this) {
+                _expectedAnalysisVersion = AnalysisVersion + 1;
                 analysisTcs = _analysisTcs;
                 _analysisTcs = new TaskCompletionSource<IModuleAnalysis>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
@@ -191,14 +193,9 @@ namespace Microsoft.PythonTools.Analysis {
             return GetCurrentParse();
         }
 
+        internal bool IsVisible(ProjectEntry assigningScope) => true;
 
-        internal bool IsVisible(ProjectEntry assigningScope) {
-            return true;
-        }
-
-        public void Analyze(CancellationToken cancel) {
-            Analyze(cancel, false);
-        }
+        public void Analyze(CancellationToken cancel) => Analyze(cancel, false);
 
         public void Analyze(CancellationToken cancel, bool enqueueOnly) {
             if (cancel.IsCancellationRequested) {
@@ -317,7 +314,8 @@ namespace Microsoft.PythonTools.Analysis {
             // publish the analysis now that it's complete/running
             Analysis = new ModuleAnalysis(
                 _unit,
-                ((ModuleScope)_unit.Scope).CloneForPublish()
+                ((ModuleScope)_unit.Scope).CloneForPublish(),
+                AnalysisVersion
             );
         }
 

--- a/src/Analysis/Engine/Impl/ProjectEntry.cs
+++ b/src/Analysis/Engine/Impl/ProjectEntry.cs
@@ -157,13 +157,12 @@ namespace Microsoft.PythonTools.Analysis {
 
         internal void SetCompleteAnalysis() {
             lock (this) {
-                if (AnalysisVersion >= _expectedParse) {
-                    _analysisTcs.TrySetResult(Analysis);
+                if (AnalysisVersion < _expectedParse) {
+                    return;
                 }
+                _analysisTcs.TrySetResult(Analysis);
             }
-            if (AnalysisVersion >= _expectedParse) {
-                RaiseNewAnalysis();
-            }
+            RaiseNewAnalysis();
         }
 
         internal void ResetCompleteAnalysis() {
@@ -294,7 +293,7 @@ namespace Microsoft.PythonTools.Analysis {
                 string pathPrefix = PathUtils.EnsureEndSeparator(Path.GetDirectoryName(FilePath));
                 var children =
                     from pair in ProjectState.ModulesByFilename
-                    // Is the candidate child package in a subdirectory of our package?
+                        // Is the candidate child package in a subdirectory of our package?
                     let fileName = pair.Key
                     where fileName.StartsWithOrdinal(pathPrefix, ignoreCase: true)
                     let moduleName = pair.Value.Name

--- a/src/Analysis/Engine/Impl/ProjectEntry.cs
+++ b/src/Analysis/Engine/Impl/ProjectEntry.cs
@@ -157,11 +157,11 @@ namespace Microsoft.PythonTools.Analysis {
 
         internal void SetCompleteAnalysis() {
             lock (this) {
-                if (AnalysisVersion == _expectedParse) {
+                if (AnalysisVersion >= _expectedParse) {
                     _analysisTcs.TrySetResult(Analysis);
                 }
             }
-            if (AnalysisVersion == _expectedParse) {
+            if (AnalysisVersion >= _expectedParse) {
                 RaiseNewAnalysis();
             }
         }

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -5406,7 +5406,7 @@ abc = 42
                 await server.SendDidOpenTextDocument(uriSrc2, src2);
                 await server.SendDidOpenTextDocument(uriSrc3, src3);
 
-                await server.GetAnalysisAsync(uriSrc1);
+                await server.WaitForCompleteAnalysisAsync(CancellationToken.None);
                 var analysis = await server.GetAnalysisAsync(uriSrc2);
 
                 analysis.Should().HaveVariable("y").WithDescription("Python module fob.y")

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -702,10 +702,7 @@ class D(object):
                 await server.SendDidOpenTextDocument(uri1, text1);
                 await server.SendDidOpenTextDocument(uri2, text2);
 
-                await server.GetAnalysisAsync(uri1);
-                await server.GetAnalysisAsync(uri2);
                 var references = await server.SendFindReferences(uri2, 1, 7);
-
                 references.Should().OnlyHaveReferences(
                     (uri1, (3, 4, 3, 5), ReferenceKind.Reference),
                     (uri2, (1, 0, 2, 8), ReferenceKind.Value),
@@ -739,8 +736,6 @@ class D(object):
                 await server.SendDidOpenTextDocument(uri1, text1);
                 await server.SendDidOpenTextDocument(uri2, text2);
 
-                await server.GetAnalysisAsync(uri1);
-                await server.GetAnalysisAsync(uri2);
                 var references = await server.SendFindReferences(uri1, 4, 9);
 
                 references.Should().OnlyHaveReferences(
@@ -751,10 +746,8 @@ class D(object):
 
                 text1 = text1.Substring(0, text1.IndexOf("    def")) + Environment.NewLine + text1.Substring(text1.IndexOf("    def"));
                 server.SendDidChangeTextDocument(uri1, text1);
-                await server.GetAnalysisAsync(uri1);
 
                 references = await server.SendFindReferences(uri1, 5, 9);
-
                 references.Should().OnlyHaveReferences(
                     (uri1, (5, 4, 6, 12), ReferenceKind.Value),
                     (uri1, (5, 8, 5, 18), ReferenceKind.Definition),
@@ -762,12 +755,9 @@ class D(object):
                 );
 
                 text2 = Environment.NewLine + text2;
-
                 server.SendDidChangeTextDocument(uri2, text2);
-                await server.GetAnalysisAsync(uri2);
 
                 references = await server.SendFindReferences(uri1, 5, 9);
-
                 references.Should().OnlyHaveReferences(
                     (uri1, (5, 4, 6, 12), ReferenceKind.Value),
                     (uri1, (5, 8, 5, 18), ReferenceKind.Definition),
@@ -898,7 +888,7 @@ class D(C):
                 completions = await server.SendCompletion(uri, 8, 19);
                 completions.Should().OnlyHaveLabels("_C__X", "__init__", "__doc__", "__class__");
 
-                    code = @"
+                code = @"
 class C(object):
     def __init__(self):
         self.f(_C__A = 42)		# sig help should be _C__A
@@ -937,7 +927,7 @@ class D(C):
         self._C__f(_C__A=42)		# member should be _C__f
 
 ";
-                
+
                 server.SendDidChangeTextDocument(uri, code);
                 await server.GetAnalysisAsync(uri);
 
@@ -1400,7 +1390,7 @@ b = a.__next__()
 
                 analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Generator)
                     .And.HaveVariable("b").OfType(BuiltinTypeId.Int);
-                    //.And.HaveVariable("c").OfType(BuiltinTypeId.Int);
+                //.And.HaveVariable("c").OfType(BuiltinTypeId.Int);
 
                 analysis = await server.ChangeDefaultDocumentAndGetAnalysisAsync(@"
 def g():
@@ -1464,13 +1454,13 @@ b = next(a)
 
         [TestMethod, Priority(0)]
         public async Task ListComprehensions() {
-//            var entry = ProcessText(@"
-//x = [2,3,4]
-//y = [a for a in x]
-//z = y[0]
-//            ");
+            //            var entry = ProcessText(@"
+            //x = [2,3,4]
+            //y = [a for a in x]
+            //z = y[0]
+            //            ");
 
-//            AssertUtil.ContainsExactly(entry.GetTypesFromName("z", 0), IntType);
+            //            AssertUtil.ContainsExactly(entry.GetTypesFromName("z", 0), IntType);
 
             string text = @"
 def f(abc):
@@ -1482,9 +1472,8 @@ def f(abc):
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 var uri = TestData.GetDefaultModuleUri();
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 4, 2);
 
+                var references = await server.SendFindReferences(uri, 4, 2);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 0, 2, 13), ReferenceKind.Value),
                     (uri, (1, 4, 1, 5), ReferenceKind.Definition),
@@ -1537,7 +1526,7 @@ exec b in a
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 var uri = TestData.GetDefaultModuleUri();
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
+
                 var referencesA = await server.SendFindReferences(uri, 1, 1);
                 var referencesB = await server.SendFindReferences(uri, 2, 1);
 
@@ -2213,7 +2202,7 @@ f = 1 / 2 # f is 'int', should be 'float' under v3.x");
                     .And.HaveVariable("e").OfType(BuiltinTypeId.Long)
                     .And.HaveVariable("f").OfType(BuiltinTypeId.Int);
             }
-            
+
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable3X)) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(@"
 a = 1. + 2. + 3. # no type info for a, b or c
@@ -2371,7 +2360,7 @@ a = not C()
                 analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Bool);
             }
         }
-        
+
         [TestMethod, Priority(0)]
         public async Task UnaryOperatorPlus() {
             using (var server = await CreateServerAsync()) {
@@ -2390,7 +2379,7 @@ b = ++C()
                     .And.HaveVariable("b").OfTypes("Result");
             }
         }
-        
+
         [TestMethod, Priority(0)]
         public async Task UnaryOperatorMinus() {
             using (var server = await CreateServerAsync()) {
@@ -2409,7 +2398,7 @@ b = --C()
                     .And.HaveVariable("b").OfTypes("Result");
             }
         }
-        
+
         [TestMethod, Priority(0)]
         public async Task UnaryOperatorTilde() {
             using (var server = await CreateServerAsync()) {
@@ -2707,7 +2696,7 @@ class C(object):
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 var uri = TestData.GetDefaultModuleUri();
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
+
                 var referencesAbc = await server.SendFindReferences(uri, 8, 15);
                 var referencesFob = await server.SendFindReferences(uri, 8, 21);
 
@@ -2739,7 +2728,7 @@ class C(object):
 ";
 
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
+
                 var referencesAbc = await server.SendFindReferences(uri, 4, 15);
                 var referencesFob = await server.SendFindReferences(uri, 4, 21);
 
@@ -2763,7 +2752,7 @@ class D(object):
 
 D(42)";
                 server.SendDidChangeTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
+
                 referencesAbc = await server.SendFindReferences(uri, 4, 15);
                 referencesFob = await server.SendFindReferences(uri, 4, 21);
                 var referencesD = await server.SendFindReferences(uri, 8, 1);
@@ -2794,9 +2783,8 @@ def f(): pass
 
 x = f()";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var referencesF = await server.SendFindReferences(uri, 3, 5);
 
+                var referencesF = await server.SendFindReferences(uri, 3, 5);
                 referencesF.Should().OnlyHaveReferences(
                     (uri, (1, 0, 1, 13), ReferenceKind.Value),
                     (uri, (1, 4, 1, 5), ReferenceKind.Definition),
@@ -2808,7 +2796,6 @@ def f(): pass
 
 x = f";
                 server.SendDidChangeTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
                 referencesF = await server.SendFindReferences(uri, 3, 5);
 
                 referencesF.Should().OnlyHaveReferences(
@@ -2831,7 +2818,6 @@ class D(object):
     del abc
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
                 var references = await server.SendFindReferences(uri, 3, 5);
 
                 references.Should().OnlyHaveReferences(
@@ -2852,7 +2838,6 @@ class D(object): pass
 a = D
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
                 var references = await server.SendFindReferences(uri, 3, 5);
 
                 references.Should().OnlyHaveReferences(
@@ -2874,9 +2859,8 @@ class D(object):
 a = D().f()
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 4, 9);
 
+                var references = await server.SendFindReferences(uri, 4, 9);
                 references.Should().OnlyHaveReferences(
                     (uri, (2, 4, 2, 21), ReferenceKind.Value),
                     (uri, (2, 8, 2, 9), ReferenceKind.Definition),
@@ -2895,9 +2879,8 @@ print abc
 del abc
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 2, 7);
 
+                var references = await server.SendFindReferences(uri, 2, 7);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 0, 1, 3), ReferenceKind.Definition),
                     (uri, (2, 6, 2, 9), ReferenceKind.Reference),
@@ -2917,9 +2900,8 @@ def f(abc):
     del abc
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 2, 11);
 
+                var references = await server.SendFindReferences(uri, 2, 11);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 9), ReferenceKind.Definition),
                     (uri, (3, 4, 3, 7), ReferenceKind.Definition),
@@ -2940,9 +2922,8 @@ def f(abc):
 f(abc = 123)
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 2, 11);
 
+                var references = await server.SendFindReferences(uri, 2, 11);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 9), ReferenceKind.Definition),
                     (uri, (2, 10, 2, 13), ReferenceKind.Reference),
@@ -3006,9 +2987,8 @@ def f(abc):
         abc
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 3, 12);
 
+                var references = await server.SendFindReferences(uri, 3, 12);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 9), ReferenceKind.Definition),
                     (uri, (3, 11, 3, 14), ReferenceKind.Reference),
@@ -3091,9 +3071,8 @@ def f(abc):
     lambda : abc
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 3, 12);
 
+                var references = await server.SendFindReferences(uri, 3, 12);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 9), ReferenceKind.Definition),
 
@@ -3153,7 +3132,6 @@ def f(a):
         a = 200
 ";
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
 
                 var references = await server.SendFindReferences(uri, 3, 15);
                 references.Should().OnlyHaveReferences(
@@ -3172,7 +3150,7 @@ def f(a):
                 );
             }
         }
-        
+
         [TestMethod, Priority(0)]
         public async Task ListDictArgReferences() {
             var text = @"
@@ -3187,7 +3165,6 @@ k = 2
             var uri = TestData.GetDefaultModuleUri();
             using (var server = await CreateServerAsync()) {
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
 
                 var referencesA = await server.SendFindReferences(uri, 2, 8);
                 var referencesK = await server.SendFindReferences(uri, 3, 8);
@@ -3218,9 +3195,8 @@ f(a=1)
             var uri = TestData.GetDefaultModuleUri();
             using (var server = await CreateServerAsync()) {
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
-                var references = await server.SendFindReferences(uri, 4, 3);
 
+                var references = await server.SendFindReferences(uri, 4, 3);
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 7), ReferenceKind.Definition),
                     (uri, (4, 2, 4, 3), ReferenceKind.Reference)
@@ -3241,10 +3217,8 @@ abc()
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable3X)) {
                 await server.SendDidOpenTextDocument(fobUri, fobText);
                 await server.SendDidOpenTextDocument(oarUri, oarText);
-                await server.GetAnalysisAsync(fobUri);
-                await server.GetAnalysisAsync(oarUri);
-                var references = await server.SendFindReferences(oarUri, 0, 7);
 
+                var references = await server.SendFindReferences(oarUri, 0, 7);
                 references.Should().OnlyHaveReferences(
                     (oarUri, (0, 0, 0, 23), ReferenceKind.Value),
                     (oarUri, (0, 6, 0, 9), ReferenceKind.Definition),
@@ -3275,10 +3249,8 @@ class bcd(abc):
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable3X)) {
                 await server.SendDidOpenTextDocument(fobUri, fobText);
                 await server.SendDidOpenTextDocument(oarUri, oarText);
-                await server.GetAnalysisAsync(fobUri);
-                await server.GetAnalysisAsync(oarUri);
-                var references = await server.SendFindReferences(oarUri, 2, 14);
 
+                var references = await server.SendFindReferences(oarUri, 2, 14);
                 references.Should().OnlyHaveReferences(
                     (oarUri, (2, 13, 2, 14), ReferenceKind.Definition),
                     (fobUri, (5, 13, 5, 14), ReferenceKind.Reference)
@@ -3307,10 +3279,6 @@ from baz import abc2 as abc";
                 await server.SendDidOpenTextDocument(oarUri, oarText);
                 await server.SendDidOpenTextDocument(bazUri, bazText);
                 await server.SendDidOpenTextDocument(oarBazUri, oarBazText);
-                await server.GetAnalysisAsync(fobUri);
-                await server.GetAnalysisAsync(oarUri);
-                await server.GetAnalysisAsync(bazUri);
-                await server.GetAnalysisAsync(oarBazUri);
 
                 var referencesAbc1 = await server.SendFindReferences(oarUri, 0, 7);
                 var referencesAbc2 = await server.SendFindReferences(bazUri, 4, 7);
@@ -3361,8 +3329,6 @@ f = fn()";
             using (var server = await CreateServerAsync()) {
                 await server.SendDidOpenTextDocument(fobUri, fobText);
                 await server.SendDidOpenTextDocument(oarUri, oarText);
-                await server.GetAnalysisAsync(fobUri);
-                await server.GetAnalysisAsync(oarUri);
 
                 var referencesConstant = await server.SendFindReferences(oarUri, 4, 5);
                 var referencesClass = await server.SendFindReferences(oarUri, 5, 5);
@@ -3406,8 +3372,6 @@ g = f()";
             using (var server = await CreateServerAsync()) {
                 await server.SendDidOpenTextDocument(fobUri, fobText);
                 await server.SendDidOpenTextDocument(oarUri, oarText);
-                await server.GetAnalysisAsync(fobUri);
-                await server.GetAnalysisAsync(oarUri);
 
                 var referencesConstant = await server.SendFindReferences(fobUri, 1, 1);
                 var referencesClass = await server.SendFindReferences(fobUri, 2, 7);
@@ -3475,7 +3439,7 @@ g = f()";
             var uri = TestData.GetDefaultModuleUri();
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable3X)) {
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
+
                 var referencesF = await server.SendFindReferences(uri, 1, 8);
                 var referencesX = await server.SendFindReferences(uri, 2, 8);
                 var referencesG = await server.SendFindReferences(uri, 3, 8);
@@ -3512,7 +3476,7 @@ g = f()";
             var uri = TestData.GetDefaultModuleUri();
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 await server.SendDidOpenTextDocument(uri, text);
-                await server.GetAnalysisAsync(uri);
+
                 var referencesF = await server.SendFindReferences(uri, 1, 8);
                 var referencesX = await server.SendFindReferences(uri, 2, 8);
                 var referencesG = await server.SendFindReferences(uri, 3, 8);
@@ -3561,7 +3525,7 @@ def m(x = math.atan2(1, 0)): pass
 
             using (var server = await CreateServerAsync()) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(code);
-                
+
                 var tests = new[] {
                     new { FuncName = "f", DefaultValue = "None" },
                     new { FuncName = "g", DefaultValue = "{}" },
@@ -3614,7 +3578,7 @@ for v in vs:
                     .And.HaveVariable("k").OfType(BuiltinTypeId.Int)
                     .And.HaveVariable("iterk").OfType(BuiltinTypeId.Int)
                     .And.HaveVariable("v").OfType(BuiltinTypeId.Int);
-            
+
 
                 // dict methods which return a key or value
                 code = @"x = {}
@@ -3664,40 +3628,40 @@ for itm in itms:
                     .And.HaveVariable("itm").OfType(BuiltinTypeId.Tuple).WithDescription("tuple[int, int]");
             }
         }
-/*
-        /// <summary>
-        /// Verifies that list indicies don't accumulate classes across multiple analysis
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public async Task ListIndiciesCrossModuleAnalysis() {
-            for (int i = 0; i < 2; i++) {
-                var code1 = "l = []";
-                var code2 = @"class C(object):
-    pass
+        /*
+                /// <summary>
+                /// Verifies that list indicies don't accumulate classes across multiple analysis
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public async Task ListIndiciesCrossModuleAnalysis() {
+                    for (int i = 0; i < 2; i++) {
+                        var code1 = "l = []";
+                        var code2 = @"class C(object):
+            pass
 
-a = C()
-import mod1
-mod1.l.append(a)
-";
+        a = C()
+        import mod1
+        mod1.l.append(a)
+        ";
 
-                var state = CreateAnalyzer();
-                var mod1 = state.AddModule("mod1", code1);
-                var mod2 = state.AddModule("mod2", code2);
-                state.ReanalyzeAll();
+                        var state = CreateAnalyzer();
+                        var mod1 = state.AddModule("mod1", code1);
+                        var mod2 = state.AddModule("mod2", code2);
+                        state.ReanalyzeAll();
 
-                if (i == 0) {
-                    // re-preparing shouldn't be necessary
-                    state.UpdateModule(mod2, code2);
+                        if (i == 0) {
+                            // re-preparing shouldn't be necessary
+                            state.UpdateModule(mod2, code2);
+                        }
+
+                        mod2.Analyze(CancellationToken.None, true);
+                        state.WaitForAnalysis();
+
+                        state.AssertDescription("l", "list[C]");
+                        state.AssertIsInstance("l[0]", "C");
+                    }
                 }
-
-                mod2.Analyze(CancellationToken.None, true);
-                state.WaitForAnalysis();
-
-                state.AssertDescription("l", "list[C]");
-                state.AssertIsInstance("l[0]", "C");
-            }
-        }
-*/
+        */
         [TestMethod, Priority(0)]
         public async Task SpecialListMethodsCrossUnitAnalysis() {
             var code = @"x = []
@@ -4022,7 +3986,7 @@ fob = abc.f()
             }
         }
 
-        
+
 
         [MatrixRow(@"
 def f(a, b, c): 
@@ -5262,7 +5226,7 @@ class C(object):
 fob = C.x
 oar = C().x
 ";
-            using(var server = await CreateServerAsync()) {
+            using (var server = await CreateServerAsync()) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(code);
 
                 analysis.Should().HaveVariable("fob").OfType(BuiltinTypeId.Int)
@@ -5287,7 +5251,7 @@ class C(object):
 
 oar = C().x
 ";
-            using(var server = await CreateServerAsync()) {
+            using (var server = await CreateServerAsync()) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(content);
 
                 analysis.Should().HaveClass("mydesc").WithFunction("__get__").WithParameter("inst").OfType("C").WithValue<IInstanceInfo>()
@@ -5304,7 +5268,7 @@ class x(object):
     def f(self):
         pass
 ";
-            using(var server = await CreateServerAsync()) {
+            using (var server = await CreateServerAsync()) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(content);
 
                 analysis.Should().HaveClass("x").WithFunction("f").WithParameter("self").WithValue<IInstanceInfo>()
@@ -5324,7 +5288,7 @@ t.x, t. =
             // http://pytools.codeplex.com/workitem/733
 
             // this just shouldn't crash, we should handle the malformed code, not much to inspect afterwards...
-            using(var server = await CreateServerAsync()) {
+            using (var server = await CreateServerAsync()) {
                 await server.OpenDefaultDocumentAndGetAnalysisAsync(content);
             }
         }
@@ -5350,7 +5314,7 @@ t.x, t. =
                 for (var i = 0; i < files.Length && server.AnalysisQueue.Count < 50; i++) {
                     await server.SendDidOpenTextDocument(new Uri(files[i]), contentTasks[i].Result);
                 }
-                
+
                 server.AnalysisQueue.Count.Should().NotBe(0);
             } finally {
                 if (server != null) {
@@ -5379,42 +5343,40 @@ class C(object):
 class C(object):
     pass
 ";
-            using(var server = await CreateServerAsync()) {
+            using (var server = await CreateServerAsync()) {
                 var uriFob = await server.OpenDocumentAndGetUriAsync("fob.py", fobSrc);
                 var uriOar = await server.OpenDocumentAndGetUriAsync("oar.py", oarSrc);
                 var uriBaz = await server.OpenDocumentAndGetUriAsync("baz.py", bazSrc);
                 server.SendDidChangeTextDocument(uriFob, "from oar import C");
 
-                await server.GetAnalysisAsync(uriOar);
-                await server.GetAnalysisAsync(uriBaz);
-                var analysis = await server.GetAnalysisAsync(uriFob);
                 var references = await server.SendFindReferences(uriFob, 0, 17);
-
-                analysis.Should().HaveVariable("C").WithDescription("C");
                 references.Should().OnlyHaveReferences(
                     (uriFob, (0, 16, 0, 17), ReferenceKind.Reference),
                     (uriOar, (1, 0, 2, 8), ReferenceKind.Value),
                     (uriOar, (1, 6, 1, 7), ReferenceKind.Definition)
                 );
 
+                var analysis = await server.GetAnalysisAsync(uriFob);
+                analysis.Should().HaveVariable("C").WithDescription("C");
+
                 // delete the class..
                 server.SendDidChangeTextDocument(uriOar, "");
-                analysis = await server.GetAnalysisAsync(uriFob);
-                await server.GetAnalysisAsync(uriOar);
 
-                analysis.Should().HaveVariable("C").WithNoTypes();
+                analysis = await server.GetAnalysisAsync(uriFob);
+                analysis.Should().NotHaveVariable("C");
 
                 // Change location of the class
                 server.SendDidChangeTextDocument(uriFob, "from baz import C");
-                analysis = await server.GetAnalysisAsync(uriFob);
-                references = await server.SendFindReferences(uriFob, 0, 17);
 
-                analysis.Should().HaveVariable("C").WithDescription("C");
+                references = await server.SendFindReferences(uriFob, 0, 17);
                 references.Should().OnlyHaveReferences(
                     (uriFob, (0, 16, 0, 17), ReferenceKind.Reference),
                     (uriBaz, (1, 0, 2, 8), ReferenceKind.Value),
                     (uriOar, (1, 6, 1, 7), ReferenceKind.Definition)
                 );
+
+                analysis = await server.GetAnalysisAsync(uriFob);
+                analysis.Should().HaveVariable("C").WithDescription("C");
             }
         }
 
@@ -5435,7 +5397,7 @@ abc = 42
             using (var server = await CreateServerAsync(rootUri: TestData.GetTestSpecificRootUri())) {
                 var pathSrc1 = TestData.GetTestSpecificPath(@"fob\__init__.py");
                 Directory.CreateDirectory(Path.GetDirectoryName(pathSrc1));
-                using (File.Create(pathSrc1)) {}
+                using (File.Create(pathSrc1)) { }
                 var uriSrc1 = new Uri(pathSrc1);
                 var uriSrc2 = TestData.GetTestSpecificUri(@"fob\x.py");
                 var uriSrc3 = TestData.GetTestSpecificUri(@"fob\y.py");
@@ -5451,2147 +5413,2147 @@ abc = 42
                     .And.HaveVariable("abc").OfType(BuiltinTypeId.Int);
             }
         }
-/*
-        [TestMethod, Priority(0)]
-        public void PackageRelativeImport() {
-            using (var state = CreateAnalyzer()) {
-                state.CreateProjectOnDisk = true;
+        /*
+                [TestMethod, Priority(0)]
+                public void PackageRelativeImport() {
+                    using (var state = CreateAnalyzer()) {
+                        state.CreateProjectOnDisk = true;
 
-                var package = state.AddModule("fob", "from .y import abc", "fob\\__init__.py");
-                var x = state.AddModule("fob.x", "from .y import abc");
-                var y = state.AddModule("fob.y", "abc = 42");
+                        var package = state.AddModule("fob", "from .y import abc", "fob\\__init__.py");
+                        var x = state.AddModule("fob.x", "from .y import abc");
+                        var y = state.AddModule("fob.y", "abc = 42");
 
-                state.WaitForAnalysis();
+                        state.WaitForAnalysis();
 
-                state.AssertIsInstance(x, "abc", BuiltinTypeId.Int);
-                state.AssertIsInstance(package, "abc", BuiltinTypeId.Int);
-            }
-        }
+                        state.AssertIsInstance(x, "abc", BuiltinTypeId.Int);
+                        state.AssertIsInstance(package, "abc", BuiltinTypeId.Int);
+                    }
+                }
 
-        [TestMethod, Priority(0)]
-        public void PackageRelativeImportPep328() {
-            var imports = new Dictionary<string, string>() {
-                { "from .moduleY import spam", "spam"},
-                { "from .moduleY import spam as ham", "ham"},
-                { "from . import moduleY", "moduleY.spam" },
-                { "from ..subpackage1 import moduleY", "moduleY.spam"},
-                { "from ..subpackage2.moduleZ import eggs", "eggs"},
-                { "from ..moduleA import foo", "foo" },
-                { "from ...package import bar", "bar"}
-            };
+                [TestMethod, Priority(0)]
+                public void PackageRelativeImportPep328() {
+                    var imports = new Dictionary<string, string>() {
+                        { "from .moduleY import spam", "spam"},
+                        { "from .moduleY import spam as ham", "ham"},
+                        { "from . import moduleY", "moduleY.spam" },
+                        { "from ..subpackage1 import moduleY", "moduleY.spam"},
+                        { "from ..subpackage2.moduleZ import eggs", "eggs"},
+                        { "from ..moduleA import foo", "foo" },
+                        { "from ...package import bar", "bar"}
+                    };
 
-            foreach (var imp in imports) {
-                using (var state = CreateAnalyzer()) {
-                    state.CreateProjectOnDisk = true;
+                    foreach (var imp in imports) {
+                        using (var state = CreateAnalyzer()) {
+                            state.CreateProjectOnDisk = true;
 
-                    var package = state.AddModule("package", "def bar():\n  pass\n", @"package\__init__.py");
-                    var modA = state.AddModule("package.moduleA", "def foo():\n  pass\n", @"package\moduleA.py");
+                            var package = state.AddModule("package", "def bar():\n  pass\n", @"package\__init__.py");
+                            var modA = state.AddModule("package.moduleA", "def foo():\n  pass\n", @"package\moduleA.py");
 
-                    var sub1 = state.AddModule("package.subpackage1", string.Empty, @"package\subpackage1\__init__.py");
-                    var modX = state.AddModule("package.subpackage1.moduleX", imp.Key, @"package\subpackage1\moduleX.py");
-                    var modY = state.AddModule("package.subpackage1.moduleY", "def spam():\n  pass\n", @"package\subpackage1\moduleY.py");
+                            var sub1 = state.AddModule("package.subpackage1", string.Empty, @"package\subpackage1\__init__.py");
+                            var modX = state.AddModule("package.subpackage1.moduleX", imp.Key, @"package\subpackage1\moduleX.py");
+                            var modY = state.AddModule("package.subpackage1.moduleY", "def spam():\n  pass\n", @"package\subpackage1\moduleY.py");
 
-                    var sub2 = state.AddModule("package.subpackage2", string.Empty, @"package\subpackage2\__init__.py");
-                    var modZ = state.AddModule("package.subpackage2.moduleZ", "def eggs():\n  pass\n", @"package\subpackage2\moduleZ.py");
+                            var sub2 = state.AddModule("package.subpackage2", string.Empty, @"package\subpackage2\__init__.py");
+                            var modZ = state.AddModule("package.subpackage2.moduleZ", "def eggs():\n  pass\n", @"package\subpackage2\moduleZ.py");
+
+                            state.WaitForAnalysis();
+                            state.AssertIsInstance(modX, imp.Value, BuiltinTypeId.Function);
+                        }
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void PackageRelativeImportAliasedMember() {
+                    // similar to unittest package which has unittest.main which contains a function called "main".
+                    // Make sure we see the function, not the module.
+                    using (var state = CreateAnalyzer()) {
+                        state.CreateProjectOnDisk = true;
+
+                        var package = state.AddModule("fob", "from .y import y", "fob\\__init__.py");
+                        var y = state.AddModule("fob.y", "def y(): pass");
+
+                        state.WaitForAnalysis();
+
+                        state.AssertIsInstance(package, "y", BuiltinTypeId.Module, BuiltinTypeId.Function);
+                    }
+                }
+
+
+                [TestMethod, Priority(0)]
+                public void Defaults() {
+                    var text = @"
+        def f(x = 42):
+            return x
+
+        a = f()
+        ";
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("a", BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void Decorator() {
+                    var text1 = @"
+        import mod2
+
+        inst = mod2.MyClass()
+
+        @inst.mydec
+        def f():
+            return 42
+
+
+        ";
+
+                    var text2 = @"
+        import mod1
+
+        class MyClass(object):
+            def mydec(self, x):
+                return x
+        ";
+
+                    PermutedTest("mod", new[] { text1, text2 }, state => {
+                        state.AssertIsInstance(state.Modules["mod1"], "f", BuiltinTypeId.Function);
+                        state.AssertIsInstance(state.Modules["mod2"], "mod1.f", BuiltinTypeId.Function);
+                        state.AssertIsInstance(state.Modules["mod2"], "MyClass().mydec(mod1.f)", BuiltinTypeId.Function);
+                    });
+                }
+
+
+                [TestMethod, Priority(0)]
+                public void DecoratorFlow() {
+                    var text1 = @"
+        import mod2
+
+        inst = mod2.MyClass()
+
+        @inst.filter(fob=42)
+        def f():
+            return 42
+
+        ";
+
+                    var text2 = @"
+        import mod1
+
+        class MyClass(object):
+            def filter(self, name=None, filter_func=None, **flags):
+                # @register.filter()
+                def dec(func):
+                    return self.filter_function(func, **flags)
+                return dec
+            def filter_function(self, func, **flags):
+                name = getattr(func, ""_decorated_function"", func).__name__
+                return self.filter(name, func, **flags)
+        ";
+
+                    PermutedTest("mod", new[] { text1, text2 }, state => {
+                        // Ensure we ended up with a function
+                        state.AssertIsInstance(state.Modules["mod1"], "f", 0, BuiltinTypeId.Function);
+
+                        // Ensure we passed a function in to the decorator (def dec(func))
+                        //state.AssertIsInstance(state.Modules["mod2"], "func", text2.IndexOf("return self.filter_function("), BuiltinTypeId.Function);
+
+                        // Ensure we saw the function passed *through* the decorator
+                        state.AssertIsInstance(state.Modules["mod2"], "func", text2.IndexOf("return self.filter("), BuiltinTypeId.Function);
+
+                        // Ensure we saw the function passed *back into* the original decorator constructor
+                        state.AssertIsInstance(
+                            state.Modules["mod2"], "filter_func", text2.IndexOf("# @register.filter()"),
+                            BuiltinTypeId.Function,
+                            BuiltinTypeId.NoneType
+                        );
+                    });
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorTypes() {
+                    var text = @"
+        def nop(fn):
+            def wrap():
+                return fn()
+            wp = wrap
+            return wp
+
+        @nop
+        def a_tuple():
+            return (1, 2, 3)
+
+        @nop
+        def a_list():
+            return [1, 2, 3]
+
+        @nop
+        def a_float():
+            return 0.1
+
+        @nop
+        def a_string():
+            return 'abc'
+
+        x = a_tuple()
+        y = a_list()
+        z = a_float()
+        w = a_string()
+        ";
+                    var entry = ProcessTextV2(text);
+                    entry.AssertIsInstance("x", BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("y", BuiltinTypeId.List);
+                    entry.AssertIsInstance("z", BuiltinTypeId.Float);
+                    entry.AssertIsInstance("w", BuiltinTypeId.Str);
+
+                    text = @"
+        def as_list(fn):
+            def wrap(v):
+                if v == 0:
+                    return list(fn())
+                elif v == 1:
+                    return set(fn(*args, **kwargs))
+                else:
+                    return str(fn())
+            return wrap
+
+        @as_list
+        def items():
+            return (1, 2, 3)
+
+        items2 = as_list(lambda: (1, 2, 3))
+
+        x = items(0)
+        ";
+                    entry = ProcessTextV2(text);
+                    entry.AssertIsInstance("items", entry.GetTypeIds("items2").ToArray());
+                    entry.AssertIsInstance("x", BuiltinTypeId.List, BuiltinTypeId.Set, BuiltinTypeId.Str);
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorReturnTypes_NoDecorator() {
+                    // https://pytools.codeplex.com/workitem/1694
+                    var text = @"# without decorator
+        def returnsGiven(parm):
+            return parm
+
+        retGivenInt = returnsGiven(1)
+        retGivenString = returnsGiven('str')
+        retGivenBool = returnsGiven(True)
+        ";
+
+                    var entry = ProcessText(text);
+
+                    entry.AssertIsInstance("retGivenInt", BuiltinTypeId.Int);
+                    entry.AssertIsInstance("retGivenString", BuiltinTypeId.Str);
+                    entry.AssertIsInstance("retGivenBool", BuiltinTypeId.Bool);
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorReturnTypes_DecoratorNoParams() {
+                    // https://pytools.codeplex.com/workitem/1694
+                    var text = @"# with decorator without wrap
+        def decoratorFunctionTakesArg1(f):
+            def wrapped_f(arg):
+                return f(arg)
+            return wrapped_f
+
+        @decoratorFunctionTakesArg1
+        def returnsGivenWithDecorator1(parm):
+            return parm
+
+        retGivenInt = returnsGivenWithDecorator1(1)
+        retGivenString = returnsGivenWithDecorator1('str')
+        retGivenBool = returnsGivenWithDecorator1(True)
+        ";
+
+                    var entry = ProcessText(text);
+
+                    entry.AssertIsInstance("retGivenInt", BuiltinTypeId.Int);
+                    entry.AssertIsInstance("retGivenString", BuiltinTypeId.Str);
+                    entry.AssertIsInstance("retGivenBool", BuiltinTypeId.Bool);
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorReturnTypes_DecoratorWithParams() {
+                    // https://pytools.codeplex.com/workitem/1694
+                    var text = @"
+        # with decorator with wrap
+        def decoratorFunctionTakesArg2():
+            def wrap(f):
+                def wrapped_f(arg):
+                    return f(arg)
+                return wrapped_f
+            return wrap
+
+        @decoratorFunctionTakesArg2()
+        def returnsGivenWithDecorator2(parm):
+            return parm
+
+        retGivenInt = returnsGivenWithDecorator2(1)
+        retGivenString = returnsGivenWithDecorator2('str')
+        retGivenBool = returnsGivenWithDecorator2(True)";
+
+                    var entry = ProcessText(text);
+
+                    entry.AssertIsInstance("retGivenInt", BuiltinTypeId.Int);
+                    entry.AssertIsInstance("retGivenString", BuiltinTypeId.Str);
+                    entry.AssertIsInstance("retGivenBool", BuiltinTypeId.Bool);
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorOverflow() {
+                    var text1 = @"
+        import mod2
+
+        @mod2.decorator_b
+        def decorator_a(fn):
+            return fn
+
+
+        ";
+
+                    var text2 = @"
+        import mod1
+
+        @mod1.decorator_a
+        def decorator_b(fn):
+            return fn
+        ";
+
+                    PermutedTest("mod", new[] { text1, text2 }, state => {
+                        // Neither decorator is callable, but at least analysis completed
+                        state.AssertIsInstance(state.Modules["mod1"], "decorator_a", BuiltinTypeId.Function);
+                        state.AssertIsInstance(state.Modules["mod2"], "decorator_b", BuiltinTypeId.Function);
+                    });
+                }
+
+                [TestMethod, Priority(0)]
+                public void ProcessDecorators() {
+                    var text = @"
+        def d(fn):
+            return []
+
+        @d
+        def my_fn():
+            return None
+        ";
+
+                    var entry = CreateAnalyzer();
+                    entry.Analyzer.Limits.ProcessCustomDecorators = true;
+                    entry.AddModule("fob", text);
+                    entry.WaitForAnalysis();
+
+                    entry.AssertIsInstance("my_fn", BuiltinTypeId.List);
+                    entry.AssertIsInstance("fn", text.IndexOf("return"), BuiltinTypeId.Function);
+                }
+
+                [TestMethod, Priority(0)]
+                public void NoProcessDecorators() {
+                    var text = @"
+        def d(fn):
+            return []
+
+        @d
+        def my_fn():
+            return None
+        ";
+
+                    var entry = CreateAnalyzer();
+                    entry.Analyzer.Limits.ProcessCustomDecorators = false;
+                    entry.AddModule("fob", text);
+                    entry.WaitForAnalysis();
+
+                    entry.AssertIsInstance("my_fn", BuiltinTypeId.Function);
+                    entry.AssertIsInstance("fn", text.IndexOf("return"), BuiltinTypeId.Function);
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorReferences() {
+                    var text = @"
+        def d1(f):
+            return f
+        class d2:
+            def __call__(self, f): return f
+
+        @d1
+        def func_d1(): pass
+        @d2()
+        def func_d2(): pass
+
+        @d1
+        class cls_d1(object): pass
+        @d2()
+        class cls_d2(object): pass
+        ";
+                    var entry = ProcessText(text);
+                    entry.AssertReferences("d1",
+                        new VariableLocation(2, 1, VariableType.Value),
+                        new VariableLocation(2, 5, VariableType.Definition),
+                        new VariableLocation(7, 2, VariableType.Reference),
+                        new VariableLocation(12, 2, VariableType.Reference)
+                    );
+                    entry.AssertReferences("d2",
+                        new VariableLocation(4, 1, VariableType.Value),
+                        new VariableLocation(4, 7, VariableType.Definition),
+                        new VariableLocation(9, 2, VariableType.Reference),
+                        new VariableLocation(14, 2, VariableType.Reference)
+                    );
+                    AssertUtil.ContainsExactly(entry.GetValues("f", 18).Select(v => v.MemberType), PythonMemberType.Function, PythonMemberType.Class);
+                    AssertUtil.ContainsExactly(entry.GetValues("f", 66).Select(v => v.MemberType), PythonMemberType.Function, PythonMemberType.Class);
+                    AssertUtil.ContainsExactly(entry.GetValues("func_d1").Select(v => v.MemberType), PythonMemberType.Function);
+                    AssertUtil.ContainsExactly(entry.GetValues("func_d2").Select(v => v.MemberType), PythonMemberType.Function);
+                    AssertUtil.ContainsExactly(entry.GetValues("cls_d1").Select(v => v.MemberType), PythonMemberType.Class);
+                    AssertUtil.ContainsExactly(entry.GetValues("cls_d2").Select(v => v.MemberType), PythonMemberType.Class);
+                }
+
+                [TestMethod, Priority(0)]
+                public void DecoratorClass() {
+                    var text = @"
+        def dec1(C):
+            def sub_method(self): pass
+            C.sub_method = sub_method
+            return C
+
+        @dec1
+        class MyBaseClass1(object):
+            def base_method(self): pass
+
+        def dec2(C):
+            class MySubClass(C):
+                def sub_method(self): pass
+            return MySubClass
+
+        @dec2
+        class MyBaseClass2(object):
+            def base_method(self): pass
+
+        mc1 = MyBaseClass1()
+        mc2 = MyBaseClass2()
+        ";
+                    var entry = ProcessText(text);
+                    AssertUtil.ContainsAtLeast(entry.GetMemberNames("mc1", 0, GetMemberOptions.None), "base_method", "sub_method");
+                    entry.AssertIsInstance("mc2", "MySubClass");
+                    AssertUtil.ContainsAtLeast(entry.GetMemberNames("mc2", 0, GetMemberOptions.None), "sub_method");
+                }
+
+                [TestMethod, Priority(0)]
+                public void ClassInit() {
+                    var text = @"
+        class X:
+            def __init__(self, value):
+                self.value = value
+
+        a = X(2)
+        ";
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("a.value", 0, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("value", text.IndexOf("self."), BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void InstanceCall() {
+                    var text = @"
+        class X:
+            def __call__(self, value):
+                return value
+
+        x = X()
+
+        a = x(2)
+        ";
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("a", BuiltinTypeId.Int);
+                }
+
+                /// <summary>
+                /// Verifies that regardless of how we get to imports/function return values that
+                /// we properly understand the imported value.
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public void ImportScopesOrder() {
+                    var text1 = @"
+        import _io
+        import mod2
+        import mmap as mm
+
+        import sys
+        def f():
+            return sys
+
+        def g():
+            return _io
+
+        def h():
+            return mod2.sys
+
+        def i():
+            import zlib
+            return zlib
+
+        def j():
+            return mm
+
+        def k():
+            return mod2.impp
+
+        import operator as op
+
+        import re
+
+        ";
+
+                    var text2 = @"
+        import sys
+        import imp as impp
+        ";
+                    PermutedTest("mod", new[] { text1, text2 }, state => {
+                        state.DefaultModule = "mod1";
+                        state.AssertDescription("g", "mod1.g() -> _io");
+                        state.AssertDescription("f", "mod1.f() -> sys");
+                        state.AssertDescription("h", "mod1.h() -> sys");
+                        state.AssertDescription("i", "mod1.i() -> zlib");
+                        state.AssertDescription("j", "mod1.j() -> mmap");
+                        state.AssertDescription("k", "mod1.k() -> imp");
+                    });
+                }
+
+                [TestMethod, Priority(0)]
+                public void ClassNew() {
+                    var text = @"
+        class X:
+            def __new__(cls, value):
+                res = object.__new__(cls)
+                res.value = value
+                return res
+
+        a = X(2)
+        ";
+                    var entry = ProcessText(text);
+                    entry.AssertDescription("cls", text.IndexOf("= value"), "X");
+                    entry.AssertIsInstance("value", text.IndexOf("res.value = "), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("res", text.IndexOf("res.value = "), "X");
+                    entry.AssertIsInstance("a", text.IndexOf("a = "), "X");
+                    entry.AssertIsInstance("a.value", BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void Global() {
+                    var text = @"
+        x = None
+        y = None
+        def f():
+            def g():
+                global x, y
+                x = 123
+                y = 123
+            return x, y
+
+        a, b = f()
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("b", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("x", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("y", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void Nonlocal() {
+                    var text = @"
+        def f():
+            x = None
+            y = None
+            def g():
+                nonlocal x, y
+                x = 123
+                y = 234
+            return x, y
+
+        a, b = f()
+        ";
+
+                    var entry = ProcessTextV3(text);
+                    entry.AssertIsInstance("x", text.IndexOf("nonlocal"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("y", text.IndexOf("nonlocal"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("x", text.IndexOf("return"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("y", text.IndexOf("return"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("b", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+
+                    entry.AssertReferences("x", text.IndexOf("x ="),
+                        new VariableLocation(3, 5, VariableType.Definition),
+                        new VariableLocation(6, 18, VariableType.Reference),
+                        new VariableLocation(7, 9, VariableType.Definition),
+                        new VariableLocation(9, 12, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("y", text.IndexOf("x ="),
+                        new VariableLocation(4, 5, VariableType.Definition),
+                        new VariableLocation(6, 21, VariableType.Reference),
+                        new VariableLocation(8, 9, VariableType.Definition),
+                        new VariableLocation(9, 15, VariableType.Reference)
+                    );
+
+
+                    text = @"
+        def f(x):
+            def g():
+                nonlocal x
+                x = 123
+            return x
+
+        a = f(None)
+        ";
+
+                    entry = ProcessTextV3(text);
+                    entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void IsInstance() {
+                    var text = @"
+        x = None
+
+
+        if True:
+            pass
+            assert isinstance(x, int)
+            z = 100
+            pass
+        else:
+            pass
+            assert isinstance(x, str)
+            y = 200
+            pass
+
+
+
+
+
+        if isinstance(x, tuple):
+            fob = 300
+            pass
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("x", text.IndexOf("z ="), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("x", text.IndexOf("z =") + 1, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("x", text.IndexOf("pass"), BuiltinTypeId.NoneType, BuiltinTypeId.Int, BuiltinTypeId.Str, BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("x", text.IndexOf("y ="), BuiltinTypeId.Str);
+                    entry.AssertIsInstance("x", text.IndexOf("y =") + 1, BuiltinTypeId.Str);
+                    entry.AssertIsInstance("x", text.IndexOf("else:") + 7, BuiltinTypeId.NoneType, BuiltinTypeId.Int, BuiltinTypeId.Str, BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("x", text.IndexOf("fob ="), BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("x", text.LastIndexOf("pass"), BuiltinTypeId.Tuple);
+
+                    entry.AssertReferences("x",
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("x", text.IndexOf("z ="),
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("x", text.IndexOf("z =") + 1,
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("x", text.IndexOf("z =") - 2,
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("x", text.IndexOf("y ="),
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("x", text.IndexOf("y =") + 1,
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("x", text.IndexOf("y =") - 2,
+                        new VariableLocation(2, 1, VariableType.Definition),
+                        new VariableLocation(7, 23, VariableType.Reference),
+                        new VariableLocation(12, 23, VariableType.Reference),
+                        new VariableLocation(20, 15, VariableType.Reference)
+                    );
+
+                    text = @"
+        def f(a):
+            def g():
+                nonlocal a
+                print(a)
+                assert isinstance(a, int)
+                pass
+
+        f('abc')
+        ";
+
+                    entry = ProcessTextV3(text);
+                    entry.AssertIsInstance("a");
+                    entry.AssertIsInstance("a", text.IndexOf("def g()"), BuiltinTypeId.Int, BuiltinTypeId.Unicode);
+                    entry.AssertIsInstance("a", text.IndexOf("pass"), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("a", text.IndexOf("print(a)"), BuiltinTypeId.Int, BuiltinTypeId.Unicode);
+
+                    text = @"x = None
+
+
+        if True:
+            pass
+            assert isinstance(x, int)
+            z = 100
+
+            pass
+
+        print(z)";
+
+                    entry = ProcessText(text);
+                    entry.AssertIsInstance("z", BuiltinTypeId.Int);
+                    entry.AssertIsInstance("z", text.IndexOf("z ="), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("z", text.Length - 1, BuiltinTypeId.Int);
+
+                    entry.AssertReferences("z",
+                        new VariableLocation(7, 5, VariableType.Definition),
+                        new VariableLocation(11, 7, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("z", text.IndexOf("z ="),
+                        new VariableLocation(7, 5, VariableType.Definition),
+                        new VariableLocation(11, 7, VariableType.Reference)
+                    );
+
+                    // http://pytools.codeplex.com/workitem/636
+
+                    // this just shouldn't crash, we should handle the malformed code, not much to inspect afterwards...
+
+                    entry = ProcessText("if isinstance(x, list):\r\n", allowParseErrors: true);
+                    entry = ProcessText("if isinstance(x, list):", allowParseErrors: true);
+                }
+
+                [TestMethod, Priority(0)]
+                public void NestedIsInstance() {
+                    var code = @"
+        def f():
+            x = None
+            y = None
+
+            assert isinstance(x, int)
+            z = x
+
+            assert isinstance(y, int)
+            w = y
+
+            pass";
+
+                    var entry = ProcessText(code);
+                    entry.AssertIsInstance("z", code.IndexOf("pass"), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("w", code.IndexOf("pass"), BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void NestedIsInstance1908() {
+                    // https://pytools.codeplex.com/workitem/1908
+                    var code = @"
+        def f(x):
+            y = object()    
+            assert isinstance(x, int)
+            if isinstance(y, float):
+                print('hi')
+
+            pass
+        ";
+
+                    var entry = ProcessText(code);
+                    entry.AssertIsInstance("y", code.IndexOf("pass"), BuiltinTypeId.Object, BuiltinTypeId.Float);
+                }
+
+                [TestMethod, Priority(0)]
+                public void IsInstanceUserDefinedType() {
+                    var text = @"
+        class C(object):
+            def f(self):
+                pass
+
+        def f(a):
+            assert isinstance(a, C)
+            print(a)
+            pass
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("a", text.IndexOf("print(a)"), "C");
+                }
+
+                [TestMethod, Priority(0)]
+                public void IsInstanceNested() {
+                    var text = @"
+        class R: pass
+
+        def fn(a, b, c):
+            result = R()
+            assert isinstance(a, str)
+            result.a = a
+
+            assert isinstance(b, type)
+            if isinstance(b, tuple):
+                pass
+            result.b = b
+
+            assert isinstance(c, str)
+            result.c = c
+            return result
+
+        r1 = fn('fob', (int, str), 'oar')
+        r2 = fn(123, None, 4.5)
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("r1.a", BuiltinTypeId.Str);
+                    entry.AssertIsInstance("r1.b", BuiltinTypeId.Type, BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("r1.c", BuiltinTypeId.Str);
+
+                    entry.AssertIsInstance("r2.a", BuiltinTypeId.Str);
+                    entry.AssertIsInstance("r2.b", BuiltinTypeId.Type, BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("r2.c", BuiltinTypeId.Str);
+                }
+
+                private static IEnumerable<string> DumpScopesToStrings(InterpreterScope scope) {
+                    yield return scope.Name;
+                    foreach (var child in scope.Children) {
+                        foreach (var s in DumpScopesToStrings(child)) {
+                            yield return "  " + s;
+                        }
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void IsInstanceAndLambdaScopes() {
+                    // https://github.com/Microsoft/PTVS/issues/2801
+                    var text = @"if isinstance(p, dict):
+            v = [i for i in (lambda x: x)()]";
+
+                    var entry = ProcessTextV3(text);
+                    var scope = entry.Modules[entry.DefaultModule].Analysis.Scope;
+                    var dump = string.Join(Environment.NewLine, DumpScopesToStrings(scope));
+
+                    Console.WriteLine($"Actual:{Environment.NewLine}{dump}");
+
+                    Assert.AreEqual(entry.DefaultModule + @"
+          <statements>
+          <isinstance scope>
+            <comprehension scope>
+              <lambda>
+                <statements>
+          <statements>", dump);
+                }
+
+                [TestMethod, Priority(0)]
+                public void IsInstanceReferences() {
+                    var text = @"def fob():
+            oar = get_b()
+            assert isinstance(oar, float)
+
+            if oar.complex:
+                raise IndexError
+
+            return oar";
+
+                    var entry = ProcessText(text);
+
+                    for (int i = text.IndexOf("oar", 0); i >= 0; i = text.IndexOf("oar", i + 1)) {
+                        entry.AssertReferences("oar", i,
+                            new VariableLocation(2, 5, VariableType.Definition),
+                            new VariableLocation(3, 23, VariableType.Reference),
+                            new VariableLocation(5, 8, VariableType.Reference),
+                            new VariableLocation(8, 12, VariableType.Reference)
+                        );
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void FunctoolsDecoratorReferences() {
+                    var text = @"from functools import wraps
+
+        def d(f):
+            @wraps(f)
+            def wrapped(*a, **kw):
+                return f(*a, **kw)
+            return wrapped
+
+        @d
+        def g(p):
+            return p
+
+        n1 = g(1)";
+
+                    var entry = ProcessText(text);
+
+                    entry.AssertReferences("d",
+                        new VariableLocation(3, 1, VariableType.Value),
+                        new VariableLocation(3, 5, VariableType.Definition),
+                        new VariableLocation(9, 2, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("g",
+                        new VariableLocation(4, 5, VariableType.Value),
+                        new VariableLocation(10, 5, VariableType.Definition),
+                        new VariableLocation(13, 6, VariableType.Reference)
+                    );
+
+                    // Decorators that don't use @wraps will expose the wrapper function
+                    // as a value.
+                    text = @"def d(f):
+            def wrapped(*a, **kw):
+                return f(*a, **kw)
+            return wrapped
+
+        @d
+        def g(p):
+            return p
+
+        n1 = g(1)";
+
+                    entry = ProcessText(text);
+
+                    entry.AssertReferences("d",
+                        new VariableLocation(1, 1, VariableType.Value),
+                        new VariableLocation(1, 5, VariableType.Definition),
+                        new VariableLocation(6, 2, VariableType.Reference)
+                    );
+
+                    entry.AssertReferences("g",
+                        new VariableLocation(2, 5, VariableType.Value),
+                        new VariableLocation(7, 5, VariableType.Definition),
+                        new VariableLocation(10, 6, VariableType.Reference)
+                    );
+                }
+
+                [TestMethod, Priority(0)]
+                public void QuickInfo() {
+                    var text = @"
+        import sys
+        a = 41.0
+        b = 42L
+        c = 'abc'
+        x = (2, 3, 4)
+        y = [2, 3, 4]
+        z = 43
+
+        class fob(object):
+            @property
+            def f(self): pass
+
+            def g(self): pass
+
+        d = fob()
+
+        def f():
+            print 'hello'
+            return 'abc'
+
+        def g():
+            return c.Length
+
+        def h():
+            return f
+            return g
+
+        class return_func_class:
+            def return_func(self):
+                '''some help'''
+                return self.return_func
+
+
+        def docstr_func():
+            '''useful documentation'''
+            return 42
+
+        def with_params(a, b, c):
+            pass
+
+        def with_params_default(a, b, c = 100):
+            pass
+
+        def with_params_default_2(a, b, c = []):
+            pass
+
+        def with_params_default_3(a, b, c = ()):
+            pass
+
+        def with_params_default_4(a, b, c = {}):
+            pass
+
+        def with_params_default_2a(a, b, c = [None]):
+            pass
+
+        def with_params_default_3a(a, b, c = (None, )):
+            pass
+
+        def with_params_default_4a(a, b, c = {42: 100}):
+            pass
+
+        def with_params_default_starargs(*args, **kwargs):
+            pass
+        ";
+                    var entry = ProcessTextV2(text);
+
+                    entry.AssertIsInstance("fob()", "fob");
+                    entry.AssertDescription("int()", "int");
+                    entry.AssertDescription("a", "float");
+                    entry.AssertDescription("a", "float");
+                    entry.AssertDescription("b", "long");
+                    entry.AssertDescription("c", "str");
+                    entry.AssertIsInstance("x", BuiltinTypeId.Tuple);
+                    entry.AssertIsInstance("y", BuiltinTypeId.List);
+                    entry.AssertDescription("z", "int");
+                    entry.AssertDescriptionContains("min", "min(");
+                    entry.AssertDescriptionContains("list.append", "list.append(");
+                    entry.AssertIsInstance("\"abc\".Length");
+                    entry.AssertIsInstance("c.Length");
+                    entry.AssertIsInstance("d", "fob");
+                    entry.AssertDescription("sys", "sys");
+                    entry.AssertDescription("f", "test-module.f() -> str");
+                    entry.AssertDescription("fob.f", "test-module.fob.f(self: fob)\r\ndeclared in fob");
+                    entry.AssertDescription("fob().g", "method g of test-module.fob objects");
+                    entry.AssertDescription("fob", "class test-module.fob(object)");
+                    //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.StringSplitOptions.RemoveEmptyEntries", 1), "field of type StringSplitOptions");
+                    entry.AssertDescription("g", "test-module.g()");    // return info could be better
+                    //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.AppDomain.DomainUnload", 1), "event of type System.EventHandler");
+                    entry.AssertDescription("None", "None");
+                    entry.AssertDescription("f.func_name", "property of type str");
+                    entry.AssertDescription("h", "test-module.h() -> test-module.f() -> str, test-module.g()");
+                    entry.AssertDescription("docstr_func", "test-module.docstr_func() -> int");
+                    entry.AssertDocumentation("docstr_func", "useful documentation");
+
+                    entry.AssertDescription("with_params", "test-module.with_params(a, b, c)");
+                    entry.AssertDescription("with_params_default", "test-module.with_params_default(a, b, c: int=100)");
+                    entry.AssertDescription("with_params_default_2", "test-module.with_params_default_2(a, b, c: list=[])");
+                    entry.AssertDescription("with_params_default_3", "test-module.with_params_default_3(a, b, c: tuple=())");
+                    entry.AssertDescription("with_params_default_4", "test-module.with_params_default_4(a, b, c: dict={})");
+                    entry.AssertDescription("with_params_default_2a", "test-module.with_params_default_2a(a, b, c: list=[...])");
+                    entry.AssertDescription("with_params_default_3a", "test-module.with_params_default_3a(a, b, c: tuple=(...))");
+                    entry.AssertDescription("with_params_default_4a", "test-module.with_params_default_4a(a, b, c: dict={...})");
+                    entry.AssertDescription("with_params_default_starargs", "test-module.with_params_default_starargs(*args, **kwargs)");
+
+                    // method which returns itself, we shouldn't stack overflow producing the help...
+                    entry.AssertDescription("return_func_class().return_func", "method return_func of test-module.return_func_class objects...");
+                    entry.AssertDocumentation("return_func_class().return_func", "some help");
+                }
+
+                [TestMethod, Priority(0)]
+                public void CompletionDocumentation() {
+                    var text = @"
+        import sys
+        a = 41.0
+        b = 42L
+        c = 'abc'
+        x = (2, 3, 4)
+        y = [2, 3, 4]
+        z = 43
+
+        class fob(object):
+            @property
+            def f(self): pass
+
+            def g(self): pass
+
+        d = fob()
+
+        def f():
+            print 'hello'
+            return 'abc'
+
+        def g():
+            return c.Length
+        ";
+                    var entry = ProcessText(text);
+
+                    AssertUtil.Contains(entry.GetCompletionDocumentation("", "d", 1).First(), "fob");
+                    AssertUtil.Contains(entry.GetCompletionDocumentation("", "int", 1).First(), "integer");
+                    AssertUtil.Contains(entry.GetCompletionDocumentation("", "min", 1).First(), "min(");
+                }
+
+                [TestMethod, Priority(0)]
+                public void MemberType() {
+                    var text = @"
+        import sys
+        a = 41.0
+        b = 42L
+        c = 'abc'
+        x = (2, 3, 4)
+        y = [2, 3, 4]
+        z = 43
+
+        class fob(object):
+            @property
+            def f(self): pass
+
+            def g(self): pass
+
+        d = fob()
+
+        def f():
+            print 'hello'
+            return 'abc'
+
+        def g():
+            return c.Length
+        ";
+                    var entry = ProcessText(text);
+
+
+                    entry.AssertAttrIsType("f", "func_name", PythonMemberType.Property);
+                    entry.AssertAttrIsType("f", "func_name", PythonMemberType.Property);
+                    entry.AssertAttrIsType("list", "append", PythonMemberType.Method);
+                    entry.AssertAttrIsType("y", "append", PythonMemberType.Method);
+                    entry.AssertAttrIsType("", "int", PythonMemberType.Class);
+                    entry.AssertAttrIsType("", "min", PythonMemberType.Function);
+                    entry.AssertAttrIsType("", "sys", PythonMemberType.Module);
+                }
+
+                [TestMethod, Priority(0)]
+                public void RecurisveDataStructures() {
+                    var text = @"
+        d = {}
+        d[0] = d
+        ";
+                    var entry = ProcessTextV2(text);
+
+                    entry.AssertDescription("d", "dict({int : dict})");
+                }
+
+                /// <summary>
+                /// Variable is refered to in the base class, defined in the derived class, we should know the type information.
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public void BaseReferencedDerivedDefined() {
+                    var text = @"
+        class Base(object):
+            def f(self):
+                x = self.map
+
+        class Derived(Base):
+            def __init__(self):
+                self.map = {}
+
+        pass
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertAttrIsType("Derived()", "map", PythonMemberType.Field);
+                }
+
+
+                /// <summary>
+                /// Test case where we have a member but we don't have any type information for the member.  It should
+                /// still show up as a member.
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public void NoTypesButIsMember() {
+                    var text = @"
+        def f(x, y):
+            C(x, y)
+
+        class C(object):
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        f(1)
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertHasAttr("C()", "x", "y");
+                }
+
+                /// <summary>
+                /// Test case where we have a member but we don't have any type information for the member.  It should
+                /// still show up as a member.
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public void SequenceFromSequence() {
+                    var text = @"
+        x = []
+        x.append(1)
+
+        t = (1, )
+
+        class MyIndexer(object):
+            def __getitem__(self, index):
+                return 1
+
+        ly = list(x)
+        lz = list(MyIndexer())
+
+        ty = tuple(x)
+        tz = tuple(MyIndexer())
+
+        lyt = list(t)
+        tyt = tuple(t)
+        ";
+
+                    var entry = ProcessText(text);
+                    entry.AssertIsInstance("x[0]", BuiltinTypeId.Int);
+
+                    foreach (string value in new[] { "ly", "lz", "ty", "tz", "lyt", "tyt" }) {
+                        entry.AssertIsInstance(value + "[0]", BuiltinTypeId.Int);
+                    }
+                }
+
+        #if FALSE
+                [TestMethod, Priority(0)]
+                public void SaveStdLib() {
+                    // only run this once...
+                    if (GetType() == typeof(AnalysisTest)) {
+                        var stdLib = AnalyzeStdLib();
+
+                        string tmpFolder = TestData.GetTempPath("6666d700-a6d8-4e11-8b73-3ba99a61e27b");
+
+                        new SaveAnalysis().Save(stdLib, tmpFolder);
+
+                        File.Copy(Path.Combine(PythonInterpreterFactory.GetBaselineDatabasePath(), "__builtin__.idb"), Path.Combine(tmpFolder, "__builtin__.idb"), true);
+
+                        var newPs = new PythonAnalyzer(new CPythonInterpreter(new TypeDatabase(tmpFolder)), PythonLanguageVersion.V27);
+                    }
+                }
+        #endif
+
+
+                [TestMethod, Priority(0)]
+                public void SubclassFindAllRefs() {
+                    string text = @"
+        class Base(object):
+            def __init__(self):
+                self.fob()
+
+            def fob(self): 
+                pass
+
+
+        class Derived(Base):
+            def fob(self): 
+                'x'
+        ";
+
+                    var entry = ProcessText(text);
+
+                    var refs = new[] {
+                        new VariableLocation(4, 14, VariableType.Reference),
+                        new VariableLocation(6, 5, VariableType.Value),
+                        new VariableLocation(6, 9, VariableType.Definition),
+                        new VariableLocation(11, 5, VariableType.Value),
+                        new VariableLocation(11, 9, VariableType.Definition),
+                    };
+
+                    entry.AssertReferences("self.fob", text.IndexOf("'x'"), refs);
+                    entry.AssertReferences("self.fob", text.IndexOf("pass"), refs);
+                    entry.AssertReferences("self.fob", text.IndexOf("self.fob"), refs);
+                }
+
+                /// <summary>
+                /// Verifies that constructing lists / tuples from more lists/tuples doesn't cause an infinite analysis as we keep creating more lists/tuples.
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public void ListRecursion() {
+                    string text = @"
+        def f(x):
+            print abc
+            return f(list(x))
+
+        abc = f(())
+        ";
+
+                    var entry = ProcessText(text);
+
+                    //var vars = entry.GetVariables("fob", GetLineNumber(text, "'x'"));
+
+                }
+
+                [TestMethod, Priority(0)]
+                public void TypeAtEndOfMethod() {
+                    string text = @"
+        class Fob(object):
+            def oar(self, a):
+                pass
+
+
+            def fob(self): 
+                pass
+
+        x = Fob()
+        x.oar(100)
+        ";
+
+                    var entry = ProcessText(text);
+                    var mod = entry.Modules[entry.DefaultModule].Analysis;
+
+                    AssertUtil.ContainsAtLeast(mod.GetAllAvailableMembers(new SourceLocation(6, 9)).Select(mr => mr.Name), "a");
+                }
+
+                [TestMethod, Priority(0)]
+                public void TypeAtEndOfIncompleteMethod() {
+                    string text = @"
+        class Fob(object):
+            def oar(self, a):
+
+
+
+
+
+        x = Fob()
+        x.oar(100)
+        ";
+
+                    var entry = ProcessText(text, allowParseErrors: true);
+                    var mod = entry.Modules[entry.DefaultModule].Analysis;
+
+                    AssertUtil.ContainsAtLeast(mod.GetAllAvailableMembers(new SourceLocation(6, 9)).Select(mr => mr.Name), "a");
+                }
+
+                [TestMethod, Priority(0)]
+                public void TypeIntersectionUserDefinedTypes() {
+                    string text = @"
+        class C1(object):
+            def fob(self): pass
+
+        class C2(object):
+            def oar(self): pass
+
+        c = C1()
+        c.fob()
+        c = C2()
+
+        ";
+
+                    var entry = ProcessText(text);
+                    AssertUtil.DoesntContain(entry.GetMemberNames("c", 0, GetMemberOptions.IntersectMultipleResults), new[] { "fob", "oar" });
+                }
+
+                [TestMethod, Priority(0)]
+                public void UpdateMethodMultiFiles() {
+                    string text1 = @"
+        def f(abc):
+            pass
+        ";
+
+                    string text2 = @"
+        import mod1
+        mod1.f(42)
+        ";
+
+                    var state = CreateAnalyzer();
+
+                    // add both files to the project
+                    var entry1 = state.AddModule("mod1", text1);
+                    var entry2 = state.AddModule("mod2", text2);
 
                     state.WaitForAnalysis();
-                    state.AssertIsInstance(modX, imp.Value, BuiltinTypeId.Function);
+                    state.AssertIsInstance(entry1, "abc", text1.IndexOf("pass"), BuiltinTypeId.Int);
+
+                    // re-analyze project1, we should still know about the type info provided by module2
+                    state.UpdateModule(entry1, null);
+                    state.WaitForAnalysis();
+
+                    state.AssertIsInstance(entry1, "abc", text1.IndexOf("pass"), BuiltinTypeId.Int);
                 }
-            }
-        }
 
-        [TestMethod, Priority(0)]
-        public void PackageRelativeImportAliasedMember() {
-            // similar to unittest package which has unittest.main which contains a function called "main".
-            // Make sure we see the function, not the module.
-            using (var state = CreateAnalyzer()) {
-                state.CreateProjectOnDisk = true;
+                [TestMethod, Priority(0)]
+                public void MetaClassesV2() {
 
-                var package = state.AddModule("fob", "from .y import y", "fob\\__init__.py");
-                var y = state.AddModule("fob.y", "def y(): pass");
+                    string text = @"class C(type):
+            def f(self):
+                print('C.f')
 
-                state.WaitForAnalysis();
+            def x(self, var):
+                pass
 
-                state.AssertIsInstance(package, "y", BuiltinTypeId.Module, BuiltinTypeId.Function);
-            }
-        }
 
+        class D(object):
+            __metaclass__ = C
+            @classmethod
+            def g(cls):
+                print cls.g
 
-        [TestMethod, Priority(0)]
-        public void Defaults() {
-            var text = @"
-def f(x = 42):
-    return x
-    
-a = f()
-";
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("a", BuiltinTypeId.Int);
-        }
 
-        [TestMethod, Priority(0)]
-        public void Decorator() {
-            var text1 = @"
-import mod2
+            def inst_method(self):
+                pass
+            ";
 
-inst = mod2.MyClass()
-
-@inst.mydec
-def f():
-    return 42
-    
-
-";
-
-            var text2 = @"
-import mod1
-
-class MyClass(object):
-    def mydec(self, x):
-        return x
-";
-
-            PermutedTest("mod", new[] { text1, text2 }, state => {
-                state.AssertIsInstance(state.Modules["mod1"], "f", BuiltinTypeId.Function);
-                state.AssertIsInstance(state.Modules["mod2"], "mod1.f", BuiltinTypeId.Function);
-                state.AssertIsInstance(state.Modules["mod2"], "MyClass().mydec(mod1.f)", BuiltinTypeId.Function);
-            });
-        }
-
-
-        [TestMethod, Priority(0)]
-        public void DecoratorFlow() {
-            var text1 = @"
-import mod2
-
-inst = mod2.MyClass()
-
-@inst.filter(fob=42)
-def f():
-    return 42
-    
-";
-
-            var text2 = @"
-import mod1
-
-class MyClass(object):
-    def filter(self, name=None, filter_func=None, **flags):
-        # @register.filter()
-        def dec(func):
-            return self.filter_function(func, **flags)
-        return dec
-    def filter_function(self, func, **flags):
-        name = getattr(func, ""_decorated_function"", func).__name__
-        return self.filter(name, func, **flags)
-";
-
-            PermutedTest("mod", new[] { text1, text2 }, state => {
-                // Ensure we ended up with a function
-                state.AssertIsInstance(state.Modules["mod1"], "f", 0, BuiltinTypeId.Function);
-
-                // Ensure we passed a function in to the decorator (def dec(func))
-                //state.AssertIsInstance(state.Modules["mod2"], "func", text2.IndexOf("return self.filter_function("), BuiltinTypeId.Function);
-
-                // Ensure we saw the function passed *through* the decorator
-                state.AssertIsInstance(state.Modules["mod2"], "func", text2.IndexOf("return self.filter("), BuiltinTypeId.Function);
-
-                // Ensure we saw the function passed *back into* the original decorator constructor
-                state.AssertIsInstance(
-                    state.Modules["mod2"], "filter_func", text2.IndexOf("# @register.filter()"),
-                    BuiltinTypeId.Function,
-                    BuiltinTypeId.NoneType
-                );
-            });
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorTypes() {
-            var text = @"
-def nop(fn):
-    def wrap():
-        return fn()
-    wp = wrap
-    return wp
-
-@nop
-def a_tuple():
-    return (1, 2, 3)
-
-@nop
-def a_list():
-    return [1, 2, 3]
-
-@nop
-def a_float():
-    return 0.1
-
-@nop
-def a_string():
-    return 'abc'
-
-x = a_tuple()
-y = a_list()
-z = a_float()
-w = a_string()
-";
-            var entry = ProcessTextV2(text);
-            entry.AssertIsInstance("x", BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("y", BuiltinTypeId.List);
-            entry.AssertIsInstance("z", BuiltinTypeId.Float);
-            entry.AssertIsInstance("w", BuiltinTypeId.Str);
-
-            text = @"
-def as_list(fn):
-    def wrap(v):
-        if v == 0:
-            return list(fn())
-        elif v == 1:
-            return set(fn(*args, **kwargs))
-        else:
-            return str(fn())
-    return wrap
-
-@as_list
-def items():
-    return (1, 2, 3)
-
-items2 = as_list(lambda: (1, 2, 3))
-
-x = items(0)
-";
-            entry = ProcessTextV2(text);
-            entry.AssertIsInstance("items", entry.GetTypeIds("items2").ToArray());
-            entry.AssertIsInstance("x", BuiltinTypeId.List, BuiltinTypeId.Set, BuiltinTypeId.Str);
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorReturnTypes_NoDecorator() {
-            // https://pytools.codeplex.com/workitem/1694
-            var text = @"# without decorator
-def returnsGiven(parm):
-    return parm
-
-retGivenInt = returnsGiven(1)
-retGivenString = returnsGiven('str')
-retGivenBool = returnsGiven(True)
-";
-
-            var entry = ProcessText(text);
-
-            entry.AssertIsInstance("retGivenInt", BuiltinTypeId.Int);
-            entry.AssertIsInstance("retGivenString", BuiltinTypeId.Str);
-            entry.AssertIsInstance("retGivenBool", BuiltinTypeId.Bool);
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorReturnTypes_DecoratorNoParams() {
-            // https://pytools.codeplex.com/workitem/1694
-            var text = @"# with decorator without wrap
-def decoratorFunctionTakesArg1(f):
-    def wrapped_f(arg):
-        return f(arg)
-    return wrapped_f
-
-@decoratorFunctionTakesArg1
-def returnsGivenWithDecorator1(parm):
-    return parm
-
-retGivenInt = returnsGivenWithDecorator1(1)
-retGivenString = returnsGivenWithDecorator1('str')
-retGivenBool = returnsGivenWithDecorator1(True)
-";
-
-            var entry = ProcessText(text);
-
-            entry.AssertIsInstance("retGivenInt", BuiltinTypeId.Int);
-            entry.AssertIsInstance("retGivenString", BuiltinTypeId.Str);
-            entry.AssertIsInstance("retGivenBool", BuiltinTypeId.Bool);
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorReturnTypes_DecoratorWithParams() {
-            // https://pytools.codeplex.com/workitem/1694
-            var text = @"
-# with decorator with wrap
-def decoratorFunctionTakesArg2():
-    def wrap(f):
-        def wrapped_f(arg):
-            return f(arg)
-        return wrapped_f
-    return wrap
-
-@decoratorFunctionTakesArg2()
-def returnsGivenWithDecorator2(parm):
-    return parm
-
-retGivenInt = returnsGivenWithDecorator2(1)
-retGivenString = returnsGivenWithDecorator2('str')
-retGivenBool = returnsGivenWithDecorator2(True)";
-
-            var entry = ProcessText(text);
-
-            entry.AssertIsInstance("retGivenInt", BuiltinTypeId.Int);
-            entry.AssertIsInstance("retGivenString", BuiltinTypeId.Str);
-            entry.AssertIsInstance("retGivenBool", BuiltinTypeId.Bool);
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorOverflow() {
-            var text1 = @"
-import mod2
-
-@mod2.decorator_b
-def decorator_a(fn):
-    return fn
-    
-
-";
-
-            var text2 = @"
-import mod1
-
-@mod1.decorator_a
-def decorator_b(fn):
-    return fn
-";
-
-            PermutedTest("mod", new[] { text1, text2 }, state => {
-                // Neither decorator is callable, but at least analysis completed
-                state.AssertIsInstance(state.Modules["mod1"], "decorator_a", BuiltinTypeId.Function);
-                state.AssertIsInstance(state.Modules["mod2"], "decorator_b", BuiltinTypeId.Function);
-            });
-        }
-
-        [TestMethod, Priority(0)]
-        public void ProcessDecorators() {
-            var text = @"
-def d(fn):
-    return []
-
-@d
-def my_fn():
-    return None
-";
-
-            var entry = CreateAnalyzer();
-            entry.Analyzer.Limits.ProcessCustomDecorators = true;
-            entry.AddModule("fob", text);
-            entry.WaitForAnalysis();
-
-            entry.AssertIsInstance("my_fn", BuiltinTypeId.List);
-            entry.AssertIsInstance("fn", text.IndexOf("return"), BuiltinTypeId.Function);
-        }
-
-        [TestMethod, Priority(0)]
-        public void NoProcessDecorators() {
-            var text = @"
-def d(fn):
-    return []
-
-@d
-def my_fn():
-    return None
-";
-
-            var entry = CreateAnalyzer();
-            entry.Analyzer.Limits.ProcessCustomDecorators = false;
-            entry.AddModule("fob", text);
-            entry.WaitForAnalysis();
-
-            entry.AssertIsInstance("my_fn", BuiltinTypeId.Function);
-            entry.AssertIsInstance("fn", text.IndexOf("return"), BuiltinTypeId.Function);
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorReferences() {
-            var text = @"
-def d1(f):
-    return f
-class d2:
-    def __call__(self, f): return f
-
-@d1
-def func_d1(): pass
-@d2()
-def func_d2(): pass
-
-@d1
-class cls_d1(object): pass
-@d2()
-class cls_d2(object): pass
-";
-            var entry = ProcessText(text);
-            entry.AssertReferences("d1",
-                new VariableLocation(2, 1, VariableType.Value),
-                new VariableLocation(2, 5, VariableType.Definition),
-                new VariableLocation(7, 2, VariableType.Reference),
-                new VariableLocation(12, 2, VariableType.Reference)
-            );
-            entry.AssertReferences("d2",
-                new VariableLocation(4, 1, VariableType.Value),
-                new VariableLocation(4, 7, VariableType.Definition),
-                new VariableLocation(9, 2, VariableType.Reference),
-                new VariableLocation(14, 2, VariableType.Reference)
-            );
-            AssertUtil.ContainsExactly(entry.GetValues("f", 18).Select(v => v.MemberType), PythonMemberType.Function, PythonMemberType.Class);
-            AssertUtil.ContainsExactly(entry.GetValues("f", 66).Select(v => v.MemberType), PythonMemberType.Function, PythonMemberType.Class);
-            AssertUtil.ContainsExactly(entry.GetValues("func_d1").Select(v => v.MemberType), PythonMemberType.Function);
-            AssertUtil.ContainsExactly(entry.GetValues("func_d2").Select(v => v.MemberType), PythonMemberType.Function);
-            AssertUtil.ContainsExactly(entry.GetValues("cls_d1").Select(v => v.MemberType), PythonMemberType.Class);
-            AssertUtil.ContainsExactly(entry.GetValues("cls_d2").Select(v => v.MemberType), PythonMemberType.Class);
-        }
-
-        [TestMethod, Priority(0)]
-        public void DecoratorClass() {
-            var text = @"
-def dec1(C):
-    def sub_method(self): pass
-    C.sub_method = sub_method
-    return C
-
-@dec1
-class MyBaseClass1(object):
-    def base_method(self): pass
-
-def dec2(C):
-    class MySubClass(C):
-        def sub_method(self): pass
-    return MySubClass
-
-@dec2
-class MyBaseClass2(object):
-    def base_method(self): pass
-
-mc1 = MyBaseClass1()
-mc2 = MyBaseClass2()
-";
-            var entry = ProcessText(text);
-            AssertUtil.ContainsAtLeast(entry.GetMemberNames("mc1", 0, GetMemberOptions.None), "base_method", "sub_method");
-            entry.AssertIsInstance("mc2", "MySubClass");
-            AssertUtil.ContainsAtLeast(entry.GetMemberNames("mc2", 0, GetMemberOptions.None), "sub_method");
-        }
-
-        [TestMethod, Priority(0)]
-        public void ClassInit() {
-            var text = @"
-class X:
-    def __init__(self, value):
-        self.value = value
-
-a = X(2)
-";
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("a.value", 0, BuiltinTypeId.Int);
-            entry.AssertIsInstance("value", text.IndexOf("self."), BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void InstanceCall() {
-            var text = @"
-class X:
-    def __call__(self, value):
-        return value
-
-x = X()
-
-a = x(2)
-";
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("a", BuiltinTypeId.Int);
-        }
-
-        /// <summary>
-        /// Verifies that regardless of how we get to imports/function return values that
-        /// we properly understand the imported value.
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public void ImportScopesOrder() {
-            var text1 = @"
-import _io
-import mod2
-import mmap as mm
-
-import sys
-def f():
-    return sys
-
-def g():
-    return _io
-
-def h():
-    return mod2.sys
-
-def i():
-    import zlib
-    return zlib
-
-def j():
-    return mm
-
-def k():
-    return mod2.impp
-
-import operator as op
-
-import re
-
-";
-
-            var text2 = @"
-import sys
-import imp as impp
-";
-            PermutedTest("mod", new[] { text1, text2 }, state => {
-                state.DefaultModule = "mod1";
-                state.AssertDescription("g", "mod1.g() -> _io");
-                state.AssertDescription("f", "mod1.f() -> sys");
-                state.AssertDescription("h", "mod1.h() -> sys");
-                state.AssertDescription("i", "mod1.i() -> zlib");
-                state.AssertDescription("j", "mod1.j() -> mmap");
-                state.AssertDescription("k", "mod1.k() -> imp");
-            });
-        }
-
-        [TestMethod, Priority(0)]
-        public void ClassNew() {
-            var text = @"
-class X:
-    def __new__(cls, value):
-        res = object.__new__(cls)
-        res.value = value
-        return res
-
-a = X(2)
-";
-            var entry = ProcessText(text);
-            entry.AssertDescription("cls", text.IndexOf("= value"), "X");
-            entry.AssertIsInstance("value", text.IndexOf("res.value = "), BuiltinTypeId.Int);
-            entry.AssertIsInstance("res", text.IndexOf("res.value = "), "X");
-            entry.AssertIsInstance("a", text.IndexOf("a = "), "X");
-            entry.AssertIsInstance("a.value", BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void Global() {
-            var text = @"
-x = None
-y = None
-def f():
-    def g():
-        global x, y
-        x = 123
-        y = 123
-    return x, y
-
-a, b = f()
-";
-
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("b", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("x", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("y", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void Nonlocal() {
-            var text = @"
-def f():
-    x = None
-    y = None
-    def g():
-        nonlocal x, y
-        x = 123
-        y = 234
-    return x, y
-
-a, b = f()
-";
-
-            var entry = ProcessTextV3(text);
-            entry.AssertIsInstance("x", text.IndexOf("nonlocal"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("y", text.IndexOf("nonlocal"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("x", text.IndexOf("return"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("y", text.IndexOf("return"), BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-            entry.AssertIsInstance("b", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-
-            entry.AssertReferences("x", text.IndexOf("x ="),
-                new VariableLocation(3, 5, VariableType.Definition),
-                new VariableLocation(6, 18, VariableType.Reference),
-                new VariableLocation(7, 9, VariableType.Definition),
-                new VariableLocation(9, 12, VariableType.Reference)
-            );
-
-            entry.AssertReferences("y", text.IndexOf("x ="),
-                new VariableLocation(4, 5, VariableType.Definition),
-                new VariableLocation(6, 21, VariableType.Reference),
-                new VariableLocation(8, 9, VariableType.Definition),
-                new VariableLocation(9, 15, VariableType.Reference)
-            );
-
-
-            text = @"
-def f(x):
-    def g():
-        nonlocal x
-        x = 123
-    return x
-
-a = f(None)
-";
-
-            entry = ProcessTextV3(text);
-            entry.AssertIsInstance("a", BuiltinTypeId.NoneType, BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void IsInstance() {
-            var text = @"
-x = None
-
-
-if True:
-    pass
-    assert isinstance(x, int)
-    z = 100
-    pass
-else:
-    pass
-    assert isinstance(x, str)
-    y = 200
-    pass
-    
-
-
-
-
-if isinstance(x, tuple):
-    fob = 300
-    pass
-";
-
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("x", text.IndexOf("z ="), BuiltinTypeId.Int);
-            entry.AssertIsInstance("x", text.IndexOf("z =") + 1, BuiltinTypeId.Int);
-            entry.AssertIsInstance("x", text.IndexOf("pass"), BuiltinTypeId.NoneType, BuiltinTypeId.Int, BuiltinTypeId.Str, BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("x", text.IndexOf("y ="), BuiltinTypeId.Str);
-            entry.AssertIsInstance("x", text.IndexOf("y =") + 1, BuiltinTypeId.Str);
-            entry.AssertIsInstance("x", text.IndexOf("else:") + 7, BuiltinTypeId.NoneType, BuiltinTypeId.Int, BuiltinTypeId.Str, BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("x", text.IndexOf("fob ="), BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("x", text.LastIndexOf("pass"), BuiltinTypeId.Tuple);
-
-            entry.AssertReferences("x",
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            entry.AssertReferences("x", text.IndexOf("z ="),
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            entry.AssertReferences("x", text.IndexOf("z =") + 1,
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            entry.AssertReferences("x", text.IndexOf("z =") - 2,
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            entry.AssertReferences("x", text.IndexOf("y ="),
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            entry.AssertReferences("x", text.IndexOf("y =") + 1,
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            entry.AssertReferences("x", text.IndexOf("y =") - 2,
-                new VariableLocation(2, 1, VariableType.Definition),
-                new VariableLocation(7, 23, VariableType.Reference),
-                new VariableLocation(12, 23, VariableType.Reference),
-                new VariableLocation(20, 15, VariableType.Reference)
-            );
-
-            text = @"
-def f(a):
-    def g():
-        nonlocal a
-        print(a)
-        assert isinstance(a, int)
-        pass
-
-f('abc')
-";
-
-            entry = ProcessTextV3(text);
-            entry.AssertIsInstance("a");
-            entry.AssertIsInstance("a", text.IndexOf("def g()"), BuiltinTypeId.Int, BuiltinTypeId.Unicode);
-            entry.AssertIsInstance("a", text.IndexOf("pass"), BuiltinTypeId.Int);
-            entry.AssertIsInstance("a", text.IndexOf("print(a)"), BuiltinTypeId.Int, BuiltinTypeId.Unicode);
-
-            text = @"x = None
-
-
-if True:
-    pass
-    assert isinstance(x, int)
-    z = 100
-    
-    pass
-
-print(z)";
-
-            entry = ProcessText(text);
-            entry.AssertIsInstance("z", BuiltinTypeId.Int);
-            entry.AssertIsInstance("z", text.IndexOf("z ="), BuiltinTypeId.Int);
-            entry.AssertIsInstance("z", text.Length - 1, BuiltinTypeId.Int);
-
-            entry.AssertReferences("z",
-                new VariableLocation(7, 5, VariableType.Definition),
-                new VariableLocation(11, 7, VariableType.Reference)
-            );
-
-            entry.AssertReferences("z", text.IndexOf("z ="),
-                new VariableLocation(7, 5, VariableType.Definition),
-                new VariableLocation(11, 7, VariableType.Reference)
-            );
-
-            // http://pytools.codeplex.com/workitem/636
-
-            // this just shouldn't crash, we should handle the malformed code, not much to inspect afterwards...
-
-            entry = ProcessText("if isinstance(x, list):\r\n", allowParseErrors: true);
-            entry = ProcessText("if isinstance(x, list):", allowParseErrors: true);
-        }
-
-        [TestMethod, Priority(0)]
-        public void NestedIsInstance() {
-            var code = @"
-def f():
-    x = None
-    y = None
-
-    assert isinstance(x, int)
-    z = x
-
-    assert isinstance(y, int)
-    w = y
-
-    pass";
-
-            var entry = ProcessText(code);
-            entry.AssertIsInstance("z", code.IndexOf("pass"), BuiltinTypeId.Int);
-            entry.AssertIsInstance("w", code.IndexOf("pass"), BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void NestedIsInstance1908() {
-            // https://pytools.codeplex.com/workitem/1908
-            var code = @"
-def f(x):
-    y = object()    
-    assert isinstance(x, int)
-    if isinstance(y, float):
-        print('hi')
-
-    pass
-";
-
-            var entry = ProcessText(code);
-            entry.AssertIsInstance("y", code.IndexOf("pass"), BuiltinTypeId.Object, BuiltinTypeId.Float);
-        }
-
-        [TestMethod, Priority(0)]
-        public void IsInstanceUserDefinedType() {
-            var text = @"
-class C(object):
-    def f(self):
-        pass
-
-def f(a):
-    assert isinstance(a, C)
-    print(a)
-    pass
-";
-
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("a", text.IndexOf("print(a)"), "C");
-        }
-
-        [TestMethod, Priority(0)]
-        public void IsInstanceNested() {
-            var text = @"
-class R: pass
-
-def fn(a, b, c):
-    result = R()
-    assert isinstance(a, str)
-    result.a = a
-
-    assert isinstance(b, type)
-    if isinstance(b, tuple):
-        pass
-    result.b = b
-
-    assert isinstance(c, str)
-    result.c = c
-    return result
-
-r1 = fn('fob', (int, str), 'oar')
-r2 = fn(123, None, 4.5)
-";
-
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("r1.a", BuiltinTypeId.Str);
-            entry.AssertIsInstance("r1.b", BuiltinTypeId.Type, BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("r1.c", BuiltinTypeId.Str);
-
-            entry.AssertIsInstance("r2.a", BuiltinTypeId.Str);
-            entry.AssertIsInstance("r2.b", BuiltinTypeId.Type, BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("r2.c", BuiltinTypeId.Str);
-        }
-
-        private static IEnumerable<string> DumpScopesToStrings(InterpreterScope scope) {
-            yield return scope.Name;
-            foreach (var child in scope.Children) {
-                foreach (var s in DumpScopesToStrings(child)) {
-                    yield return "  " + s;
+                    var entry = ProcessTextV2(text);
+                    int i = text.IndexOf("print cls.g");
+                    entry.AssertHasParameters("cls.f", i);
+                    entry.AssertHasParameters("cls.g", i);
+                    entry.AssertHasParameters("cls.x", i, "var");
+                    entry.AssertHasParameters("cls.inst_method", i, "self");
                 }
-            }
-        }
 
-        [TestMethod, Priority(0)]
-        public void IsInstanceAndLambdaScopes() {
-            // https://github.com/Microsoft/PTVS/issues/2801
-            var text = @"if isinstance(p, dict):
-    v = [i for i in (lambda x: x)()]";
+                [TestMethod, Priority(0)]
+                public void MetaClassesV3() {
+                    var text = @"class C(type):
+            def f(self):
+                print('C.f')
 
-            var entry = ProcessTextV3(text);
-            var scope = entry.Modules[entry.DefaultModule].Analysis.Scope;
-            var dump = string.Join(Environment.NewLine, DumpScopesToStrings(scope));
+            def x(self, var):
+                pass
 
-            Console.WriteLine($"Actual:{Environment.NewLine}{dump}");
 
-            Assert.AreEqual(entry.DefaultModule + @"
-  <statements>
-  <isinstance scope>
-    <comprehension scope>
-      <lambda>
-        <statements>
-  <statements>", dump);
-        }
+        class D(object, metaclass = C):
+            @classmethod
+            def g(cls):
+                print(cls.g)
 
-        [TestMethod, Priority(0)]
-        public void IsInstanceReferences() {
-            var text = @"def fob():
-    oar = get_b()
-    assert isinstance(oar, float)
 
-    if oar.complex:
-        raise IndexError
+            def inst_method(self):
+                pass
+            ";
 
-    return oar";
-
-            var entry = ProcessText(text);
-
-            for (int i = text.IndexOf("oar", 0); i >= 0; i = text.IndexOf("oar", i + 1)) {
-                entry.AssertReferences("oar", i,
-                    new VariableLocation(2, 5, VariableType.Definition),
-                    new VariableLocation(3, 23, VariableType.Reference),
-                    new VariableLocation(5, 8, VariableType.Reference),
-                    new VariableLocation(8, 12, VariableType.Reference)
-                );
-            }
-        }
-
-        [TestMethod, Priority(0)]
-        public void FunctoolsDecoratorReferences() {
-            var text = @"from functools import wraps
-
-def d(f):
-    @wraps(f)
-    def wrapped(*a, **kw):
-        return f(*a, **kw)
-    return wrapped
-
-@d
-def g(p):
-    return p
-
-n1 = g(1)";
-
-            var entry = ProcessText(text);
-
-            entry.AssertReferences("d",
-                new VariableLocation(3, 1, VariableType.Value),
-                new VariableLocation(3, 5, VariableType.Definition),
-                new VariableLocation(9, 2, VariableType.Reference)
-            );
-
-            entry.AssertReferences("g",
-                new VariableLocation(4, 5, VariableType.Value),
-                new VariableLocation(10, 5, VariableType.Definition),
-                new VariableLocation(13, 6, VariableType.Reference)
-            );
-
-            // Decorators that don't use @wraps will expose the wrapper function
-            // as a value.
-            text = @"def d(f):
-    def wrapped(*a, **kw):
-        return f(*a, **kw)
-    return wrapped
-
-@d
-def g(p):
-    return p
-
-n1 = g(1)";
-
-            entry = ProcessText(text);
-
-            entry.AssertReferences("d",
-                new VariableLocation(1, 1, VariableType.Value),
-                new VariableLocation(1, 5, VariableType.Definition),
-                new VariableLocation(6, 2, VariableType.Reference)
-            );
-
-            entry.AssertReferences("g",
-                new VariableLocation(2, 5, VariableType.Value),
-                new VariableLocation(7, 5, VariableType.Definition),
-                new VariableLocation(10, 6, VariableType.Reference)
-            );
-        }
-
-        [TestMethod, Priority(0)]
-        public void QuickInfo() {
-            var text = @"
-import sys
-a = 41.0
-b = 42L
-c = 'abc'
-x = (2, 3, 4)
-y = [2, 3, 4]
-z = 43
-
-class fob(object):
-    @property
-    def f(self): pass
-
-    def g(self): pass
-    
-d = fob()
-
-def f():
-    print 'hello'
-    return 'abc'
-
-def g():
-    return c.Length
-
-def h():
-    return f
-    return g
-
-class return_func_class:
-    def return_func(self):
-        '''some help'''
-        return self.return_func
-
-
-def docstr_func():
-    '''useful documentation'''
-    return 42
-
-def with_params(a, b, c):
-    pass
-
-def with_params_default(a, b, c = 100):
-    pass
-
-def with_params_default_2(a, b, c = []):
-    pass
-
-def with_params_default_3(a, b, c = ()):
-    pass
-
-def with_params_default_4(a, b, c = {}):
-    pass
-
-def with_params_default_2a(a, b, c = [None]):
-    pass
-
-def with_params_default_3a(a, b, c = (None, )):
-    pass
-
-def with_params_default_4a(a, b, c = {42: 100}):
-    pass
-
-def with_params_default_starargs(*args, **kwargs):
-    pass
-";
-            var entry = ProcessTextV2(text);
-
-            entry.AssertIsInstance("fob()", "fob");
-            entry.AssertDescription("int()", "int");
-            entry.AssertDescription("a", "float");
-            entry.AssertDescription("a", "float");
-            entry.AssertDescription("b", "long");
-            entry.AssertDescription("c", "str");
-            entry.AssertIsInstance("x", BuiltinTypeId.Tuple);
-            entry.AssertIsInstance("y", BuiltinTypeId.List);
-            entry.AssertDescription("z", "int");
-            entry.AssertDescriptionContains("min", "min(");
-            entry.AssertDescriptionContains("list.append", "list.append(");
-            entry.AssertIsInstance("\"abc\".Length");
-            entry.AssertIsInstance("c.Length");
-            entry.AssertIsInstance("d", "fob");
-            entry.AssertDescription("sys", "sys");
-            entry.AssertDescription("f", "test-module.f() -> str");
-            entry.AssertDescription("fob.f", "test-module.fob.f(self: fob)\r\ndeclared in fob");
-            entry.AssertDescription("fob().g", "method g of test-module.fob objects");
-            entry.AssertDescription("fob", "class test-module.fob(object)");
-            //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.StringSplitOptions.RemoveEmptyEntries", 1), "field of type StringSplitOptions");
-            entry.AssertDescription("g", "test-module.g()");    // return info could be better
-            //AssertUtil.ContainsExactly(entry.GetVariableDescriptionsByIndex("System.AppDomain.DomainUnload", 1), "event of type System.EventHandler");
-            entry.AssertDescription("None", "None");
-            entry.AssertDescription("f.func_name", "property of type str");
-            entry.AssertDescription("h", "test-module.h() -> test-module.f() -> str, test-module.g()");
-            entry.AssertDescription("docstr_func", "test-module.docstr_func() -> int");
-            entry.AssertDocumentation("docstr_func", "useful documentation");
-
-            entry.AssertDescription("with_params", "test-module.with_params(a, b, c)");
-            entry.AssertDescription("with_params_default", "test-module.with_params_default(a, b, c: int=100)");
-            entry.AssertDescription("with_params_default_2", "test-module.with_params_default_2(a, b, c: list=[])");
-            entry.AssertDescription("with_params_default_3", "test-module.with_params_default_3(a, b, c: tuple=())");
-            entry.AssertDescription("with_params_default_4", "test-module.with_params_default_4(a, b, c: dict={})");
-            entry.AssertDescription("with_params_default_2a", "test-module.with_params_default_2a(a, b, c: list=[...])");
-            entry.AssertDescription("with_params_default_3a", "test-module.with_params_default_3a(a, b, c: tuple=(...))");
-            entry.AssertDescription("with_params_default_4a", "test-module.with_params_default_4a(a, b, c: dict={...})");
-            entry.AssertDescription("with_params_default_starargs", "test-module.with_params_default_starargs(*args, **kwargs)");
-
-            // method which returns itself, we shouldn't stack overflow producing the help...
-            entry.AssertDescription("return_func_class().return_func", "method return_func of test-module.return_func_class objects...");
-            entry.AssertDocumentation("return_func_class().return_func", "some help");
-        }
-
-        [TestMethod, Priority(0)]
-        public void CompletionDocumentation() {
-            var text = @"
-import sys
-a = 41.0
-b = 42L
-c = 'abc'
-x = (2, 3, 4)
-y = [2, 3, 4]
-z = 43
-
-class fob(object):
-    @property
-    def f(self): pass
-
-    def g(self): pass
-    
-d = fob()
-
-def f():
-    print 'hello'
-    return 'abc'
-
-def g():
-    return c.Length
-";
-            var entry = ProcessText(text);
-
-            AssertUtil.Contains(entry.GetCompletionDocumentation("", "d", 1).First(), "fob");
-            AssertUtil.Contains(entry.GetCompletionDocumentation("", "int", 1).First(), "integer");
-            AssertUtil.Contains(entry.GetCompletionDocumentation("", "min", 1).First(), "min(");
-        }
-
-        [TestMethod, Priority(0)]
-        public void MemberType() {
-            var text = @"
-import sys
-a = 41.0
-b = 42L
-c = 'abc'
-x = (2, 3, 4)
-y = [2, 3, 4]
-z = 43
-
-class fob(object):
-    @property
-    def f(self): pass
-
-    def g(self): pass
-    
-d = fob()
-
-def f():
-    print 'hello'
-    return 'abc'
-
-def g():
-    return c.Length
-";
-            var entry = ProcessText(text);
-
-
-            entry.AssertAttrIsType("f", "func_name", PythonMemberType.Property);
-            entry.AssertAttrIsType("f", "func_name", PythonMemberType.Property);
-            entry.AssertAttrIsType("list", "append", PythonMemberType.Method);
-            entry.AssertAttrIsType("y", "append", PythonMemberType.Method);
-            entry.AssertAttrIsType("", "int", PythonMemberType.Class);
-            entry.AssertAttrIsType("", "min", PythonMemberType.Function);
-            entry.AssertAttrIsType("", "sys", PythonMemberType.Module);
-        }
-
-        [TestMethod, Priority(0)]
-        public void RecurisveDataStructures() {
-            var text = @"
-d = {}
-d[0] = d
-";
-            var entry = ProcessTextV2(text);
-
-            entry.AssertDescription("d", "dict({int : dict})");
-        }
-
-        /// <summary>
-        /// Variable is refered to in the base class, defined in the derived class, we should know the type information.
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public void BaseReferencedDerivedDefined() {
-            var text = @"
-class Base(object):
-    def f(self):
-        x = self.map
-
-class Derived(Base):
-    def __init__(self):
-        self.map = {}
-
-pass
-";
-
-            var entry = ProcessText(text);
-            entry.AssertAttrIsType("Derived()", "map", PythonMemberType.Field);
-        }
-
-
-        /// <summary>
-        /// Test case where we have a member but we don't have any type information for the member.  It should
-        /// still show up as a member.
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public void NoTypesButIsMember() {
-            var text = @"
-def f(x, y):
-    C(x, y)
-
-class C(object):
-    def __init__(self, x, y):
-        self.x = x
-        self.y = y
-
-f(1)
-";
-
-            var entry = ProcessText(text);
-            entry.AssertHasAttr("C()", "x", "y");
-        }
-
-        /// <summary>
-        /// Test case where we have a member but we don't have any type information for the member.  It should
-        /// still show up as a member.
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public void SequenceFromSequence() {
-            var text = @"
-x = []
-x.append(1)
-
-t = (1, )
-
-class MyIndexer(object):
-    def __getitem__(self, index):
-        return 1
-
-ly = list(x)
-lz = list(MyIndexer())
-
-ty = tuple(x)
-tz = tuple(MyIndexer())
-
-lyt = list(t)
-tyt = tuple(t)
-";
-
-            var entry = ProcessText(text);
-            entry.AssertIsInstance("x[0]", BuiltinTypeId.Int);
-
-            foreach (string value in new[] { "ly", "lz", "ty", "tz", "lyt", "tyt" }) {
-                entry.AssertIsInstance(value + "[0]", BuiltinTypeId.Int);
-            }
-        }
-
-#if FALSE
-        [TestMethod, Priority(0)]
-        public void SaveStdLib() {
-            // only run this once...
-            if (GetType() == typeof(AnalysisTest)) {
-                var stdLib = AnalyzeStdLib();
-
-                string tmpFolder = TestData.GetTempPath("6666d700-a6d8-4e11-8b73-3ba99a61e27b");
-
-                new SaveAnalysis().Save(stdLib, tmpFolder);
-
-                File.Copy(Path.Combine(PythonInterpreterFactory.GetBaselineDatabasePath(), "__builtin__.idb"), Path.Combine(tmpFolder, "__builtin__.idb"), true);
-
-                var newPs = new PythonAnalyzer(new CPythonInterpreter(new TypeDatabase(tmpFolder)), PythonLanguageVersion.V27);
-            }
-        }
-#endif
-
-
-        [TestMethod, Priority(0)]
-        public void SubclassFindAllRefs() {
-            string text = @"
-class Base(object):
-    def __init__(self):
-        self.fob()
-    
-    def fob(self): 
-        pass
-    
-    
-class Derived(Base):
-    def fob(self): 
-        'x'
-";
-
-            var entry = ProcessText(text);
-
-            var refs = new[] {
-                new VariableLocation(4, 14, VariableType.Reference),
-                new VariableLocation(6, 5, VariableType.Value),
-                new VariableLocation(6, 9, VariableType.Definition),
-                new VariableLocation(11, 5, VariableType.Value),
-                new VariableLocation(11, 9, VariableType.Definition),
-            };
-
-            entry.AssertReferences("self.fob", text.IndexOf("'x'"), refs);
-            entry.AssertReferences("self.fob", text.IndexOf("pass"), refs);
-            entry.AssertReferences("self.fob", text.IndexOf("self.fob"), refs);
-        }
-
-        /// <summary>
-        /// Verifies that constructing lists / tuples from more lists/tuples doesn't cause an infinite analysis as we keep creating more lists/tuples.
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public void ListRecursion() {
-            string text = @"
-def f(x):
-    print abc
-    return f(list(x))
-
-abc = f(())
-";
-
-            var entry = ProcessText(text);
-
-            //var vars = entry.GetVariables("fob", GetLineNumber(text, "'x'"));
-
-        }
-
-        [TestMethod, Priority(0)]
-        public void TypeAtEndOfMethod() {
-            string text = @"
-class Fob(object):
-    def oar(self, a):
-        pass
-
-
-    def fob(self): 
-        pass
-
-x = Fob()
-x.oar(100)
-";
-
-            var entry = ProcessText(text);
-            var mod = entry.Modules[entry.DefaultModule].Analysis;
-
-            AssertUtil.ContainsAtLeast(mod.GetAllAvailableMembers(new SourceLocation(6, 9)).Select(mr => mr.Name), "a");
-        }
-
-        [TestMethod, Priority(0)]
-        public void TypeAtEndOfIncompleteMethod() {
-            string text = @"
-class Fob(object):
-    def oar(self, a):
-
-
-
-
-
-x = Fob()
-x.oar(100)
-";
-
-            var entry = ProcessText(text, allowParseErrors: true);
-            var mod = entry.Modules[entry.DefaultModule].Analysis;
-
-            AssertUtil.ContainsAtLeast(mod.GetAllAvailableMembers(new SourceLocation(6, 9)).Select(mr => mr.Name), "a");
-        }
-
-        [TestMethod, Priority(0)]
-        public void TypeIntersectionUserDefinedTypes() {
-            string text = @"
-class C1(object):
-    def fob(self): pass
-
-class C2(object):
-    def oar(self): pass
-
-c = C1()
-c.fob()
-c = C2()
-
-";
-
-            var entry = ProcessText(text);
-            AssertUtil.DoesntContain(entry.GetMemberNames("c", 0, GetMemberOptions.IntersectMultipleResults), new[] { "fob", "oar" });
-        }
-
-        [TestMethod, Priority(0)]
-        public void UpdateMethodMultiFiles() {
-            string text1 = @"
-def f(abc):
-    pass
-";
-
-            string text2 = @"
-import mod1
-mod1.f(42)
-";
-
-            var state = CreateAnalyzer();
-
-            // add both files to the project
-            var entry1 = state.AddModule("mod1", text1);
-            var entry2 = state.AddModule("mod2", text2);
-
-            state.WaitForAnalysis();
-            state.AssertIsInstance(entry1, "abc", text1.IndexOf("pass"), BuiltinTypeId.Int);
-
-            // re-analyze project1, we should still know about the type info provided by module2
-            state.UpdateModule(entry1, null);
-            state.WaitForAnalysis();
-
-            state.AssertIsInstance(entry1, "abc", text1.IndexOf("pass"), BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void MetaClassesV2() {
-
-            string text = @"class C(type):
-    def f(self):
-        print('C.f')
-
-    def x(self, var):
-        pass
-
-
-class D(object):
-    __metaclass__ = C
-    @classmethod
-    def g(cls):
-        print cls.g
-
-
-    def inst_method(self):
-        pass
-    ";
-
-            var entry = ProcessTextV2(text);
-            int i = text.IndexOf("print cls.g");
-            entry.AssertHasParameters("cls.f", i);
-            entry.AssertHasParameters("cls.g", i);
-            entry.AssertHasParameters("cls.x", i, "var");
-            entry.AssertHasParameters("cls.inst_method", i, "self");
-        }
-
-        [TestMethod, Priority(0)]
-        public void MetaClassesV3() {
-            var text = @"class C(type):
-    def f(self):
-        print('C.f')
-
-    def x(self, var):
-        pass
-
-
-class D(object, metaclass = C):
-    @classmethod
-    def g(cls):
-        print(cls.g)
-
-
-    def inst_method(self):
-        pass
-    ";
-
-            var entry = ProcessTextV3(text);
-            int i = text.IndexOf("print(cls.g)");
-            entry.AssertHasParameters("cls.f", i);
-            entry.AssertHasParameters("cls.g", i);
-            entry.AssertHasParameters("cls.x", i, "var");
-            entry.AssertHasParameters("cls.inst_method", i, "self");
-        }
-
-        /// <summary>
-        /// Tests assigning odd things to the metaclass variable.
-        /// </summary>
-        [TestMethod, Priority(0)]
-        public void InvalidMetaClassValues() {
-            var assigns = new[] { "[1,2,3]", "(1,2)", "1", "abc", "1.0", "lambda x: 42", "C.f", "C().f", "f", "{2:3}" };
-
-            foreach (var assign in assigns) {
-                string text = @"
-class C(object): 
-    def f(self): pass
-
-def f():  pass
-
-class D(object):
-    __metaclass__ = " + assign + @"
-    @classmethod
-    def g(cls):
-        print cls.g
-
-
-    def inst_method(self):
-        pass
-    ";
-
-                ProcessTextV2(text);
-            }
-
-            foreach (var assign in assigns) {
-                string text = @"
-class C(object): 
-    def f(self): pass
-
-def f():  pass
-
-class D(metaclass = " + assign + @"):
-    @classmethod
-    def g(cls):
-        print cls.g
-
-
-    def inst_method(self):
-        pass
-    ";
-
-                ProcessTextV3(text, allowParseErrors: true);
-            }
-        }
-
-        [TestMethod, Priority(0)]
-        public void FromImport() {
-            ProcessText("from #   blah", allowParseErrors: true);
-        }
-
-        [TestMethod, Priority(0)]
-        public void SelfNestedMethod() {
-            // http://pytools.codeplex.com/workitem/648
-            var code = @"class MyClass:
-    def func1(self):
-        def func2(a, b):
-            return a
-
-        return func2('abc', 123)
-
-x = MyClass().func1()
-";
-
-            var entry = ProcessText(code);
-
-            entry.AssertIsInstance("x", BuiltinTypeId.Str);
-        }
-
-        [TestMethod, Priority(0)]
-        public void Super() {
-            var code = @"
-class Base1(object):
-    def base_func(self, x): pass
-    def base1_func(self): pass
-class Base2(object):
-    def base_func(self, x, y, z): pass
-    def base2_func(self): pass
-class Derived1(Base1, Base2):
-    def derived1_func(self):
-        print('derived1_func')
-class Derived2(Base2, Base1):
-    def derived2_func(self):
-        print('derived2_func')
-class Derived3(object):
-    def derived3_func(self):
-        cls = Derived1
-        cls = Derived2
-        print('derived3_func')
-";
-            var entry = ProcessText(code);
-
-            // super(Derived1)
-            {
-                // Member from derived class should not be present
-                entry.AssertNotHasAttr("super(Derived1)", code.IndexOf("print('derived1_func')"), "derived1_func");
-
-                // Members from both base classes with distinct names should be present, and should have all parameters including self
-                entry.AssertHasParameters("super(Derived1).base1_func", code.IndexOf("print('derived1_func')"), "self");
-                entry.AssertHasParameters("super(Derived1).base2_func", code.IndexOf("print('derived1_func')"), "self");
-
-                // Only one member with clashing names should be present, and it should be from Base1
-                entry.AssertHasParameters("super(Derived1).base_func", code.IndexOf("print('derived1_func')"), "self", "x");
-            }
-
-            // super(Derived2)
-            {
-                // Only one member with clashing names should be present, and it should be from Base2
-                entry.AssertHasParameters("super(Derived2).base_func", code.IndexOf("print('derived2_func')"), "self", "x", "y", "z");
-            }
-
-            // super(Derived1, self), or Py3k magic super() to the same effect
-            int i = code.IndexOf("print('derived1_func')");
-            entry.AssertNotHasAttr("super(Derived1, self)", i, "derived1_func");
-            entry.AssertHasParameters("super(Derived1, self).base1_func", i);
-            entry.AssertHasParameters("super(Derived1, self).base2_func", i);
-            entry.AssertHasParameters("super(Derived1, self).base_func", i, "x");
-
-            if (entry.Analyzer.LanguageVersion.Is3x()) {
-                entry.AssertNotHasAttr("super()", i, "derived1_func");
-                entry.AssertHasParameters("super().base1_func", i);
-                entry.AssertHasParameters("super().base2_func", i);
-                entry.AssertHasParameters("super().base_func", i, "x");
-            }
-
-            // super(Derived2, self), or Py3k magic super() to the same effect
-            i = code.IndexOf("print('derived2_func')");
-            entry.AssertHasParameters("super(Derived2, self).base_func", i, "x", "y", "z");
-            if (entry.Analyzer.LanguageVersion.Is3x()) {
-                entry.AssertHasParameters("super().base_func", i, "x", "y", "z");
-            }
-
-            // super(Derived1 union Derived1)
-            {
-                // Members with clashing names from both potential bases should be unioned
-                var sigs = entry.GetSignatures("super(cls).base_func", code.IndexOf("print('derived3_func')"));
-                Assert.AreEqual(2, sigs.Length);
-                Assert.IsTrue(sigs.Any(overload => overload.Parameters.Length == 2)); // (self, x)
-                Assert.IsTrue(sigs.Any(overload => overload.Parameters.Length == 4)); // (self, x, y, z)
-            }
-        }
-
-        [TestMethod, Priority(0)]
-        public void ParameterAnnotation() {
-            var text = @"
-s = None
-def f(s: s = 123):
-    return s
-";
-            var entry = ProcessTextV3(text);
-
-            entry.AssertIsInstance("s", text.IndexOf("s:"), BuiltinTypeId.Int, BuiltinTypeId.NoneType);
-            entry.AssertIsInstance("s", text.IndexOf("s ="), BuiltinTypeId.NoneType);
-            entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int, BuiltinTypeId.NoneType);
-        }
-
-        [TestMethod, Priority(0)]
-        public void ParameterAnnotationLambda() {
-            var text = @"
-s = None
-def f(s: lambda s: s > 0 = 123):
-    return s
-";
-            var entry = ProcessTextV3(text);
-
-            entry.AssertIsInstance("s", text.IndexOf("s:"), BuiltinTypeId.Int);
-            entry.AssertIsInstance("s", text.IndexOf("s >"), BuiltinTypeId.NoneType);
-            entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void ReturnAnnotation() {
-            var text = @"
-s = None
-def f(s = 123) -> s:
-    return s
-";
-            var entry = ProcessTextV3(text);
-
-            entry.AssertIsInstance("s", text.IndexOf("(s =") + 1, BuiltinTypeId.Int);
-            entry.AssertIsInstance("s", text.IndexOf("s:"), BuiltinTypeId.NoneType);
-            entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void FunctoolsPartial() {
-            var text = @"
-from _functools import partial
-
-def fob(a, b, c, d):
-    return a, b, c, d
-
-sanity = fob(123, 3.14, 'abc', [])
-
-fob_1 = partial(fob, 123, 3.14, 'abc', [])
-result_1 = fob_1()
-
-fob_2 = partial(fob, d = [], c = 'abc', b = 3.14, a = 123)
-result_2 = fob_2()
-
-fob_3 = partial(fob, 123, 3.14)
-result_3 = fob_3('abc', [])
-
-fob_4 = partial(fob, c = 'abc', d = [])
-result_4 = fob_4(123, 3.14)
-
-func_from_fob_1 = fob_1.func
-args_from_fob_1 = fob_1.args
-keywords_from_fob_2 = fob_2.keywords
-";
-            var entry = ProcessText(text);
-
-            foreach (var name in new[] {
-                "sanity",
-                "result_1",
-                "result_2",
-                "result_3",
-                "result_4",
-                "args_from_fob_1"
-            }) {
-                entry.AssertDescription(name, "tuple[int, float, str, list]");
-                var result = entry.GetValue<AnalysisValue>(name);
-                Console.WriteLine("{0} = {1}", name, result);
-                AssertTupleContains(result, BuiltinTypeId.Int, BuiltinTypeId.Float, entry.BuiltinTypeId_Str, BuiltinTypeId.List);
-            }
-
-            var fob = entry.GetValue<FunctionInfo>("fob");
-            var fob2 = entry.GetValue<FunctionInfo>("func_from_fob_1");
-            Assert.AreSame(fob, fob2);
-
-            entry.GetValue<DictionaryInfo>("keywords_from_fob_2");
-        }
-
-        [TestMethod, Priority(0)]
-        public void FunctoolsWraps() {
-            var text = @"
-from functools import wraps, update_wrapper
-
-def decorator1(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        fn(*args, **kwargs)
-        return 'decorated'
-    return wrapper
-
-@decorator1
-def test1():
-    '''doc'''
-    return 'undecorated'
-
-def test2():
-    pass
-
-def test2a():
-    pass
-
-test2.test_attr = 123
-update_wrapper(test2a, test2, ('test_attr',))
-
-test1_result = test1()
-";
-
-            var state = CreateAnalyzer();
-            var textEntry = state.AddModule("fob", text);
-            state.WaitForAnalysis();
-
-            state.AssertConstantEquals("test1.__name__", "test1");
-            state.AssertConstantEquals("test1.__doc__", "doc");
-            var fi = state.GetValue<FunctionInfo>("test1");
-            Assert.AreEqual("doc", fi.Documentation);
-            state.GetValue<FunctionInfo>("test1.__wrapped__");
-            Assert.AreEqual(2, state.GetValue<FunctionInfo>("test1").Overloads.Count());
-            state.AssertConstantEquals("test1_result", "decorated");
-
-            // __name__ should not have been changed by update_wrapper
-            state.AssertConstantEquals("test2.__name__", "test2");
-            state.AssertConstantEquals("test2a.__name__", "test2a");
-
-            // test_attr should have been copied by update_wrapper
-            state.AssertIsInstance("test2.test_attr", BuiltinTypeId.Int);
-            state.AssertIsInstance("test2a.test_attr", BuiltinTypeId.Int);
-        }
-
-        private static void AssertTupleContains(AnalysisValue tuple, params BuiltinTypeId[] id) {
-            var indexTypes = (tuple as SequenceInfo)?.IndexTypes?.Select(v => v.TypesNoCopy).ToArray() ??
-                (tuple as ProtocolInfo)?.GetProtocols<TupleProtocol>()?.FirstOrDefault()?._values;
-            Assert.IsNotNull(indexTypes);
-
-            var expected = string.Join(", ", id);
-            var actual = string.Join(", ", indexTypes.Select(t => {
-                if (t.Count == 1) {
-                    return t.Single().TypeId.ToString();
-                } else {
-                    return "{" + string.Join(", ", t.Select(t2 => t2.TypeId).OrderBy(t2 => t2)) + "}";
+                    var entry = ProcessTextV3(text);
+                    int i = text.IndexOf("print(cls.g)");
+                    entry.AssertHasParameters("cls.f", i);
+                    entry.AssertHasParameters("cls.g", i);
+                    entry.AssertHasParameters("cls.x", i, "var");
+                    entry.AssertHasParameters("cls.inst_method", i, "self");
                 }
-            }));
-            if (indexTypes
-                .Zip(id, (t1, id2) => t1.Count == 1 && t1.Single().TypeId == id2)
-                .Any(b => !b)) {
-                Assert.Fail(string.Format("Expected <{0}>. Actual <{1}>.", expected, actual));
-            }
-        }
+
+                /// <summary>
+                /// Tests assigning odd things to the metaclass variable.
+                /// </summary>
+                [TestMethod, Priority(0)]
+                public void InvalidMetaClassValues() {
+                    var assigns = new[] { "[1,2,3]", "(1,2)", "1", "abc", "1.0", "lambda x: 42", "C.f", "C().f", "f", "{2:3}" };
+
+                    foreach (var assign in assigns) {
+                        string text = @"
+        class C(object): 
+            def f(self): pass
+
+        def f():  pass
+
+        class D(object):
+            __metaclass__ = " + assign + @"
+            @classmethod
+            def g(cls):
+                print cls.g
 
 
-        [TestMethod, Priority(0)]
-        public void ValidatePotentialModuleNames() {
-            // Validating against the structure given in
-            // http://www.python.org/dev/peps/pep-0328/
+            def inst_method(self):
+                pass
+            ";
 
-            var entry = new MockPythonProjectEntry {
-                ModuleName = "package.subpackage1.moduleX",
-                FilePath = "C:\\package\\subpackage1\\moduleX.py"
-            };
-
-            // Without absolute_import, we should see these two possibilities
-            // for a regular import.
-            AssertUtil.ArrayEquals(
-                ModuleResolver.ResolvePotentialModuleNames(entry, "moduleY", false).ToArray(),
-                new[] { "package.subpackage1.moduleY", "moduleY" }
-            );
-
-            // With absolute_import, we should see the two possibilities for a
-            // regular import, but in the opposite order.
-            AssertUtil.ArrayEquals(
-                ModuleResolver.ResolvePotentialModuleNames(entry, "moduleY", true).ToArray(),
-                new[] { "moduleY", "package.subpackage1.moduleY" }
-            );
-
-            // Regardless of absolute import, we should see these results for
-            // relative imports.
-            foreach (var absoluteImport in new[] { true, false }) {
-                Console.WriteLine("Testing with absoluteImport = {0}", absoluteImport);
-
-                AssertUtil.ContainsExactly(
-                    ModuleResolver.ResolvePotentialModuleNames(entry, ".moduleY", absoluteImport),
-                    "package.subpackage1.moduleY"
-                );
-                AssertUtil.ContainsExactly(
-                    ModuleResolver.ResolvePotentialModuleNames(entry, ".", absoluteImport),
-                    "package.subpackage1"
-                );
-                AssertUtil.ContainsExactly(
-                    ModuleResolver.ResolvePotentialModuleNames(entry, "..subpackage1", absoluteImport),
-                    "package.subpackage1"
-                );
-                AssertUtil.ContainsExactly(
-                    ModuleResolver.ResolvePotentialModuleNames(entry, "..subpackage2.moduleZ", absoluteImport),
-                    "package.subpackage2.moduleZ"
-                );
-                AssertUtil.ContainsExactly(
-                    ModuleResolver.ResolvePotentialModuleNames(entry, "..moduleA", absoluteImport),
-                    "package.moduleA"
-                );
-
-                // Despite what PEP 328 says, this relative import never succeeds.
-                AssertUtil.ContainsExactly(
-                    ModuleResolver.ResolvePotentialModuleNames(entry, "...package", absoluteImport),
-                    "package"
-                );
-            }
-        }
-
-        [TestMethod, Priority(0)]
-        public void MultilineFunctionDescription() {
-            var code = @"class A:
-    def fn(self):
-        return lambda: 123
-";
-            var entry = ProcessText(code);
-
-            Assert.AreEqual(
-                "test-module.A.fn(self: A) -> lambda: 123 -> int\ndeclared in A",
-                entry.GetDescriptions("A.fn", 0).Single().Replace("\r\n", "\n")
-            );
-        }
-
-        [TestMethod, Priority(0)]
-        public void SysModulesSetSpecialization() {
-            var code = @"import sys
-modules = sys.modules
-
-modules['name_in_modules'] = None
-";
-            code += string.Join(
-                Environment.NewLine,
-                Enumerable.Range(0, 100).Select(i => string.Format("sys.modules['name{0}'] = None", i))
-            );
-
-            var entry = ProcessTextV2(code);
-
-            var sys = entry.GetValue<SysModuleInfo>("sys");
-
-            var modules = entry.GetValue<SysModuleInfo.SysModulesDictionaryInfo>("modules");
-            Assert.IsInstanceOfType(modules, typeof(SysModuleInfo.SysModulesDictionaryInfo));
-
-            AssertUtil.ContainsExactly(
-                sys.Modules.Keys,
-                Enumerable.Range(0, 100).Select(i => string.Format("name{0}", i))
-                    .Concat(new[] { "name_in_modules" })
-            );
-        }
-
-        [TestMethod, Priority(0)]
-        public void SysModulesGetSpecialization() {
-            var code = @"import sys
-modules = sys.modules
-
-modules['value_in_modules'] = 'abc'
-modules['value_in_modules'] = 123
-value_in_modules = modules['value_in_modules']
-builtins = modules['__builtin__']
-builtins2 = modules.get('__builtin__')
-builtins3 = modules.pop('__builtin__')
-";
-
-            var entry = ProcessTextV2(code);
-
-            entry.AssertIsInstance("value_in_modules", BuiltinTypeId.Int);
-
-            Assert.AreEqual("__builtin__", entry.GetValue<AnalysisValue>("builtins").Name);
-            Assert.AreEqual("__builtin__", entry.GetValue<AnalysisValue>("builtins2").Name);
-            Assert.AreEqual("__builtin__", entry.GetValue<AnalysisValue>("builtins3").Name);
-        }
-
-        [TestMethod, Priority(0)]
-        public void ClassInstanceAttributes() {
-            var code = @"
-class A:
-    abc = 123
-
-p1 = A.abc
-p2 = A().abc
-a = A()
-a.abc = 3.1415
-p4 = A().abc
-p3 = a.abc
-";
-            var entry = ProcessText(code);
-
-            entry.AssertIsInstance("p1", BuiltinTypeId.Int);
-            entry.AssertIsInstance("p3", BuiltinTypeId.Int, BuiltinTypeId.Float);
-            entry.AssertIsInstance("p4", BuiltinTypeId.Int, BuiltinTypeId.Float);
-            entry.AssertIsInstance("p2", BuiltinTypeId.Int, BuiltinTypeId.Float);
-        }
-
-        [TestMethod, Priority(0)]
-        public void RecursiveGetDescriptor() {
-            // see https://pytools.codeplex.com/workitem/2955
-            var entry = ProcessText(@"
-class WithGet:
-    __get__ = WithGet()
-
-class A:
-    wg = WithGet()
-
-x = A().wg");
-
-            Assert.IsNotNull(entry);
-        }
-
-        [TestMethod, Priority(0)]
-        public void Coroutine() {
-            var code = @"
-async def g():
-    return 123
-
-async def f():
-    x = await g()
-    g2 = g()
-    y = await g2
-";
-            var entry = ProcessText(code, PythonLanguageVersion.V35);
-
-            entry.AssertIsInstance("x", code.IndexOf("x ="), BuiltinTypeId.Int);
-            entry.AssertIsInstance("y", code.IndexOf("x ="), BuiltinTypeId.Int);
-            entry.AssertIsInstance("g2", code.IndexOf("x ="), BuiltinTypeId.Generator);
-        }
-
-        [TestMethod, Priority(0)]
-        public void AsyncWithStatement() {
-            var text = @"
-class X(object):
-    def x_method(self): pass
-    async def __aenter__(self): return self
-    async def __aexit__(self, exc_type, exc_value, traceback): return False
-
-class Y(object):
-    def y_method(self): pass
-    async def __aenter__(self): return 123
-    async def __aexit__(self, exc_type, exc_value, traceback): return False
-
-async def f():
-    async with X() as x:
-        pass #x
-
-    async with Y() as y:
-        pass #y
-";
-            var entry = ProcessText(text, PythonLanguageVersion.V35);
-            entry.AssertHasAttr("x", text.IndexOf("pass #x"), "x_method");
-            entry.AssertIsInstance("y", text.IndexOf("pass #y"), BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void AsyncForIterator() {
-            var code = @"
-class X:
-    async def __aiter__(self): return self
-    async def __anext__(self): return 123
-
-class Y:
-    async def __aiter__(self): return X()
-
-async def f():
-    async for i in Y():
-        pass
-";
-            var entry = ProcessText(code, PythonLanguageVersion.V35);
-
-            entry.AssertIsInstance("i", code.IndexOf("pass"), BuiltinTypeId.Int);
-        }
-
-
-        [TestMethod, Priority(0)]
-        public void RecursiveDecorators() {
-            // See https://github.com/Microsoft/PTVS/issues/542
-            // Should not crash/OOM
-            var code = @"
-def f():
-    def d(fn):
-        @f()
-        def g(): pass
-
-    return d
-";
-
-            ProcessText(code);
-        }
-
-        [TestMethod, Priority(0)]
-        public void NullNamedArgument() {
-            CallDelegate callable = (node, unit, args, keywordArgNames) => {
-                bool anyNull = false;
-                Console.WriteLine("fn({0})", string.Join(", ", keywordArgNames.Select(n => {
-                    if (n == null) {
-                        anyNull = true;
-                        return "(null)";
-                    } else {
-                        return n.Name + "=(value)";
+                        ProcessTextV2(text);
                     }
-                })));
-                Assert.IsFalse(anyNull, "Some arguments were null");
-                return AnalysisSet.Empty;
-            };
 
-            using (var state = CreateAnalyzer(allowParseErrors: true)) {
-                state.Analyzer.SpecializeFunction("NullNamedArgument", "fn", callable);
+                    foreach (var assign in assigns) {
+                        string text = @"
+        class C(object): 
+            def f(self): pass
 
-                var entry1 = state.AddModule("NullNamedArgument", "def fn(**kwargs): pass");
-                var entry2 = state.AddModule("test", "import NullNamedArgument; NullNamedArgument.fn(a=0, ]]])");
-                state.WaitForAnalysis();
-            }
-        }
+        def f():  pass
 
-        [TestMethod, Priority(0)]
-        public void ModuleNameWalker() {
-            foreach (var item in new[] {
-                new { Code="import abc", Index=7, Expected="abc", Base="" },
-                new { Code="import abc", Index=8, Expected="abc", Base="" },
-                new { Code="import abc", Index=9, Expected="abc", Base="" },
-                new { Code="import abc", Index=10, Expected="abc", Base="" },
-                new { Code="import deg, abc as A", Index=12, Expected="abc", Base="" },
-                new { Code="from abc import A", Index=6, Expected="abc", Base="" },
-                new { Code="from .deg import A", Index=9, Expected="deg", Base="abc" },
-                new { Code="from .hij import A", Index=9, Expected="abc.hij", Base="abc.deg" },
-                new { Code="from ..hij import A", Index=10, Expected="hij", Base="abc.deg" },
-                new { Code="from ..hij import A", Index=10, Expected="abc.hij", Base="abc.deg.HIJ" },
-            }) {
-                var entry = ProcessTextV3(item.Code);
-                var walker = new ImportedModuleNameWalker(item.Base, string.Empty, item.Index, null);
-                entry.Modules[entry.DefaultModule].Tree.Walk(walker);
-
-                Assert.AreEqual(item.Expected, walker.ImportedModules.FirstOrDefault()?.Name);
-            }
-        }
-
-        [TestMethod, Priority(0)]
-        public void CrossModuleFunctionCallMemLeak() {
-            var modA = @"from B import h
-def f(x): return h(x)
-
-f(1)";
-            var modB = @"def g(x): pass
-def h(x): return g(x)";
-
-            var analyzer = CreateAnalyzer();
-            var entryA = analyzer.AddModule("A", modA);
-            var entryB = analyzer.AddModule("B", modB);
-            analyzer.WaitForAnalysis(CancellationTokens.After5s);
-            for (int i = 100; i > 0; --i) {
-                entryA.Analyze(CancellationToken.None, true);
-                analyzer.WaitForAnalysis(CancellationTokens.After5s);
-            }
-            var g = analyzer.GetValue<FunctionInfo>(entryB, "g");
-            Assert.AreEqual(1, g.References.Count());
-        }
-
-        [TestMethod, Priority(0)]
-        public void DefaultModuleAttributes() {
-            var entry3 = ProcessTextV3("x = 1");
-            AssertUtil.ContainsExactly(entry3.GetNamesNoBuiltins(), "__builtins__", "__file__", "__name__", "__package__", "__cached__", "__spec__", "x");
-            var package = entry3.AddModule("package", "", Path.Combine(TestData.GetTempPath("package"), "__init__.py"));
-            AssertUtil.ContainsExactly(entry3.GetNamesNoBuiltins(package), "__path__", "__builtins__", "__file__", "__name__", "__package__", "__cached__", "__spec__");
-
-            entry3.AssertIsInstance("__file__", BuiltinTypeId.Unicode);
-            entry3.AssertIsInstance("__name__", BuiltinTypeId.Unicode);
-            entry3.AssertIsInstance("__package__", BuiltinTypeId.Unicode);
-            entry3.AssertIsInstance(package, "__path__", BuiltinTypeId.List);
-
-            var entry2 = ProcessTextV2("x = 1");
-            AssertUtil.ContainsExactly(entry2.GetNamesNoBuiltins(), "__builtins__", "__file__", "__name__", "__package__", "x");
-
-            entry2.AssertIsInstance("__file__", BuiltinTypeId.Bytes);
-            entry2.AssertIsInstance("__name__", BuiltinTypeId.Bytes);
-            entry2.AssertIsInstance("__package__", BuiltinTypeId.Bytes);
-        }
-
-        [TestMethod, Priority(0)]
-        public void CrossModuleBaseClasses() {
-            var analyzer = CreateAnalyzer();
-            var entryA = analyzer.AddModule("A", @"class ClsA(object): pass");
-            var entryB = analyzer.AddModule("B", @"from A import ClsA
-class ClsB(ClsA): pass
-
-x = ClsB.x");
-            analyzer.WaitForAnalysis();
-            analyzer.AssertIsInstance(entryB, "x");
-
-            analyzer.UpdateModule(entryA, @"class ClsA(object): x = 123");
-            entryA.Analyze(CancellationToken.None, true);
-            analyzer.WaitForAnalysis();
-            analyzer.AssertIsInstance(entryB, "x", BuiltinTypeId.Int);
-        }
-
-        [TestMethod, Priority(0)]
-        public void UndefinedVariableDiagnostic() {
-            PythonAnalysis entry;
-            string code;
+        class D(metaclass = " + assign + @"):
+            @classmethod
+            def g(cls):
+                print cls.g
 
 
-            code = @"a = b + c
-class D(b): pass
-d()
-D()
-(e for e in e if e)
-{f for f in f if f}
-[g for g in g if g]
+            def inst_method(self):
+                pass
+            ";
 
-def func(b, c):
-    b, c, d     # b, c are defined here
-b, c, d         # but they are undefined here
-";
-            entry = ProcessTextV3(code);
-            entry.AssertDiagnostics(
-                "used-before-assignment:unknown variable 'b':(1, 5) - (1, 6)",
-                "used-before-assignment:unknown variable 'c':(1, 9) - (1, 10)",
-                "used-before-assignment:unknown variable 'b':(2, 9) - (2, 10)",
-                "used-before-assignment:unknown variable 'd':(3, 1) - (3, 2)",
-                "used-before-assignment:unknown variable 'e':(5, 13) - (5, 14)",
-                "used-before-assignment:unknown variable 'f':(6, 13) - (6, 14)",
-                "used-before-assignment:unknown variable 'g':(7, 13) - (7, 14)",
-                "used-before-assignment:unknown variable 'd':(10, 11) - (10, 12)",
-                "used-before-assignment:unknown variable 'b':(11, 1) - (11, 2)",
-                "used-before-assignment:unknown variable 'c':(11, 4) - (11, 5)",
-                "used-before-assignment:unknown variable 'd':(11, 7) - (11, 8)"
-            );
+                        ProcessTextV3(text, allowParseErrors: true);
+                    }
+                }
 
-            // Ensure all of these cases correctly generate no warning
-            code = @"
-for x in []:
-    (_ for _ in x)
-    [_ for _ in x]
-    {_ for _ in x}
-    {_ : _ for _ in x}
+                [TestMethod, Priority(0)]
+                public void FromImport() {
+                    ProcessText("from #   blah", allowParseErrors: true);
+                }
 
-import sys
-from sys import not_a_real_name_but_no_warning_anyway
+                [TestMethod, Priority(0)]
+                public void SelfNestedMethod() {
+                    // http://pytools.codeplex.com/workitem/648
+                    var code = @"class MyClass:
+            def func1(self):
+                def func2(a, b):
+                    return a
 
-def f(v = sys.version, u = not_a_real_name_but_no_warning_anyway):
-    pass
+                return func2('abc', 123)
 
-with f() as v2:
-    pass
+        x = MyClass().func1()
+        ";
 
-";
-            entry = ProcessTextV3(code);
-            entry.AssertDiagnostics();
-        }
+                    var entry = ProcessText(code);
 
-        [TestMethod, Priority(0)]
-        public void UncallableObjectDiagnostic() {
-            var code = @"class MyClass:
-    pass
+                    entry.AssertIsInstance("x", BuiltinTypeId.Str);
+                }
 
-class MyCallableClass:
-    def __call__(self): return 123
+                [TestMethod, Priority(0)]
+                public void Super() {
+                    var code = @"
+        class Base1(object):
+            def base_func(self, x): pass
+            def base1_func(self): pass
+        class Base2(object):
+            def base_func(self, x, y, z): pass
+            def base2_func(self): pass
+        class Derived1(Base1, Base2):
+            def derived1_func(self):
+                print('derived1_func')
+        class Derived2(Base2, Base1):
+            def derived2_func(self):
+                print('derived2_func')
+        class Derived3(object):
+            def derived3_func(self):
+                cls = Derived1
+                cls = Derived2
+                print('derived3_func')
+        ";
+                    var entry = ProcessText(code);
 
-mc = MyClass()
-mcc = MyCallableClass()
+                    // super(Derived1)
+                    {
+                        // Member from derived class should not be present
+                        entry.AssertNotHasAttr("super(Derived1)", code.IndexOf("print('derived1_func')"), "derived1_func");
 
-x = mc()
-y = mcc()
-";
-            var entry = ProcessTextV3(code);
-            entry.AssertIsInstance("x");
-            entry.AssertIsInstance("y", BuiltinTypeId.Int);
-            entry.AssertDiagnostics(
-                "not-callable:'MyClass' may not be callable:(10, 5) - (10, 7)"
-            );
-        }
-*/
+                        // Members from both base classes with distinct names should be present, and should have all parameters including self
+                        entry.AssertHasParameters("super(Derived1).base1_func", code.IndexOf("print('derived1_func')"), "self");
+                        entry.AssertHasParameters("super(Derived1).base2_func", code.IndexOf("print('derived1_func')"), "self");
+
+                        // Only one member with clashing names should be present, and it should be from Base1
+                        entry.AssertHasParameters("super(Derived1).base_func", code.IndexOf("print('derived1_func')"), "self", "x");
+                    }
+
+                    // super(Derived2)
+                    {
+                        // Only one member with clashing names should be present, and it should be from Base2
+                        entry.AssertHasParameters("super(Derived2).base_func", code.IndexOf("print('derived2_func')"), "self", "x", "y", "z");
+                    }
+
+                    // super(Derived1, self), or Py3k magic super() to the same effect
+                    int i = code.IndexOf("print('derived1_func')");
+                    entry.AssertNotHasAttr("super(Derived1, self)", i, "derived1_func");
+                    entry.AssertHasParameters("super(Derived1, self).base1_func", i);
+                    entry.AssertHasParameters("super(Derived1, self).base2_func", i);
+                    entry.AssertHasParameters("super(Derived1, self).base_func", i, "x");
+
+                    if (entry.Analyzer.LanguageVersion.Is3x()) {
+                        entry.AssertNotHasAttr("super()", i, "derived1_func");
+                        entry.AssertHasParameters("super().base1_func", i);
+                        entry.AssertHasParameters("super().base2_func", i);
+                        entry.AssertHasParameters("super().base_func", i, "x");
+                    }
+
+                    // super(Derived2, self), or Py3k magic super() to the same effect
+                    i = code.IndexOf("print('derived2_func')");
+                    entry.AssertHasParameters("super(Derived2, self).base_func", i, "x", "y", "z");
+                    if (entry.Analyzer.LanguageVersion.Is3x()) {
+                        entry.AssertHasParameters("super().base_func", i, "x", "y", "z");
+                    }
+
+                    // super(Derived1 union Derived1)
+                    {
+                        // Members with clashing names from both potential bases should be unioned
+                        var sigs = entry.GetSignatures("super(cls).base_func", code.IndexOf("print('derived3_func')"));
+                        Assert.AreEqual(2, sigs.Length);
+                        Assert.IsTrue(sigs.Any(overload => overload.Parameters.Length == 2)); // (self, x)
+                        Assert.IsTrue(sigs.Any(overload => overload.Parameters.Length == 4)); // (self, x, y, z)
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void ParameterAnnotation() {
+                    var text = @"
+        s = None
+        def f(s: s = 123):
+            return s
+        ";
+                    var entry = ProcessTextV3(text);
+
+                    entry.AssertIsInstance("s", text.IndexOf("s:"), BuiltinTypeId.Int, BuiltinTypeId.NoneType);
+                    entry.AssertIsInstance("s", text.IndexOf("s ="), BuiltinTypeId.NoneType);
+                    entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int, BuiltinTypeId.NoneType);
+                }
+
+                [TestMethod, Priority(0)]
+                public void ParameterAnnotationLambda() {
+                    var text = @"
+        s = None
+        def f(s: lambda s: s > 0 = 123):
+            return s
+        ";
+                    var entry = ProcessTextV3(text);
+
+                    entry.AssertIsInstance("s", text.IndexOf("s:"), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("s", text.IndexOf("s >"), BuiltinTypeId.NoneType);
+                    entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void ReturnAnnotation() {
+                    var text = @"
+        s = None
+        def f(s = 123) -> s:
+            return s
+        ";
+                    var entry = ProcessTextV3(text);
+
+                    entry.AssertIsInstance("s", text.IndexOf("(s =") + 1, BuiltinTypeId.Int);
+                    entry.AssertIsInstance("s", text.IndexOf("s:"), BuiltinTypeId.NoneType);
+                    entry.AssertIsInstance("s", text.IndexOf("return"), BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void FunctoolsPartial() {
+                    var text = @"
+        from _functools import partial
+
+        def fob(a, b, c, d):
+            return a, b, c, d
+
+        sanity = fob(123, 3.14, 'abc', [])
+
+        fob_1 = partial(fob, 123, 3.14, 'abc', [])
+        result_1 = fob_1()
+
+        fob_2 = partial(fob, d = [], c = 'abc', b = 3.14, a = 123)
+        result_2 = fob_2()
+
+        fob_3 = partial(fob, 123, 3.14)
+        result_3 = fob_3('abc', [])
+
+        fob_4 = partial(fob, c = 'abc', d = [])
+        result_4 = fob_4(123, 3.14)
+
+        func_from_fob_1 = fob_1.func
+        args_from_fob_1 = fob_1.args
+        keywords_from_fob_2 = fob_2.keywords
+        ";
+                    var entry = ProcessText(text);
+
+                    foreach (var name in new[] {
+                        "sanity",
+                        "result_1",
+                        "result_2",
+                        "result_3",
+                        "result_4",
+                        "args_from_fob_1"
+                    }) {
+                        entry.AssertDescription(name, "tuple[int, float, str, list]");
+                        var result = entry.GetValue<AnalysisValue>(name);
+                        Console.WriteLine("{0} = {1}", name, result);
+                        AssertTupleContains(result, BuiltinTypeId.Int, BuiltinTypeId.Float, entry.BuiltinTypeId_Str, BuiltinTypeId.List);
+                    }
+
+                    var fob = entry.GetValue<FunctionInfo>("fob");
+                    var fob2 = entry.GetValue<FunctionInfo>("func_from_fob_1");
+                    Assert.AreSame(fob, fob2);
+
+                    entry.GetValue<DictionaryInfo>("keywords_from_fob_2");
+                }
+
+                [TestMethod, Priority(0)]
+                public void FunctoolsWraps() {
+                    var text = @"
+        from functools import wraps, update_wrapper
+
+        def decorator1(fn):
+            @wraps(fn)
+            def wrapper(*args, **kwargs):
+                fn(*args, **kwargs)
+                return 'decorated'
+            return wrapper
+
+        @decorator1
+        def test1():
+            '''doc'''
+            return 'undecorated'
+
+        def test2():
+            pass
+
+        def test2a():
+            pass
+
+        test2.test_attr = 123
+        update_wrapper(test2a, test2, ('test_attr',))
+
+        test1_result = test1()
+        ";
+
+                    var state = CreateAnalyzer();
+                    var textEntry = state.AddModule("fob", text);
+                    state.WaitForAnalysis();
+
+                    state.AssertConstantEquals("test1.__name__", "test1");
+                    state.AssertConstantEquals("test1.__doc__", "doc");
+                    var fi = state.GetValue<FunctionInfo>("test1");
+                    Assert.AreEqual("doc", fi.Documentation);
+                    state.GetValue<FunctionInfo>("test1.__wrapped__");
+                    Assert.AreEqual(2, state.GetValue<FunctionInfo>("test1").Overloads.Count());
+                    state.AssertConstantEquals("test1_result", "decorated");
+
+                    // __name__ should not have been changed by update_wrapper
+                    state.AssertConstantEquals("test2.__name__", "test2");
+                    state.AssertConstantEquals("test2a.__name__", "test2a");
+
+                    // test_attr should have been copied by update_wrapper
+                    state.AssertIsInstance("test2.test_attr", BuiltinTypeId.Int);
+                    state.AssertIsInstance("test2a.test_attr", BuiltinTypeId.Int);
+                }
+
+                private static void AssertTupleContains(AnalysisValue tuple, params BuiltinTypeId[] id) {
+                    var indexTypes = (tuple as SequenceInfo)?.IndexTypes?.Select(v => v.TypesNoCopy).ToArray() ??
+                        (tuple as ProtocolInfo)?.GetProtocols<TupleProtocol>()?.FirstOrDefault()?._values;
+                    Assert.IsNotNull(indexTypes);
+
+                    var expected = string.Join(", ", id);
+                    var actual = string.Join(", ", indexTypes.Select(t => {
+                        if (t.Count == 1) {
+                            return t.Single().TypeId.ToString();
+                        } else {
+                            return "{" + string.Join(", ", t.Select(t2 => t2.TypeId).OrderBy(t2 => t2)) + "}";
+                        }
+                    }));
+                    if (indexTypes
+                        .Zip(id, (t1, id2) => t1.Count == 1 && t1.Single().TypeId == id2)
+                        .Any(b => !b)) {
+                        Assert.Fail(string.Format("Expected <{0}>. Actual <{1}>.", expected, actual));
+                    }
+                }
+
+
+                [TestMethod, Priority(0)]
+                public void ValidatePotentialModuleNames() {
+                    // Validating against the structure given in
+                    // http://www.python.org/dev/peps/pep-0328/
+
+                    var entry = new MockPythonProjectEntry {
+                        ModuleName = "package.subpackage1.moduleX",
+                        FilePath = "C:\\package\\subpackage1\\moduleX.py"
+                    };
+
+                    // Without absolute_import, we should see these two possibilities
+                    // for a regular import.
+                    AssertUtil.ArrayEquals(
+                        ModuleResolver.ResolvePotentialModuleNames(entry, "moduleY", false).ToArray(),
+                        new[] { "package.subpackage1.moduleY", "moduleY" }
+                    );
+
+                    // With absolute_import, we should see the two possibilities for a
+                    // regular import, but in the opposite order.
+                    AssertUtil.ArrayEquals(
+                        ModuleResolver.ResolvePotentialModuleNames(entry, "moduleY", true).ToArray(),
+                        new[] { "moduleY", "package.subpackage1.moduleY" }
+                    );
+
+                    // Regardless of absolute import, we should see these results for
+                    // relative imports.
+                    foreach (var absoluteImport in new[] { true, false }) {
+                        Console.WriteLine("Testing with absoluteImport = {0}", absoluteImport);
+
+                        AssertUtil.ContainsExactly(
+                            ModuleResolver.ResolvePotentialModuleNames(entry, ".moduleY", absoluteImport),
+                            "package.subpackage1.moduleY"
+                        );
+                        AssertUtil.ContainsExactly(
+                            ModuleResolver.ResolvePotentialModuleNames(entry, ".", absoluteImport),
+                            "package.subpackage1"
+                        );
+                        AssertUtil.ContainsExactly(
+                            ModuleResolver.ResolvePotentialModuleNames(entry, "..subpackage1", absoluteImport),
+                            "package.subpackage1"
+                        );
+                        AssertUtil.ContainsExactly(
+                            ModuleResolver.ResolvePotentialModuleNames(entry, "..subpackage2.moduleZ", absoluteImport),
+                            "package.subpackage2.moduleZ"
+                        );
+                        AssertUtil.ContainsExactly(
+                            ModuleResolver.ResolvePotentialModuleNames(entry, "..moduleA", absoluteImport),
+                            "package.moduleA"
+                        );
+
+                        // Despite what PEP 328 says, this relative import never succeeds.
+                        AssertUtil.ContainsExactly(
+                            ModuleResolver.ResolvePotentialModuleNames(entry, "...package", absoluteImport),
+                            "package"
+                        );
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void MultilineFunctionDescription() {
+                    var code = @"class A:
+            def fn(self):
+                return lambda: 123
+        ";
+                    var entry = ProcessText(code);
+
+                    Assert.AreEqual(
+                        "test-module.A.fn(self: A) -> lambda: 123 -> int\ndeclared in A",
+                        entry.GetDescriptions("A.fn", 0).Single().Replace("\r\n", "\n")
+                    );
+                }
+
+                [TestMethod, Priority(0)]
+                public void SysModulesSetSpecialization() {
+                    var code = @"import sys
+        modules = sys.modules
+
+        modules['name_in_modules'] = None
+        ";
+                    code += string.Join(
+                        Environment.NewLine,
+                        Enumerable.Range(0, 100).Select(i => string.Format("sys.modules['name{0}'] = None", i))
+                    );
+
+                    var entry = ProcessTextV2(code);
+
+                    var sys = entry.GetValue<SysModuleInfo>("sys");
+
+                    var modules = entry.GetValue<SysModuleInfo.SysModulesDictionaryInfo>("modules");
+                    Assert.IsInstanceOfType(modules, typeof(SysModuleInfo.SysModulesDictionaryInfo));
+
+                    AssertUtil.ContainsExactly(
+                        sys.Modules.Keys,
+                        Enumerable.Range(0, 100).Select(i => string.Format("name{0}", i))
+                            .Concat(new[] { "name_in_modules" })
+                    );
+                }
+
+                [TestMethod, Priority(0)]
+                public void SysModulesGetSpecialization() {
+                    var code = @"import sys
+        modules = sys.modules
+
+        modules['value_in_modules'] = 'abc'
+        modules['value_in_modules'] = 123
+        value_in_modules = modules['value_in_modules']
+        builtins = modules['__builtin__']
+        builtins2 = modules.get('__builtin__')
+        builtins3 = modules.pop('__builtin__')
+        ";
+
+                    var entry = ProcessTextV2(code);
+
+                    entry.AssertIsInstance("value_in_modules", BuiltinTypeId.Int);
+
+                    Assert.AreEqual("__builtin__", entry.GetValue<AnalysisValue>("builtins").Name);
+                    Assert.AreEqual("__builtin__", entry.GetValue<AnalysisValue>("builtins2").Name);
+                    Assert.AreEqual("__builtin__", entry.GetValue<AnalysisValue>("builtins3").Name);
+                }
+
+                [TestMethod, Priority(0)]
+                public void ClassInstanceAttributes() {
+                    var code = @"
+        class A:
+            abc = 123
+
+        p1 = A.abc
+        p2 = A().abc
+        a = A()
+        a.abc = 3.1415
+        p4 = A().abc
+        p3 = a.abc
+        ";
+                    var entry = ProcessText(code);
+
+                    entry.AssertIsInstance("p1", BuiltinTypeId.Int);
+                    entry.AssertIsInstance("p3", BuiltinTypeId.Int, BuiltinTypeId.Float);
+                    entry.AssertIsInstance("p4", BuiltinTypeId.Int, BuiltinTypeId.Float);
+                    entry.AssertIsInstance("p2", BuiltinTypeId.Int, BuiltinTypeId.Float);
+                }
+
+                [TestMethod, Priority(0)]
+                public void RecursiveGetDescriptor() {
+                    // see https://pytools.codeplex.com/workitem/2955
+                    var entry = ProcessText(@"
+        class WithGet:
+            __get__ = WithGet()
+
+        class A:
+            wg = WithGet()
+
+        x = A().wg");
+
+                    Assert.IsNotNull(entry);
+                }
+
+                [TestMethod, Priority(0)]
+                public void Coroutine() {
+                    var code = @"
+        async def g():
+            return 123
+
+        async def f():
+            x = await g()
+            g2 = g()
+            y = await g2
+        ";
+                    var entry = ProcessText(code, PythonLanguageVersion.V35);
+
+                    entry.AssertIsInstance("x", code.IndexOf("x ="), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("y", code.IndexOf("x ="), BuiltinTypeId.Int);
+                    entry.AssertIsInstance("g2", code.IndexOf("x ="), BuiltinTypeId.Generator);
+                }
+
+                [TestMethod, Priority(0)]
+                public void AsyncWithStatement() {
+                    var text = @"
+        class X(object):
+            def x_method(self): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, exc_type, exc_value, traceback): return False
+
+        class Y(object):
+            def y_method(self): pass
+            async def __aenter__(self): return 123
+            async def __aexit__(self, exc_type, exc_value, traceback): return False
+
+        async def f():
+            async with X() as x:
+                pass #x
+
+            async with Y() as y:
+                pass #y
+        ";
+                    var entry = ProcessText(text, PythonLanguageVersion.V35);
+                    entry.AssertHasAttr("x", text.IndexOf("pass #x"), "x_method");
+                    entry.AssertIsInstance("y", text.IndexOf("pass #y"), BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void AsyncForIterator() {
+                    var code = @"
+        class X:
+            async def __aiter__(self): return self
+            async def __anext__(self): return 123
+
+        class Y:
+            async def __aiter__(self): return X()
+
+        async def f():
+            async for i in Y():
+                pass
+        ";
+                    var entry = ProcessText(code, PythonLanguageVersion.V35);
+
+                    entry.AssertIsInstance("i", code.IndexOf("pass"), BuiltinTypeId.Int);
+                }
+
+
+                [TestMethod, Priority(0)]
+                public void RecursiveDecorators() {
+                    // See https://github.com/Microsoft/PTVS/issues/542
+                    // Should not crash/OOM
+                    var code = @"
+        def f():
+            def d(fn):
+                @f()
+                def g(): pass
+
+            return d
+        ";
+
+                    ProcessText(code);
+                }
+
+                [TestMethod, Priority(0)]
+                public void NullNamedArgument() {
+                    CallDelegate callable = (node, unit, args, keywordArgNames) => {
+                        bool anyNull = false;
+                        Console.WriteLine("fn({0})", string.Join(", ", keywordArgNames.Select(n => {
+                            if (n == null) {
+                                anyNull = true;
+                                return "(null)";
+                            } else {
+                                return n.Name + "=(value)";
+                            }
+                        })));
+                        Assert.IsFalse(anyNull, "Some arguments were null");
+                        return AnalysisSet.Empty;
+                    };
+
+                    using (var state = CreateAnalyzer(allowParseErrors: true)) {
+                        state.Analyzer.SpecializeFunction("NullNamedArgument", "fn", callable);
+
+                        var entry1 = state.AddModule("NullNamedArgument", "def fn(**kwargs): pass");
+                        var entry2 = state.AddModule("test", "import NullNamedArgument; NullNamedArgument.fn(a=0, ]]])");
+                        state.WaitForAnalysis();
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void ModuleNameWalker() {
+                    foreach (var item in new[] {
+                        new { Code="import abc", Index=7, Expected="abc", Base="" },
+                        new { Code="import abc", Index=8, Expected="abc", Base="" },
+                        new { Code="import abc", Index=9, Expected="abc", Base="" },
+                        new { Code="import abc", Index=10, Expected="abc", Base="" },
+                        new { Code="import deg, abc as A", Index=12, Expected="abc", Base="" },
+                        new { Code="from abc import A", Index=6, Expected="abc", Base="" },
+                        new { Code="from .deg import A", Index=9, Expected="deg", Base="abc" },
+                        new { Code="from .hij import A", Index=9, Expected="abc.hij", Base="abc.deg" },
+                        new { Code="from ..hij import A", Index=10, Expected="hij", Base="abc.deg" },
+                        new { Code="from ..hij import A", Index=10, Expected="abc.hij", Base="abc.deg.HIJ" },
+                    }) {
+                        var entry = ProcessTextV3(item.Code);
+                        var walker = new ImportedModuleNameWalker(item.Base, string.Empty, item.Index, null);
+                        entry.Modules[entry.DefaultModule].Tree.Walk(walker);
+
+                        Assert.AreEqual(item.Expected, walker.ImportedModules.FirstOrDefault()?.Name);
+                    }
+                }
+
+                [TestMethod, Priority(0)]
+                public void CrossModuleFunctionCallMemLeak() {
+                    var modA = @"from B import h
+        def f(x): return h(x)
+
+        f(1)";
+                    var modB = @"def g(x): pass
+        def h(x): return g(x)";
+
+                    var analyzer = CreateAnalyzer();
+                    var entryA = analyzer.AddModule("A", modA);
+                    var entryB = analyzer.AddModule("B", modB);
+                    analyzer.WaitForAnalysis(CancellationTokens.After5s);
+                    for (int i = 100; i > 0; --i) {
+                        entryA.Analyze(CancellationToken.None, true);
+                        analyzer.WaitForAnalysis(CancellationTokens.After5s);
+                    }
+                    var g = analyzer.GetValue<FunctionInfo>(entryB, "g");
+                    Assert.AreEqual(1, g.References.Count());
+                }
+
+                [TestMethod, Priority(0)]
+                public void DefaultModuleAttributes() {
+                    var entry3 = ProcessTextV3("x = 1");
+                    AssertUtil.ContainsExactly(entry3.GetNamesNoBuiltins(), "__builtins__", "__file__", "__name__", "__package__", "__cached__", "__spec__", "x");
+                    var package = entry3.AddModule("package", "", Path.Combine(TestData.GetTempPath("package"), "__init__.py"));
+                    AssertUtil.ContainsExactly(entry3.GetNamesNoBuiltins(package), "__path__", "__builtins__", "__file__", "__name__", "__package__", "__cached__", "__spec__");
+
+                    entry3.AssertIsInstance("__file__", BuiltinTypeId.Unicode);
+                    entry3.AssertIsInstance("__name__", BuiltinTypeId.Unicode);
+                    entry3.AssertIsInstance("__package__", BuiltinTypeId.Unicode);
+                    entry3.AssertIsInstance(package, "__path__", BuiltinTypeId.List);
+
+                    var entry2 = ProcessTextV2("x = 1");
+                    AssertUtil.ContainsExactly(entry2.GetNamesNoBuiltins(), "__builtins__", "__file__", "__name__", "__package__", "x");
+
+                    entry2.AssertIsInstance("__file__", BuiltinTypeId.Bytes);
+                    entry2.AssertIsInstance("__name__", BuiltinTypeId.Bytes);
+                    entry2.AssertIsInstance("__package__", BuiltinTypeId.Bytes);
+                }
+
+                [TestMethod, Priority(0)]
+                public void CrossModuleBaseClasses() {
+                    var analyzer = CreateAnalyzer();
+                    var entryA = analyzer.AddModule("A", @"class ClsA(object): pass");
+                    var entryB = analyzer.AddModule("B", @"from A import ClsA
+        class ClsB(ClsA): pass
+
+        x = ClsB.x");
+                    analyzer.WaitForAnalysis();
+                    analyzer.AssertIsInstance(entryB, "x");
+
+                    analyzer.UpdateModule(entryA, @"class ClsA(object): x = 123");
+                    entryA.Analyze(CancellationToken.None, true);
+                    analyzer.WaitForAnalysis();
+                    analyzer.AssertIsInstance(entryB, "x", BuiltinTypeId.Int);
+                }
+
+                [TestMethod, Priority(0)]
+                public void UndefinedVariableDiagnostic() {
+                    PythonAnalysis entry;
+                    string code;
+
+
+                    code = @"a = b + c
+        class D(b): pass
+        d()
+        D()
+        (e for e in e if e)
+        {f for f in f if f}
+        [g for g in g if g]
+
+        def func(b, c):
+            b, c, d     # b, c are defined here
+        b, c, d         # but they are undefined here
+        ";
+                    entry = ProcessTextV3(code);
+                    entry.AssertDiagnostics(
+                        "used-before-assignment:unknown variable 'b':(1, 5) - (1, 6)",
+                        "used-before-assignment:unknown variable 'c':(1, 9) - (1, 10)",
+                        "used-before-assignment:unknown variable 'b':(2, 9) - (2, 10)",
+                        "used-before-assignment:unknown variable 'd':(3, 1) - (3, 2)",
+                        "used-before-assignment:unknown variable 'e':(5, 13) - (5, 14)",
+                        "used-before-assignment:unknown variable 'f':(6, 13) - (6, 14)",
+                        "used-before-assignment:unknown variable 'g':(7, 13) - (7, 14)",
+                        "used-before-assignment:unknown variable 'd':(10, 11) - (10, 12)",
+                        "used-before-assignment:unknown variable 'b':(11, 1) - (11, 2)",
+                        "used-before-assignment:unknown variable 'c':(11, 4) - (11, 5)",
+                        "used-before-assignment:unknown variable 'd':(11, 7) - (11, 8)"
+                    );
+
+                    // Ensure all of these cases correctly generate no warning
+                    code = @"
+        for x in []:
+            (_ for _ in x)
+            [_ for _ in x]
+            {_ for _ in x}
+            {_ : _ for _ in x}
+
+        import sys
+        from sys import not_a_real_name_but_no_warning_anyway
+
+        def f(v = sys.version, u = not_a_real_name_but_no_warning_anyway):
+            pass
+
+        with f() as v2:
+            pass
+
+        ";
+                    entry = ProcessTextV3(code);
+                    entry.AssertDiagnostics();
+                }
+
+                [TestMethod, Priority(0)]
+                public void UncallableObjectDiagnostic() {
+                    var code = @"class MyClass:
+            pass
+
+        class MyCallableClass:
+            def __call__(self): return 123
+
+        mc = MyClass()
+        mcc = MyCallableClass()
+
+        x = mc()
+        y = mcc()
+        ";
+                    var entry = ProcessTextV3(code);
+                    entry.AssertIsInstance("x");
+                    entry.AssertIsInstance("y", BuiltinTypeId.Int);
+                    entry.AssertDiagnostics(
+                        "not-callable:'MyClass' may not be callable:(10, 5) - (10, 7)"
+                    );
+                }
+        */
         [TestMethod, Priority(0)]
         public async Task OsPathMembers() {
             var code = @"import os.path as P
@@ -7659,7 +7621,7 @@ e = Employee('Guido')
             return server;
         }
 
-        protected virtual AnalysisLimits GetLimits() => AnalysisLimits.GetDefaultLimits(); 
+        protected virtual AnalysisLimits GetLimits() => AnalysisLimits.GetDefaultLimits();
 
 
         /// <summary>
@@ -7682,7 +7644,7 @@ e = Employee('Guido')
         }
 
         private Task PermutedTestAsync(string text1, string text2, string text3, Action<IModuleAnalysis, IModuleAnalysis, IModuleAnalysis> test)
-            => PermutedTestAsync("mod", new []{text1, text2, text3}, analysis => test(analysis["mod1"], analysis["mod2"], analysis["mod3"]));
+            => PermutedTestAsync("mod", new[] { text1, text2, text3 }, analysis => test(analysis["mod1"], analysis["mod2"], analysis["mod3"]));
 
         /// <summary>
         /// For a given set of module definitions, build analysis info for each unique permutation
@@ -7710,7 +7672,7 @@ e = Employee('Guido')
                     await Task.WhenAll(analysis);
 
                     test(analysis.ToDictionary(a => a.Result.ModuleName, a => a.Result));
-                    Trace.WriteLine($"--- End Permutation [{string.Join(',',p)}] ---");
+                    Trace.WriteLine($"--- End Permutation [{string.Join(',', p)}] ---");
                 }
             }
         }
@@ -7732,7 +7694,7 @@ e = Employee('Guido')
 
         #endregion
     }
-    
+
     [TestClass]
     public class StdLibAnalysisTest : AnalysisTest {
         protected override AnalysisLimits GetLimits() => AnalysisLimits.GetStandardLibraryLimits();

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -5376,7 +5376,8 @@ class C(object):
                 references.Should().OnlyHaveReferences(
                     (uriFob, (0, 16, 0, 17), ReferenceKind.Reference),
                     (uriBaz, (1, 0, 2, 8), ReferenceKind.Value),
-                    (uriOar, (1, 6, 1, 7), ReferenceKind.Definition)
+                    (uriBaz, (1, 6, 1, 7), ReferenceKind.Definition),
+                    (uriBaz, (0, 0, 0, 0), ReferenceKind.Definition)
                 );
 
                 analysis = await server.GetAnalysisAsync(uriFob);

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -156,10 +156,10 @@ f(x=42, y = 'abc')
         [TestMethod, Priority(0)]
         public async Task TestPackageImportStar() {
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable3X)) {
-                var fob = server.AddModuleWithContent("fob", "fob\\__init__.py", "from oar import *");
-                var oar = server.AddModuleWithContent("fob.oar", "fob\\oar\\__init__.py", "from .baz import *");
-                var baz = server.AddModuleWithContent("fob.oar.baz", "fob\\oar\\baz.py", "import fob.oar.quox as quox\r\nfunc = quox.func");
-                var quox = server.AddModuleWithContent("fob.oar.quox", "fob\\oar\\quox.py", "def func(): return 42");
+                var fob = await server.AddModuleWithContentAsync("fob", "fob\\__init__.py", "from oar import *");
+                var oar = await server.AddModuleWithContentAsync("fob.oar", "fob\\oar\\__init__.py", "from .baz import *");
+                var baz = await server.AddModuleWithContentAsync("fob.oar.baz", "fob\\oar\\baz.py", "import fob.oar.quox as quox\r\nfunc = quox.func");
+                var quox = await server.AddModuleWithContentAsync("fob.oar.quox", "fob\\oar\\quox.py", "def func(): return 42");
 
                 var fobAnalysis = await fob.GetAnalysisAsync();
                 var oarAnalysis = await oar.GetAnalysisAsync();
@@ -559,7 +559,7 @@ x['y'] = y
 i = x['y']['x']['value']
 s = y['x']['y']['value']
 ";
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 analysis = await server.GetAnalysisAsync(uri);
 
                 analysis.Should().HaveVariable("i").OfTypes(BuiltinTypeId.Int)
@@ -745,7 +745,7 @@ class D(object):
                 );
 
                 text1 = text1.Substring(0, text1.IndexOf("    def")) + Environment.NewLine + text1.Substring(text1.IndexOf("    def"));
-                server.SendDidChangeTextDocument(uri1, text1);
+                await server.SendDidChangeTextDocumentAsync(uri1, text1);
 
                 references = await server.SendFindReferences(uri1, 5, 9);
                 references.Should().OnlyHaveReferences(
@@ -755,7 +755,7 @@ class D(object):
                 );
 
                 text2 = Environment.NewLine + text2;
-                server.SendDidChangeTextDocument(uri2, text2);
+                await server.SendDidChangeTextDocumentAsync(uri2, text2);
 
                 references = await server.SendFindReferences(uri1, 5, 9);
                 references.Should().OnlyHaveReferences(
@@ -799,7 +799,7 @@ import mod1
 z = mod1.f('abc')
 ";
 
-                server.SendDidChangeTextDocument(uri2, text2);
+                await server.SendDidChangeTextDocumentAsync(uri2, text2);
                 analysis2 = await server.GetAnalysisAsync(uri2);
 
                 analysis1.Should().HaveFunction("f")
@@ -902,7 +902,7 @@ class D(C):
         self.f(_C__A=42)		# sig help should be _C__A
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 await server.GetAnalysisAsync(uri);
 
                 var signatures = await server.SendSignatureHelp(uri, 3, 15);
@@ -928,7 +928,7 @@ class D(C):
 
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 await server.GetAnalysisAsync(uri);
 
                 completions = await server.SendCompletion(uri, 3, 13);
@@ -948,7 +948,7 @@ class C(object):
 xyz = C._C__FOB  # Advanced members completion should work here
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 await server.GetAnalysisAsync(uri);
 
                 completions = await server.SendCompletion(uri, 5, 16);
@@ -1018,7 +1018,7 @@ class C(A, B): pass
 c = C()
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 analysis = await server.GetAnalysisAsync(uri);
 
                 analysis.Should().HaveClassInfo("C")
@@ -1032,7 +1032,7 @@ class G(F,E): pass
 G.remember2buy
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 analysis = await server.GetAnalysisAsync(uri);
 
                 analysis.Should().HaveClassInfo("G")
@@ -1047,7 +1047,7 @@ class G(E,F): pass
 G.remember2buy
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 analysis = await server.GetAnalysisAsync(uri);
 
                 analysis.Should().HaveClassInfo("G")
@@ -1067,7 +1067,7 @@ class Z(K1,K2,K3): pass
 z = Z()
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 analysis = await server.GetAnalysisAsync(uri);
 
                 analysis.Should().HaveClassInfo("Z")
@@ -1081,7 +1081,7 @@ class C(str): pass
 z = None
 ";
 
-                server.SendDidChangeTextDocument(uri, code);
+                await server.SendDidChangeTextDocumentAsync(uri, code);
                 analysis = await server.GetAnalysisAsync(uri);
 
                 analysis.Should().HaveClassInfo("A").WithMethodResolutionOrder("A", "type int", "type object")
@@ -1141,7 +1141,7 @@ iC = iter(C)
                     .And.HaveVariable("iB").OfType(BuiltinTypeId.StrIterator)
                     .And.HaveVariable("iC").OfType(BuiltinTypeId.ListIterator);
 
-                server.SendDidChangeTextDocument(uri, @"
+                await server.SendDidChangeTextDocumentAsync(uri, @"
 A = [1, 2, 3]
 B = 'abc'
 C = [1.0, 'a', 3]
@@ -1157,7 +1157,7 @@ iC = C.__iter__()
                     .And.HaveVariable("iB").OfType(BuiltinTypeId.StrIterator)
                     .And.HaveVariable("iC").OfType(BuiltinTypeId.ListIterator);
 
-                server.SendDidChangeTextDocument(uri, @"
+                await server.SendDidChangeTextDocumentAsync(uri, @"
 A = [1, 2, 3]
 B = 'abc'
 C = [1.0, 'a', 3]
@@ -1174,7 +1174,7 @@ c = _next(iC)
                     .And.HaveVariable("b").OfType(BuiltinTypeId.Str)
                     .And.HaveVariable("c").OfTypes(BuiltinTypeId.Int, BuiltinTypeId.Str, BuiltinTypeId.Float);
 
-                server.SendDidChangeTextDocument(uri, @"
+                await server.SendDidChangeTextDocumentAsync(uri, @"
 iA = iter(lambda: 1, 2)
 iB = iter(lambda: 'abc', None)
 iC = iter(lambda: 1, 'abc')
@@ -1213,7 +1213,7 @@ c = _next(iC)
                     .And.HaveVariable("b").OfType(BuiltinTypeId.Unicode)
                     .And.HaveVariable("c").OfTypes(BuiltinTypeId.Int, BuiltinTypeId.Unicode, BuiltinTypeId.Float);
 
-                server.SendDidChangeTextDocument(uri, @"
+                await server.SendDidChangeTextDocumentAsync(uri, @"
 iA = iter(lambda: 1, 2)
 iB = iter(lambda: 'abc', None)
 iC = iter(lambda: 1, 'abc')
@@ -2751,7 +2751,7 @@ class D(object):
         print self.abc
 
 D(42)";
-                server.SendDidChangeTextDocument(uri, text);
+                await server.SendDidChangeTextDocumentAsync(uri, text);
 
                 referencesAbc = await server.SendFindReferences(uri, 4, 15);
                 referencesFob = await server.SendFindReferences(uri, 4, 21);
@@ -2795,7 +2795,7 @@ x = f()";
 def f(): pass
 
 x = f";
-                server.SendDidChangeTextDocument(uri, text);
+                await server.SendDidChangeTextDocumentAsync(uri, text);
                 referencesF = await server.SendFindReferences(uri, 3, 5);
 
                 referencesF.Should().OnlyHaveReferences(
@@ -3695,7 +3695,8 @@ for abc in x:
             using (var server = await CreateServerAsync()) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(code);
 
-                analysis.Should().HaveVariable("x").WithDescription("set[int]")
+                analysis.Should()
+                    .HaveVariable("x").WithDescription("set[int]")
                     .And.HaveVariable("abc").OfType(BuiltinTypeId.Int);
             }
         }
@@ -5347,26 +5348,29 @@ class C(object):
                 var uriFob = await server.OpenDocumentAndGetUriAsync("fob.py", fobSrc);
                 var uriOar = await server.OpenDocumentAndGetUriAsync("oar.py", oarSrc);
                 var uriBaz = await server.OpenDocumentAndGetUriAsync("baz.py", bazSrc);
-                server.SendDidChangeTextDocument(uriFob, "from oar import C");
+                await server.SendDidChangeTextDocumentAsync(uriFob, "from oar import C");
 
                 var references = await server.SendFindReferences(uriFob, 0, 17);
                 references.Should().OnlyHaveReferences(
                     (uriFob, (0, 16, 0, 17), ReferenceKind.Reference),
                     (uriOar, (1, 0, 2, 8), ReferenceKind.Value),
-                    (uriOar, (1, 6, 1, 7), ReferenceKind.Definition)
+                    (uriOar, (1, 6, 1, 7), ReferenceKind.Definition),
+                    (uriOar, (0, 0, 0, 0), ReferenceKind.Definition)
                 );
 
+                await server.WaitForCompleteAnalysisAsync(CancellationToken.None);
                 var analysis = await server.GetAnalysisAsync(uriFob);
                 analysis.Should().HaveVariable("C").WithDescription("C");
 
                 // delete the class..
-                server.SendDidChangeTextDocument(uriOar, "");
+                await server.SendDidChangeTextDocumentAsync(uriOar, "");
 
+                await server.WaitForCompleteAnalysisAsync(CancellationToken.None);
                 analysis = await server.GetAnalysisAsync(uriFob);
-                analysis.Should().NotHaveVariable("C");
+                analysis.Should().HaveVariable("C").WithNoTypes();
 
                 // Change location of the class
-                server.SendDidChangeTextDocument(uriFob, "from baz import C");
+                await server.SendDidChangeTextDocumentAsync(uriFob, "from baz import C");
 
                 references = await server.SendFindReferences(uriFob, 0, 17);
                 references.Should().OnlyHaveReferences(
@@ -5409,7 +5413,8 @@ abc = 42
                 await server.WaitForCompleteAnalysisAsync(CancellationToken.None);
                 var analysis = await server.GetAnalysisAsync(uriSrc2);
 
-                analysis.Should().HaveVariable("y").WithDescription("Python module fob.y")
+                analysis.Should()
+                    .HaveVariable("y").WithDescription("Python module fob.y")
                     .And.HaveVariable("abc").OfType(BuiltinTypeId.Int);
             }
         }
@@ -7662,7 +7667,7 @@ e = Employee('Guido')
                         var content = code[p[i]];
                         var filename = name.Replace('.', '\\') + ".py";
 
-                        entries[p[i]] = server.AddModuleWithContent(name, filename, content);
+                        entries[p[i]] = await server.AddModuleWithContentAsync(name, filename, content);
                     }
 
                     var analysis = entries

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -205,7 +205,7 @@ namespace AnalysisTests {
 
             var parseComplete = EventTaskSources.Server.OnParseComplete.Create(s);
 
-            s.DidChangeTextDocument(new DidChangeTextDocumentParams {
+            await s.DidChangeTextDocument(new DidChangeTextDocumentParams {
                 textDocument = new VersionedTextDocumentIdentifier {
                     uri = document,
                     version = finalVersion,
@@ -214,7 +214,7 @@ namespace AnalysisTests {
                     range = c.WholeBuffer ? null : (Range?)c.ReplacedSpan,
                     text = c.InsertedText
                 }).ToArray()
-            });
+            }, CancellationToken.None);
 
             await parseComplete;
 
@@ -576,7 +576,7 @@ mc
             );
 
             // Send the document update.
-            s.DidChangeTextDocument(new DidChangeTextDocumentParams {
+            await s.DidChangeTextDocument(new DidChangeTextDocumentParams {
                 textDocument = new VersionedTextDocumentIdentifier { uri = mod, version = 1 },
                 contentChanges = new[] { new TextDocumentContentChangedEvent {
                     text = ".",
@@ -587,7 +587,7 @@ mc
                 } },
                 // Suppress reanalysis to avoid a race
                 _enqueueForAnalysis = false
-            });
+            }, CancellationToken.None);
 
             // Now with the "." event sent, we should see this as a dot completion
             await AssertCompletion(s, mod,
@@ -957,14 +957,14 @@ datetime.datetime.now().day
                 Trace.TraceInformation("Testing {0}", tc);
 
                 var mod = await AddModule(s, "");
-                s.DidChangeTextDocument(new DidChangeTextDocumentParams {
+                await s.DidChangeTextDocument(new DidChangeTextDocumentParams {
                     contentChanges = new[] {
                             new TextDocumentContentChangedEvent {
                                 text = "def f():\r\n        pass\r\n\tpass"
                             }
                         },
                     textDocument = new VersionedTextDocumentIdentifier { uri = mod, version = 2 }
-                });
+                }, CancellationToken.None);
                 await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
 
                 var messages = GetDiagnostics(diags, mod).ToArray();

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -111,7 +111,7 @@ namespace AnalysisTests {
 
             if (rootUri != null) {
                 await LoadFromDirectoryAsync(s, rootUri.LocalPath).ConfigureAwait(false);
-                await s.WaitForCompleteAnalysisAsync().ConfigureAwait(false);
+                await s.WaitForCompleteAnalysisAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
             return s;
@@ -153,7 +153,7 @@ namespace AnalysisTests {
                     languageId = language ?? "python"
                 }
             }, CancellationToken.None).ConfigureAwait(false);
-            await s.WaitForCompleteAnalysisAsync().ConfigureAwait(false);
+            await s.WaitForCompleteAnalysisAsync(CancellationToken.None).ConfigureAwait(false);
             return uri;
         }
 
@@ -617,7 +617,7 @@ mc
             );
 
             await s.UnloadFileAsync(mod2);
-            await s.WaitForCompleteAnalysisAsync();
+            await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
 
             await AssertCompletion(s, mod1,
                 position: new Position { line = 2, character = 5 },
@@ -897,18 +897,18 @@ datetime.datetime.now().day
             await AssertCompletion(s, mod, new[] { "x" }, null);
 
             Assert.AreEqual(Tuple.Create("y = 2", 1), await ApplyChange(s, modP2, DocumentChange.Insert("y = 2", SourceLocation.MinValue)));
-            await s.WaitForCompleteAnalysisAsync();
+            await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
 
             await AssertCompletion(s, modP2, new[] { "x", "y" }, null);
 
             Assert.AreEqual(Tuple.Create("z = 3", 1), await ApplyChange(s, modP3, DocumentChange.Insert("z = 3", SourceLocation.MinValue)));
-            await s.WaitForCompleteAnalysisAsync();
+            await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
 
             await AssertCompletion(s, modP3, new[] { "x", "y", "z" }, null);
             await AssertCompletion(s, mod, new[] { "x", "y", "z" }, null);
 
             await ApplyChange(s, mod, DocumentChange.Delete(SourceLocation.MinValue, SourceLocation.MinValue.AddColumns(5)));
-            await s.WaitForCompleteAnalysisAsync();
+            await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
             await AssertCompletion(s, modP2, new[] { "y", "z" }, new[] { "x" });
             await AssertCompletion(s, modP3, new[] { "y", "z" }, new[] { "x" });
         }
@@ -965,7 +965,7 @@ datetime.datetime.now().day
                         },
                     textDocument = new VersionedTextDocumentIdentifier { uri = mod, version = 2 }
                 });
-                await s.WaitForCompleteAnalysisAsync();
+                await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
 
                 var messages = GetDiagnostics(diags, mod).ToArray();
                 if (tc == DiagnosticSeverity.Unspecified) {

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -1023,7 +1023,7 @@ datetime.datetime.now().day
 
                     if (command == _typeId.ToString()) {
                         var res = new List<string>();
-                        foreach (var m in entry.Analysis.GetAllAvailableMembers(location)) {
+                        foreach (var m in entry.Analysis.GetAllMembers(location)) {
                             if (m.Values.Any(v => v.MemberType == PythonMemberType.Constant && v.TypeId == _typeId)) {
                                 res.Add(m.Name);
                             }

--- a/src/Analysis/Engine/Test/ServerExtensions.cs
+++ b/src/Analysis/Engine/Test/ServerExtensions.cs
@@ -64,20 +64,20 @@ namespace Microsoft.PythonTools.Analysis {
         public static Task<IModuleAnalysis> GetAnalysisAsync(this Server server, Uri uri, int waitingTimeout = -1, int failAfter = 30000)
             => ((ProjectEntry)server.ProjectFiles.GetEntry(uri)).GetAnalysisAsync(waitingTimeout, new CancellationTokenSource(failAfter).Token);
 
-        public static void EnqueueItem(this Server server, Uri uri) 
-            => server.EnqueueItem((IDocument)server.ProjectFiles.GetEntry(uri));
+        public static Task EnqueueItemAsync(this Server server, Uri uri) 
+            => server.EnqueueItemAsync((IDocument)server.ProjectFiles.GetEntry(uri));
 
-        public static void EnqueueItems(this Server server, params IDocument[] projectEntries) {
+        public static async Task EnqueueItemsAsync(this Server server, CancellationToken cancellationToken, params IDocument[] projectEntries) {
             foreach (var document in projectEntries) {
-                server.EnqueueItem(document);
+                await server.EnqueueItemAsync(document);
             }
         }
 
         // TODO: Replace usages of AddModuleWithContent with OpenDefaultDocumentAndGetUriAsync
-        public static ProjectEntry AddModuleWithContent(this Server server, string moduleName, string relativePath, string content) {
+        public static async Task<ProjectEntry> AddModuleWithContentAsync(this Server server, string moduleName, string relativePath, string content) {
             var entry = (ProjectEntry)server.Analyzer.AddModule(moduleName, TestData.GetTestSpecificPath(relativePath));
             entry.ResetDocument(0, content);
-            server.EnqueueItem(entry);
+            await server.EnqueueItemAsync(entry);
             return entry;
         }
 
@@ -153,8 +153,8 @@ namespace Microsoft.PythonTools.Analysis {
             return await projectEntry.GetAnalysisAsync(cancellationToken: cancellationToken);
         }
 
-        public static void SendDidChangeTextDocument(this Server server, Uri uri, string text) {
-            server.DidChangeTextDocument(new DidChangeTextDocumentParams {
+        public static Task SendDidChangeTextDocumentAsync(this Server server, Uri uri, string text) {
+            return server.DidChangeTextDocument(new DidChangeTextDocumentParams {
                 textDocument = new VersionedTextDocumentIdentifier {
                     uri = uri
                 }, 
@@ -163,12 +163,12 @@ namespace Microsoft.PythonTools.Analysis {
                         text = text,
                     }, 
                 }
-            });
+            }, CancellationToken.None);
         }
 
         public static async Task<IModuleAnalysis> ChangeDefaultDocumentAndGetAnalysisAsync(this Server server, string text, int failAfter = 30000) {
             var projectEntry = (ProjectEntry) server.ProjectFiles.All.Single();
-            server.SendDidChangeTextDocument(projectEntry.DocumentUri, text);
+            await server.SendDidChangeTextDocumentAsync(projectEntry.DocumentUri, text);
             return await projectEntry.GetAnalysisAsync(cancellationToken: new CancellationTokenSource(failAfter).Token);
         }
 

--- a/src/Analysis/Engine/Test/ServerExtensions.cs
+++ b/src/Analysis/Engine/Test/ServerExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.PythonTools.Analysis {
             var cancellationToken = new CancellationTokenSource(failAfter).Token;
             await server.SendDidOpenTextDocument(TestData.GetDefaultModuleUri(), content, languageId);
             cancellationToken.ThrowIfCancellationRequested();
-            var projectEntry = (ProjectEntry) server.ProjectFiles.All.Single();
+            var projectEntry = (ProjectEntry) server.ProjectFiles.Single();
             return await projectEntry.GetAnalysisAsync(cancellationToken: cancellationToken);
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public static async Task<IModuleAnalysis> ChangeDefaultDocumentAndGetAnalysisAsync(this Server server, string text, int failAfter = 30000) {
-            var projectEntry = (ProjectEntry) server.ProjectFiles.All.Single();
+            var projectEntry = (ProjectEntry) server.ProjectFiles.Single();
             await server.SendDidChangeTextDocumentAsync(projectEntry.DocumentUri, text);
             return await projectEntry.GetAnalysisAsync(cancellationToken: new CancellationTokenSource(failAfter).Token);
         }

--- a/src/Analysis/Engine/Test/ThreadingTest.cs
+++ b/src/Analysis/Engine/Test/ThreadingTest.cs
@@ -135,7 +135,6 @@ mc.fn([])
             // One analysis before we start
             foreach (var e in entries) {
                 e.Analyze(cancel, true);
-                e.ResetCompleteAnalysis();
             }
             state.AnalyzeQueuedEntries(cancel);
 

--- a/src/LanguageServer/Impl/Implementation/AnalysisProgressReporter.cs
+++ b/src/LanguageServer/Impl/Implementation/AnalysisProgressReporter.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 
@@ -25,12 +26,15 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         private readonly ILogger _logger;
         private readonly Server _server;
         private readonly object _lock = new object();
+        private readonly CancellationToken _cancellationToken;
+
         private IProgress _progress;
         private Task _queueMonitoringTask;
 
-        public AnalysisProgressReporter(Server server, IProgressService progressService, ILogger logger) {
+        public AnalysisProgressReporter(Server server, IProgressService progressService, ILogger logger, CancellationToken cancellationToken) {
             _progressService = progressService;
             _logger = logger;
+            _cancellationToken = cancellationToken;
 
             _server = server;
             _server.OnAnalysisQueued += OnAnalysisQueued;
@@ -69,7 +73,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         private async Task QueueMonitoringTask() {
             try {
-                await _server.WaitForCompleteAnalysisAsync();
+                await _server.WaitForCompleteAnalysisAsync(_cancellationToken);
             } finally {
                 EndProgress();
             }

--- a/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
+++ b/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             }
 
             _log.TraceMessage($"Completing all names");
-            var members = Analysis.GetAllAvailableMembers(Position, opts);
+            var members = Analysis.GetAllMembers(Position, opts);
 
             if (allowArguments) {
                 var finder = new ExpressionFinder(Tree, new GetExpressionOptions { Calls = true });

--- a/src/LanguageServer/Impl/Implementation/EditorFiles.cs
+++ b/src/LanguageServer/Impl/Implementation/EditorFiles.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
                 var toVersion = @params.textDocument.version ?? (fromVersion + changes.Length);
 
+                cancellationToken.ThrowIfCancellationRequested();
                 doc.UpdateDocument(part, new DocumentChangeSet(
                     fromVersion,
                     toVersion,
@@ -122,7 +123,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     })
                 ));
 
-                cancellationToken.ThrowIfCancellationRequested();
                 DidChangeTextDocumentParams? next = null;
                 lock (_pendingChanges) {
                     var notExpired = _pendingChanges

--- a/src/LanguageServer/Impl/Implementation/EditorFiles.cs
+++ b/src/LanguageServer/Impl/Implementation/EditorFiles.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Analysis.Analyzer;
 using Microsoft.PythonTools.Analysis.Infrastructure;
@@ -80,7 +81,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _syncContext.Post(_ => HideDiagnostics(documentUri), null);
         }
 
-        public void DidChangeTextDocument(DidChangeTextDocumentParams @params, bool enqueueForParsing) {
+        public async Task DidChangeTextDocument(DidChangeTextDocumentParams @params, bool enqueueForParsing, CancellationToken cancellationToken) {
             var changes = @params.contentChanges;
             if (changes == null || changes.Length == 0) {
                 return;
@@ -121,6 +122,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     })
                 ));
 
+                cancellationToken.ThrowIfCancellationRequested();
                 DidChangeTextDocumentParams? next = null;
                 lock (_pendingChanges) {
                     var notExpired = _pendingChanges
@@ -135,12 +137,12 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     }
                 }
                 if (next.HasValue) {
-                    DidChangeTextDocument(next.Value, false);
+                    await DidChangeTextDocument(next.Value, false, cancellationToken);
                 }
             } finally {
                 if (enqueueForParsing) {
                     _server.TraceMessage($"Applied changes to {uri}");
-                    _server.EnqueueItem(doc, enqueueForAnalysis: @params._enqueueForAnalysis ?? true);
+                    await _server.EnqueueItemAsync(doc, enqueueForAnalysis: @params._enqueueForAnalysis ?? true);
                 }
             }
         }

--- a/src/LanguageServer/Impl/Implementation/EditorFiles.cs
+++ b/src/LanguageServer/Impl/Implementation/EditorFiles.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         public void Close(Uri uri) => GetDocument(uri).Close(uri);
 
         public void UpdateDiagnostics() {
-            foreach (var entry in _server.ProjectFiles.All) {
+            foreach (var entry in _server.ProjectFiles) {
                 GetDocument(entry.DocumentUri).UpdateAnalysisDiagnostics(entry, -1);
             }
         }

--- a/src/LanguageServer/Impl/Implementation/ParseQueue.cs
+++ b/src/LanguageServer/Impl/Implementation/ParseQueue.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         public Task WaitForAllAsync() => _parsingInProgress.WaitForZeroAsync();
 
-        public Task<IAnalysisCookie> Enqueue(IDocument doc, PythonLanguageVersion languageVersion) {
+        public Task<IAnalysisCookie> EnqueueAsync(IDocument doc, PythonLanguageVersion languageVersion) {
             if (doc == null) {
                 throw new ArgumentNullException(nameof(doc));
             }

--- a/src/LanguageServer/Impl/Implementation/ProjectFiles.cs
+++ b/src/LanguageServer/Impl/Implementation/ProjectFiles.cs
@@ -40,13 +40,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             return _projectFiles.TryRemove(documentUri, out var entry) ? entry : null;
         }
 
-        public IEnumerable<IProjectEntry> All {
-            get {
-                ThrowIfDisposed();
-                return _projectFiles.Values;
-            }
-        }
-
         public IEnumerable<string> GetLoadedFiles() {
             ThrowIfDisposed();
             return _projectFiles.Keys.Select(k => k.AbsoluteUri);
@@ -103,8 +96,13 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         #region IEnumerable<IProjectEntry>
-        public IEnumerator<IProjectEntry> GetEnumerator() => All.GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => All.GetEnumerator();
+        public IEnumerator<IProjectEntry> GetEnumerator() => GetAll().GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetAll().GetEnumerator();
+
+        private ICollection<IProjectEntry>  GetAll() {
+            ThrowIfDisposed();
+            return _projectFiles.Values;
+        }
         #endregion
     }
 }

--- a/src/LanguageServer/Impl/Implementation/ProjectFiles.cs
+++ b/src/LanguageServer/Impl/Implementation/ProjectFiles.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -25,7 +26,7 @@ using Microsoft.PythonTools.Intellisense;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Implementation {
-    internal sealed class ProjectFiles : IDisposable {
+    internal sealed class ProjectFiles : IDisposable, IEnumerable<IProjectEntry> {
         private readonly ConcurrentDictionary<Uri, IProjectEntry> _projectFiles = new ConcurrentDictionary<Uri, IProjectEntry>();
         private bool _disposed;
 
@@ -100,5 +101,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 throw new ObjectDisposedException(nameof(ProjectFiles));
             }
         }
+
+        #region IEnumerable<IProjectEntry>
+        public IEnumerator<IProjectEntry> GetEnumerator() => All.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => All.GetEnumerator();
+        #endregion
     }
 }

--- a/src/LanguageServer/Impl/Implementation/Server.FindReferences.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.FindReferences.cs
@@ -28,6 +28,8 @@ using Microsoft.PythonTools.Parsing.Ast;
 namespace Microsoft.Python.LanguageServer.Implementation {
     public sealed partial class Server {
         public override async Task<Reference[]> FindReferences(ReferencesParams @params, CancellationToken cancellationToken) {
+            await WaitForCompleteAnalysisAsync(cancellationToken);
+
             var uri = @params.textDocument.uri;
             ProjectFiles.GetEntry(@params.textDocument, @params._version, out var entry, out var tree);
 

--- a/src/LanguageServer/Impl/Implementation/Server.WorkspaceSymbols.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.WorkspaceSymbols.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         private static IEnumerable<IMemberResult> GetModuleVariables(ProjectEntry entry, GetMemberOptions opts, string prefix, IModuleAnalysis analysis) {
-            var all = analysis.GetAllAvailableMembers(SourceLocation.None, opts);
+            var all = analysis.GetAllMembers(SourceLocation.None, opts);
             return all
                 .Where(m => {
                     if (m.Values.Any(v => v.DeclaringModule == entry || v.Locations.Any(l => l.DocumentUri == entry.DocumentUri))) {

--- a/src/LanguageServer/Impl/Implementation/Server.WorkspaceSymbols.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.WorkspaceSymbols.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             var members = Enumerable.Empty<IMemberResult>();
             var opts = GetMemberOptions.ExcludeBuiltins | GetMemberOptions.DeclaredOnly;
 
-            foreach (var entry in ProjectFiles.All) {
+            foreach (var entry in ProjectFiles) {
                 members = members.Concat(
                     await GetModuleVariablesAsync(entry as ProjectEntry, opts, @params.query, 50, cancellationToken)
                 );

--- a/src/LanguageServer/Impl/Implementation/ServerBase.cs
+++ b/src/LanguageServer/Impl/Implementation/ServerBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         public abstract Task DidOpenTextDocument(DidOpenTextDocumentParams @params, CancellationToken cancellationToken);
 
-        public abstract void DidChangeTextDocument(DidChangeTextDocumentParams @params);
+        public abstract Task DidChangeTextDocument(DidChangeTextDocumentParams @params, CancellationToken cancellationToken);
 
         public virtual Task WillSaveTextDocument(WillSaveTextDocumentParams @params, CancellationToken cancellationToken)
             => Task.CompletedTask;

--- a/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         private async Task IfTestWaitForAnalysisCompleteAsync() {
             if (_initParams.initializationOptions.testEnvironment) {
-                await _server.WaitForCompleteAnalysisAsync();
+                await _server.WaitForCompleteAnalysisAsync(_shutdownCts.Token);
             }
         }
     }

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Python.LanguageServer.Services;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 using Newtonsoft.Json;

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -440,14 +440,16 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         private void HandlePathWatchChange(JToken section) {
             var watchSearchPaths = GetSetting(section, "watchSearchPaths", true);
             if (!watchSearchPaths) {
-                // No longer watching
+                // No longer watching.
                 _pathsWatcher?.Dispose();
                 _searchPaths = Array.Empty<string>();
                 _watchSearchPaths = false;
+                return;
             }
 
+            // Now watching.
             if (!_watchSearchPaths || (_watchSearchPaths && _searchPaths.SetEquals(_initParams.initializationOptions.searchPaths))) {
-                // Were not watching, now watching OR were watching but paths have changed. Recreate watcher.
+                // Were not watching OR were watching but paths have changed. Recreate the watcher.
                 _pathsWatcher?.Dispose();
                 _pathsWatcher = new PathsWatcher(
                     _initParams.initializationOptions.searchPaths,

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 .Add(() => _server.OnApplyWorkspaceEdit -= OnApplyWorkspaceEdit)
                 .Add(() => _server.OnRegisterCapability -= OnRegisterCapability)
                 .Add(() => _server.OnUnregisterCapability -= OnUnregisterCapability)
+                .Add(() => _shutdownCts.Cancel())
                 .Add(_prioritizer)
                 .Add(_analysisProgressReporter)
                 .Add(() => _pathsWatcher?.Dispose());
@@ -88,7 +89,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         public void Dispose() {
-            _shutdownCts.Cancel();
             _disposables.TryDispose();
             _server.Dispose();
         }

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -462,33 +462,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _searchPaths = _initParams.initializationOptions.searchPaths;
         }
 
-        private sealed class IdleTimeTracker : IDisposable {
-            private readonly int _delay;
-            private readonly Action _action;
-            private Timer _timer;
-            private DateTime _lastActivityTime;
-
-            public IdleTimeTracker(int msDelay, Action action) {
-                _delay = msDelay;
-                _action = action;
-                _timer = new Timer(OnTimer, this, 50, 50);
-                NotifyUserActivity();
-            }
-
-            public void NotifyUserActivity() => _lastActivityTime = DateTime.Now;
-
-            public void Dispose() {
-                _timer?.Dispose();
-                _timer = null;
-            }
-
-            private void OnTimer(object state) {
-                if ((DateTime.Now - _lastActivityTime).TotalMilliseconds >= _delay && _timer != null) {
-                    _action();
-                }
-            }
-        }
-
         private class Prioritizer : IDisposable {
             private const int InitializePriority = 0;
             private const int ConfigurationPriority = 1;

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -210,13 +210,13 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         [JsonRpcMethod("textDocument/didChange")]
-        public async Task DidChangeTextDocument(JToken token) {
+        public async Task DidChangeTextDocument(JToken token, CancellationToken cancellationToken) {
             _idleTimeTracker?.NotifyUserActivity();
             using (await _prioritizer.DocumentChangePriorityAsync()) {
                 var @params = ToObject<DidChangeTextDocumentParams>(token);
                 var version = @params.textDocument.version;
                 if (version == null || @params.contentChanges.IsNullOrEmpty()) {
-                    _server.DidChangeTextDocument(@params);
+                    await _server.DidChangeTextDocument(@params, cancellationToken);
                     return;
                 }
 
@@ -225,7 +225,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 var changes = SplitDidChangeTextDocumentParams(@params, version.Value);
 
                 foreach (var change in changes) {
-                    _server.DidChangeTextDocument(change);
+                    await _server.DidChangeTextDocument(change, cancellationToken);
                 }
             }
         }

--- a/src/LanguageServer/Impl/PathsWatcher.cs
+++ b/src/LanguageServer/Impl/PathsWatcher.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Python.LanguageServer {
                         .Add(() => fsw.Changed -= OnChanged)
                         .Add(() => fsw.Created -= OnChanged)
                         .Add(() => fsw.Deleted -= OnChanged)
+                        .Add(() => fsw.EnableRaisingEvents = false)
                         .Add(fsw);
                 } catch(ArgumentException ex) {
                     _log.TraceMessage($"Unable to create file watcher for {p}, exception {ex.Message}");

--- a/src/LanguageServer/Impl/Services/IdleTimeTracker.cs
+++ b/src/LanguageServer/Impl/Services/IdleTimeTracker.cs
@@ -1,0 +1,47 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Python.LanguageServer.Services {
+    sealed class IdleTimeTracker : IDisposable {
+        private readonly int _delay;
+        private readonly Action _action;
+        private Timer _timer;
+        private DateTime _lastActivityTime;
+
+        public IdleTimeTracker(int msDelay, Action action) {
+            _delay = msDelay;
+            _action = action;
+            _timer = new Timer(OnTimer, this, 50, 50);
+            NotifyUserActivity();
+        }
+
+        public void NotifyUserActivity() => _lastActivityTime = DateTime.Now;
+
+        public void Dispose() {
+            _timer?.Dispose();
+            _timer = null;
+        }
+
+        private void OnTimer(object state) {
+            if ((DateTime.Now - _lastActivityTime).TotalMilliseconds >= _delay && _timer != null) {
+                _action();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #111 

- Improves #109 - avoid reloading modules on any configuration change. Still need to debug why reloading modules leaks.

- Improves test stability as well as Rename/FindReferences/DocumentSymbols/GotoDefinition by waiting for the complete analysis.