### PR TITLE
Port PR from PTVS: https://github.com/Microsoft/PTVS/pull/4716

### DIFF
--- a/src/Analysis/Engine/Test/InheritanceTests.cs
+++ b/src/Analysis/Engine/Test/InheritanceTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Python.LanguageServer.Implementation;
+using Microsoft.PythonTools.Analysis.FluentAssertions;
+using Microsoft.PythonTools.Interpreter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Microsoft.PythonTools.Analysis {
+    [TestClass]
+    public class InheritanceTests {
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize() => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void TestCleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod]
+        public async Task AbstractMethodReturnTypeIgnored() {
+            var code = @"import abc
+class A:
+    @abc.abstractmethod
+    def virt():
+        pass
+class B(A):
+    def virt():
+        return 42
+a = A()
+b = a.virt()";
+
+            using (var server = await new Server().InitializeAsync(PythonVersions.Required_Python36X)) {
+                var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(code);
+
+                analysis.Should().HaveVariable("b").OfType(BuiltinTypeId.Int);
+            }
+        }
+    }
+}


### PR DESCRIPTION
From @lostmsu:

This change fixes https://github.com/Microsoft/PTVS/pull/4715

Rationale:
If class A(B), and both have method foo, then any variable v of type B can potentially hold value of type A. Which means, that v.foo() can return a value of type that of return value of A.foo or B.foo.

To achieve that, when function return type is determined by DDG, it is also added as a potential return type for all of the function's bases (e.g. functions, that this function overrides).

In addition to that, this change also improves DDG.LookupBaseMethods, which previously only took into account built-in classes.