### PR TITLE
A test to ensure @abc.abstractproperty return value is analyzed correctly

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
@@ -101,7 +101,8 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
 
             // Only handle these if they are specialized
             foreach (var d in decorator.OfType<SpecializedCallable>()) {
-                if (d.DeclaringModule?.ModuleName != "abc") {
+                if (d.DeclaringModule != null
+                    && d.DeclaringModule.ModuleName != "abc") {
                     continue;
                 }
 

--- a/src/Analysis/Engine/Impl/Values/SpecializedNamespace.cs
+++ b/src/Analysis/Engine/Impl/Values/SpecializedNamespace.cs
@@ -217,6 +217,15 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
+        public override string Name {
+            get {
+                if (_original == null)
+                    return base.Name;
+
+                return _original.Name;
+            }
+        }
+
         public override IEnumerable<OverloadResult> Overloads {
             get {
                 if (_original == null) {

--- a/src/Analysis/Engine/Impl/Values/SpecializedNamespace.cs
+++ b/src/Analysis/Engine/Impl/Values/SpecializedNamespace.cs
@@ -217,14 +217,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
-        public override string Name {
-            get {
-                if (_original == null)
-                    return base.Name;
-
-                return _original.Name;
-            }
-        }
+        public override string Name => _original == null ? base.Name : this._original.Name;
 
         public override IEnumerable<OverloadResult> Overloads {
             get {

--- a/src/Analysis/Engine/Test/Microsoft.Python.Analysis.Engine.Tests.csproj
+++ b/src/Analysis/Engine/Test/Microsoft.Python.Analysis.Engine.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RootNamespace>Microsoft.PythonTools.Analysis</RootNamespace>
+    <RootNamespace>AnalysisTests</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Engine.Tests</AssemblyName>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This adds a test for the analysis of return values of abstract properties (properties, marked with `@abc.abstractproperty`).

This also adds a partial fix for it not being analyzed properly. (related to #115)

Unfortunately, due to some regression (?) between PTVS/master and python-language-server/master, this does not seem to be enough: test variable `b` analysis results in two possible return values, `int` (correct) and `A.virt` (which is incorrect, and eventually resolves to be `Unknown`). The later seems to be happening because on the first pass `ddg._eval.Evaluate(@abc.abstractproperty)` results in empty set.