### PR TITLE
Fix string concatenation spacing in line formatter

### DIFF
--- a/src/Analysis/Engine/Test/LineFormatterTests.cs
+++ b/src/Analysis/Engine/Test/LineFormatterTests.cs
@@ -390,6 +390,19 @@ limit { limit_num}; """"""", line: 5);
             AssertSingleLineFormat("a+# comment\nb", "a +  # comment");
         }
 
+        [DataRow("'a''b'", "'a' 'b'")]
+        [DataRow("'a' 'b'", "'a' 'b'")]
+        [DataRow("'''a''''''b'''", "'''a''' '''b'''")]
+        [DataRow("'''a'''r'''b'''", "'''a''' r'''b'''")]
+        [DataRow("\"a\"\"b\"", "\"a\" \"b\"")]
+        [DataRow("\"a\" \"b\"", "\"a\" \"b\"")]
+        [DataRow("\"\"\"a\"\"\"\"\"\"b\"\"\"", "\"\"\"a\"\"\" \"\"\"b\"\"\"")]
+        [DataRow("\"\"\"a\"\"\"r\"\"\"b\"\"\"", "\"\"\"a\"\"\" r\"\"\"b\"\"\"")]
+        [DataTestMethod, Priority(0)]
+        public void StringConcat(string code, string expected) {
+            AssertSingleLineFormat(code, expected);
+        }
+
 
         [TestMethod, Priority(0)]
         public void GrammarFile() {

--- a/src/LanguageServer/Impl/Implementation/LineFormatter.cs
+++ b/src/LanguageServer/Impl/Implementation/LineFormatter.cs
@@ -287,8 +287,15 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                         builder.EnsureEndsWithSpace();
                         break;
 
-                    case TokenKind.Name:
                     case TokenKind.Constant:
+                        if (token.IsString && next != null && next.IsString) {
+                            builder.Append(token);
+                            builder.EnsureEndsWithSpace();
+                            break;
+                        }
+                        goto case TokenKind.Name;
+
+                    case TokenKind.Name:
                     case TokenKind.KeywordFalse:
                     case TokenKind.KeywordTrue:
                     case TokenKind.Ellipsis: // Ellipsis is a value
@@ -410,19 +417,9 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             public bool IsKeyword => (Kind >= TokenKind.FirstKeyword && Kind <= TokenKind.LastKeyword) || Kind == TokenKind.KeywordAsync || Kind == TokenKind.KeywordAwait;
 
-            public bool IsMultilineString {
-                get {
-                    if (Span.Start.Line == Span.End.Line) {
-                        return false;
-                    }
+            public bool IsString => Kind == TokenKind.Constant && Token != Tokens.NoneToken && (Token.Value is string || Token.Value is AsciiString);
 
-                    if (Kind != TokenKind.Constant || Token == Tokens.NoneToken) {
-                        return false;
-                    }
-
-                    return Token.Value is string || Token.Value is AsciiString;
-                }
-            }
+            public bool IsMultilineString => Span.Start.Line != Span.End.Line && IsString;
 
             public bool IsSimpleSliceToLeft {
                 get {


### PR DESCRIPTION
I thought of this case while reading the fstring spec. The line formatter defaults to not spacing around string literals, but it's likely better to insert a space between two string literals next to each other.

For reference:
- autopep8 leaves spacing as-is, so `'a''b'` and `'a' 'b'` would not be changed (even with more than one space between). I could emulate this behavior in the line formatter, since `TokenExt` includes `PreceedingWhitespace`.
- yapf ensures there is a space between two strings.
- black behaves the same as yapf (barring its replacement of `'` with `"`).