### PR TITLE
Fix type annotation on overloads

### DIFF
--- a/src/Analysis/Engine/Impl/AnalysisSet.cs
+++ b/src/Analysis/Engine/Impl/AnalysisSet.cs
@@ -593,9 +593,7 @@ namespace Microsoft.PythonTools.Analysis {
             return (x == null) ? (y == null) : x.UnionEquals(y, Strength);
         }
 
-        public int GetHashCode(AnalysisValue obj) {
-            return (obj == null) ? 0 : obj.UnionHashCode(Strength);
-        }
+        public int GetHashCode(AnalysisValue obj) => obj == null ? 0 : obj.UnionHashCode(Strength);
 
         public AnalysisValue MergeTypes(AnalysisValue x, AnalysisValue y, out bool wasChanged) {
             if (Object.ReferenceEquals(x, y)) {

--- a/src/Analysis/Engine/Impl/OverloadResult.cs
+++ b/src/Analysis/Engine/Impl/OverloadResult.cs
@@ -144,7 +144,7 @@ namespace Microsoft.PythonTools.Analysis {
         private string _name;
         private string _doc;
         private string[] _pnames;
-        private IAnalysisSet[] _ptypes;
+        private string[] _ptypes;
         private string[] _pdefaults;
         private readonly HashSet<string> _rtypes;
 
@@ -152,7 +152,7 @@ namespace Microsoft.PythonTools.Analysis {
             _name = name;
             _doc = documentation;
             _pnames = new string[parameters];
-            _ptypes = new IAnalysisSet[parameters];
+            _ptypes = new string[parameters];
             _pdefaults = new string[parameters];
             ParameterCount = parameters;
             _rtypes = new HashSet<string>();
@@ -181,7 +181,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         private IAnalysisSet ChooseBest(IAnalysisSet x, IAnalysisSet y) {
             if (x == null || x.IsObjectOrUnknown()) {
-                return (y == null) ? AnalysisSet.Empty : y;
+                return (y == null || y.IsObjectOrUnknown()) ? AnalysisSet.Empty : y;
             }
             if (y == null || y.IsObjectOrUnknown()) {
                 return AnalysisSet.Empty;
@@ -189,7 +189,7 @@ namespace Microsoft.PythonTools.Analysis {
             return x.Union(y);
         }
 
-        public bool TryAddOverload(string name, string documentation, string[] names, IAnalysisSet[] types, string[] defaults, IEnumerable<string> returnTypes) {
+        public bool TryAddOverload(string name, string documentation, string[] names, string[] types, string[] defaults, IEnumerable<string> returnTypes) {
             if (names.Length != _pnames.Length || types.Length != _ptypes.Length) {
                 return false;
             }
@@ -233,7 +233,7 @@ namespace Microsoft.PythonTools.Analysis {
                 parameters[i] = new ParameterResult(
                     _pnames[i],
                     null,
-                    (_ptypes[i] == null || _ptypes[i].IsObjectOrUnknown()) ? null : string.Join(", ", _ptypes[i].GetShortDescriptions()),
+                    _ptypes[i],
                     false,
                     null,
                     _pdefaults[i]

--- a/src/Analysis/Engine/Impl/OverloadResult.cs
+++ b/src/Analysis/Engine/Impl/OverloadResult.cs
@@ -16,12 +16,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis.Infrastructure;
-using Microsoft.PythonTools.Analysis.Values;
 using Microsoft.PythonTools.Interpreter;
 
 namespace Microsoft.PythonTools.Analysis {
@@ -63,7 +61,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             var sb = new StringBuilder();
-            int nestCount = 0;
+            var nestCount = 0;
             foreach (var c in x) {
                 if (c == ',' && nestCount == 0) {
                     yield return sb.ToString().Trim();
@@ -95,7 +93,7 @@ namespace Microsoft.PythonTools.Analysis {
             var parameters = overloads.Select(o => o.Parameters).Aggregate(Array.Empty<ParameterResult>(), (all, pms) => {
                 var res = all.Concat(pms.Skip(all.Length)).ToArray();
 
-                for (int i = 0; i < res.Length; ++i) {
+                for (var i = 0; i < res.Length; ++i) {
                     if (res[i] == null) {
                         res[i] = pms[i];
                     } else {
@@ -179,16 +177,6 @@ namespace Microsoft.PythonTools.Analysis {
             return x.Length >= y.Length ? x : y;
         }
 
-        private IAnalysisSet ChooseBest(IAnalysisSet x, IAnalysisSet y) {
-            if (x == null || x.IsObjectOrUnknown()) {
-                return (y == null || y.IsObjectOrUnknown()) ? AnalysisSet.Empty : y;
-            }
-            if (y == null || y.IsObjectOrUnknown()) {
-                return AnalysisSet.Empty;
-            }
-            return x.Union(y);
-        }
-
         public bool TryAddOverload(string name, string documentation, string[] names, string[] types, string[] defaults, IEnumerable<string> returnTypes) {
             if (names.Length != _pnames.Length || types.Length != _ptypes.Length) {
                 return false;
@@ -225,7 +213,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         public OverloadResult ToOverloadResult() {
             var parameters = new ParameterResult[_pnames.Length];
-            for (int i = 0; i < parameters.Length; ++i) {
+            for (var i = 0; i < parameters.Length; ++i) {
                 if (string.IsNullOrEmpty(_pnames[i])) {
                     return null;
                 }
@@ -328,7 +316,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
 
             foreach (var param in _overload.GetParameters()) {
-                if (!String.IsNullOrEmpty(param.Documentation)) {
+                if (!string.IsNullOrEmpty(param.Documentation)) {
                     doc.AppendLine();
                     doc.Append(param.Name);
                     doc.Append(": ");
@@ -336,7 +324,7 @@ namespace Microsoft.PythonTools.Analysis {
                 }
             }
 
-            if (!String.IsNullOrEmpty(_overload.ReturnDocumentation)) {
+            if (!string.IsNullOrEmpty(_overload.ReturnDocumentation)) {
                 doc.AppendLine();
                 doc.AppendLine();
                 doc.Append("Returns: ");
@@ -359,7 +347,7 @@ namespace Microsoft.PythonTools.Analysis {
 
                         var pinfo = _overload.GetParameters();
                         var result = new List<ParameterResult>(pinfo.Length + _extraParameters.Length);
-                        int ignored = 0;
+                        var ignored = 0;
                         ParameterResult kwDict = null;
                         foreach (var param in pinfo) {
                             if (ignored < _removedParams) {
@@ -392,7 +380,7 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         internal ParameterResult GetParameterResultFromParameterInfo(IParameterInfo param) {
-            string name = param.Name;
+            var name = param.Name;
 
             string typeName;
             if (param.ParameterTypes != null) {
@@ -402,8 +390,7 @@ namespace Microsoft.PythonTools.Analysis {
             }
             if (param.IsParamArray) {
                 name = "*" + name;
-                var advType = param.ParameterTypes as IAdvancedPythonType;
-                if (advType != null && advType.IsArray) {
+                if (param.ParameterTypes is IAdvancedPythonType advType && advType.IsArray) {
                     var elemType = advType.GetElementType();
                     if (elemType == _projectState.Types[BuiltinTypeId.Object]) {
                         typeName = "sequence";
@@ -416,8 +403,8 @@ namespace Microsoft.PythonTools.Analysis {
                 typeName = "object";
             }
 
-            bool isOptional = false;
-            string defaultValue = param.DefaultValue;
+            var isOptional = false;
+            var defaultValue = param.DefaultValue;
             if (defaultValue != null && defaultValue.Length == 0) {
                 isOptional = true;
                 defaultValue = null;
@@ -456,7 +443,7 @@ namespace Microsoft.PythonTools.Analysis {
                 return false;
             }
 
-            for (int i = 0; i < x.Parameters.Length; ++i) {
+            for (var i = 0; i < x.Parameters.Length; ++i) {
                 if (_weak) {
                     if (!x.Parameters[i].Name.Equals(y.Parameters[i].Name)) {
                         return false;
@@ -474,7 +461,7 @@ namespace Microsoft.PythonTools.Analysis {
         public override int GetHashCode(OverloadResult obj) {
             // Don't use Documentation for hash code, since it changes over time
             // in some implementations of IOverloadResult.
-            int hc = 552127 ^ obj.Name.GetHashCode();
+            var hc = 552127 ^ obj.Name.GetHashCode();
             if (obj.Parameters != null) {
                 foreach (var p in obj.Parameters) {
                     hc ^= _weak ? p.Name.GetHashCode() : p.GetHashCode();

--- a/src/Analysis/Engine/Impl/Resources.Designer.cs
+++ b/src/Analysis/Engine/Impl/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.PythonTools.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Documentation is still being calculated, please try again soon..
+        /// </summary>
+        internal static string CalculatingDocumentation {
+            get {
+                return ResourceManager.GetString("CalculatingDocumentation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The number of empty lines to include between class or function declarations at the top level of a module..
         /// </summary>
         internal static string LinesBetweenLevelDeclarationsLong {

--- a/src/Analysis/Engine/Impl/Resources.resx
+++ b/src/Analysis/Engine/Impl/Resources.resx
@@ -300,4 +300,7 @@
     <value># Sets the width for wrapping comments
 # and documentation strings.</value>
   </data>
+  <data name="CalculatingDocumentation" xml:space="preserve">
+    <value>Documentation is still being calculated, please try again soon.</value>
+  </data>
 </root>

--- a/src/Analysis/Engine/Impl/Values/BuiltinInstanceInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/BuiltinInstanceInfo.cs
@@ -337,9 +337,6 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 if (ns is InstanceInfo ii) {
                     return ClassInfo.UnionMergeTypes(ii.ClassInfo, strength).GetInstanceType().Single();
                 }
-                if (ns is ProtocolInfo pi) {
-                    return pi.UnionMergeTypes(this, strength).GetInstanceType().Single();
-                }
             } else if (this is ConstantInfo || ns is ConstantInfo) {
                 return ClassInfo.Instance;
             }

--- a/src/Analysis/Engine/Impl/Values/BuiltinInstanceInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/BuiltinInstanceInfo.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         IBuiltinClassInfo IBuiltinInstanceInfo.ClassInfo => ClassInfo;
         public BuiltinClassInfo ClassInfo => _klass;
 
+        public override string Name => _klass.Name;
         public override IPythonType PythonType => _type;
 
         public override IAnalysisSet GetInstanceType() {
@@ -165,7 +166,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     Pop();
                 }
             }
-            
+
             return res;
         }
 
@@ -330,18 +331,18 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 return ProjectState.ClassInfos[BuiltinTypeId.Object].Instance;
 
             } else if (strength >= MergeStrength.ToBaseClass) {
-                var bii = ns as BuiltinInstanceInfo;
-                if (bii != null) {
+                if (ns is BuiltinInstanceInfo bii) {
                     return ClassInfo.UnionMergeTypes(bii.ClassInfo, strength).GetInstanceType().Single();
                 }
-                var ii = ns as InstanceInfo;
-                if (ii != null) {
+                if (ns is InstanceInfo ii) {
                     return ClassInfo.UnionMergeTypes(ii.ClassInfo, strength).GetInstanceType().Single();
+                }
+                if (ns is ProtocolInfo pi) {
+                    return pi.UnionMergeTypes(this, strength).GetInstanceType().Single();
                 }
             } else if (this is ConstantInfo || ns is ConstantInfo) {
                 return ClassInfo.Instance;
             }
-
             return base.UnionMergeTypes(ns, strength);
         }
 

--- a/src/Analysis/Engine/Impl/Values/ClassInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/ClassInfo.cs
@@ -271,7 +271,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                                                 overload.Parameters,
                                                 ClassDefinition.Name,
                                                 overload.Documentation,
-                                                overload.ReturnType
+                                                overload.ReturnTypes
                                             )
                                         );
                                     }
@@ -289,7 +289,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                         new ParameterResult[0],
                         ClassDefinition.Name,
                         ClassDefinition.Body.Documentation.TrimDocumentation(),
-                        new[] { ShortDescription }
+                        AnalysisSet.Empty
                     ));
                 }
 
@@ -303,8 +303,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return new OverloadResult(
                 overload.Parameters.RemoveFirst(),
                 ClassDefinition.Name,
-                String.IsNullOrEmpty(doc) ? Documentation : doc,
-                overload.ReturnType
+                string.IsNullOrEmpty(doc) ? Documentation : doc,
+                overload.ReturnTypes
             );
         }
 
@@ -313,8 +313,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return new OverloadResult(
                 overload.Parameters.RemoveFirst(),
                 ClassDefinition.Name,
-                String.IsNullOrEmpty(doc) ? Documentation : doc,
-                overload.ReturnType
+                string.IsNullOrEmpty(doc) ? Documentation : doc,
+                overload.ReturnTypes
             );
         }
 

--- a/src/Analysis/Engine/Impl/Values/ClassInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/ClassInfo.cs
@@ -271,7 +271,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                                                 overload.Parameters,
                                                 ClassDefinition.Name,
                                                 overload.Documentation,
-                                                overload.ReturnTypes
+                                                overload.ReturnType
                                             )
                                         );
                                     }
@@ -289,7 +289,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                         new ParameterResult[0],
                         ClassDefinition.Name,
                         ClassDefinition.Body.Documentation.TrimDocumentation(),
-                        AnalysisSet.Empty
+                        new[] { ShortDescription }
                     ));
                 }
 
@@ -304,7 +304,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 overload.Parameters.RemoveFirst(),
                 ClassDefinition.Name,
                 string.IsNullOrEmpty(doc) ? Documentation : doc,
-                overload.ReturnTypes
+                overload.ReturnType
             );
         }
 
@@ -314,7 +314,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 overload.Parameters.RemoveFirst(),
                 ClassDefinition.Name,
                 string.IsNullOrEmpty(doc) ? Documentation : doc,
-                overload.ReturnTypes
+                overload.ReturnType
             );
         }
 

--- a/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
@@ -485,12 +485,13 @@ namespace Microsoft.PythonTools.Analysis.Values {
                             LazyCallArgs = new Lazy<ArgumentSet>(() => new ArgumentSet(vars, null, null, null)),
                             ResolveFully = true
                         }, out _)
+                        .GetShortDescriptions()
                         .ToArray();
 
                     bool needNewSet = true;
                     foreach (var set in parameterSets) {
                         if (set.ParameterCount == names.Length) {
-                            if (set.TryAddOverload(null, null, names, vars, defaults, AnalysisSet.Create(rtypes))) {
+                            if (set.TryAddOverload(null, null, names, vars, defaults, rtypes)) {
                                 needNewSet = false;
                                 break;
                             }
@@ -500,7 +501,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     if (needNewSet) {
                         var set = new AccumulatedOverloadResult(FunctionDefinition.Name, Documentation, names.Length);
                         parameterSets.Add(set);
-                        set.TryAddOverload(null, null, names, vars, defaults, AnalysisSet.Create(rtypes));
+                        set.TryAddOverload(null, null, names, vars, defaults, rtypes);
                     }
                 }
 

--- a/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
@@ -485,13 +485,12 @@ namespace Microsoft.PythonTools.Analysis.Values {
                             LazyCallArgs = new Lazy<ArgumentSet>(() => new ArgumentSet(vars, null, null, null)),
                             ResolveFully = true
                         }, out _)
-                        .GetShortDescriptions()
                         .ToArray();
 
                     bool needNewSet = true;
                     foreach (var set in parameterSets) {
                         if (set.ParameterCount == names.Length) {
-                            if (set.TryAddOverload(null, null, names, vars, defaults, rtypes)) {
+                            if (set.TryAddOverload(null, null, names, vars, defaults, AnalysisSet.Create(rtypes))) {
                                 needNewSet = false;
                                 break;
                             }
@@ -501,7 +500,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     if (needNewSet) {
                         var set = new AccumulatedOverloadResult(FunctionDefinition.Name, Documentation, names.Length);
                         parameterSets.Add(set);
-                        set.TryAddOverload(null, null, names, vars, defaults, rtypes);
+                        set.TryAddOverload(null, null, names, vars, defaults, AnalysisSet.Create(rtypes));
                     }
                 }
 

--- a/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
@@ -466,27 +466,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
                 foreach (var unit in units) {
                     var names = FunctionDefinition.Parameters.Select(MakeParameterName).ToArray();
-
-                    var vars = FunctionDefinition.Parameters.Select(p => {
-                        if (unit != AnalysisUnit && unit.InterpreterScope.TryGetVariable(p.Name, out var param)) {
-                            return param.Types.Resolve(unit);
-                        } else if (_analysisUnit._scope is FunctionScope fs) {
-                            return fs.GetParameter(p.Name)?.Types.Resolve(unit) ?? AnalysisSet.Empty;
-                        }
-                        return AnalysisSet.Empty;
-                    }).ToArray();
-
+                    var vars = FunctionDefinition.Parameters.Select(p => GetAnnotation(ProjectState, p, DeclaringModule.Tree)).ToArray();
                     var defaults = FunctionDefinition.Parameters.Select(p => GetDefaultValue(unit.State, p, DeclaringModule.Tree)).ToArray();
-
-                    var rtypes = (unit.Scope as FunctionScope)?.ReturnValue
-                        .Types
-                        .Resolve(unit, new ResolutionContext {
-                            Caller = this,
-                            LazyCallArgs = new Lazy<ArgumentSet>(() => new ArgumentSet(vars, null, null, null)),
-                            ResolveFully = true
-                        }, out _)
-                        .GetShortDescriptions()
-                        .ToArray();
+                    var rtypes = GetReturnValue().GetShortDescriptions().ToArray();
 
                     bool needNewSet = true;
                     foreach (var set in parameterSets) {

--- a/src/Analysis/Engine/Impl/Values/InstanceInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/InstanceInfo.cs
@@ -33,6 +33,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
             _classInfo = classInfo;
         }
 
+        public override string Name => _classInfo.Name;
+        public override IPythonType PythonType => _classInfo.PythonType;
+
         public override IDictionary<string, IAnalysisSet> GetAllMembers(IModuleContext moduleContext, GetMemberOptions options = GetMemberOptions.None) {
             var res = new Dictionary<string, IAnalysisSet>();
             if (_instanceAttrs != null) {

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -187,7 +187,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         private OverloadResult[] GenerateOverloads() {
             return new[] {
-                new OverloadResult(Arguments.Select(ToParameterResult).ToArray(), Name, null, ReturnType)
+                new OverloadResult(Arguments.Select(ToParameterResult).ToArray(), Name, null, ReturnType.GetShortDescriptions())
             };
         }
 

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -187,7 +187,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         private OverloadResult[] GenerateOverloads() {
             return new[] {
-                new OverloadResult(Arguments.Select(ToParameterResult).ToArray(), Name, null, ReturnType.GetShortDescriptions())
+                new OverloadResult(Arguments.Select(ToParameterResult).ToArray(), Name, null, ReturnType)
             };
         }
 

--- a/src/Analysis/Engine/Test/TypeAnnotationTests.cs
+++ b/src/Analysis/Engine/Test/TypeAnnotationTests.cs
@@ -369,18 +369,18 @@ x = f()
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_1() {
+        public async Task TypingModuleDocumentationExample_01() {
             await TypingModuleDocumentationExampleAsync(@"def greeting(name: str) -> str:
     return 'Hello ' + name
-", 
+",
                 new[] {
-                    "greeting:greeting(name:str=)->[str]"
+                    "greeting:greeting(name:str) -> str"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_2() {
+        public async Task TypingModuleDocumentationExample_02() {
             await TypingModuleDocumentationExampleAsync(@"from typing import List
 Vector = List[float]
 
@@ -391,13 +391,13 @@ def scale(scalar: float, vector: Vector) -> Vector:
 new_vector = scale(2.0, [1.0, -4.2, 5.4])
 ",
                 new[] {
-                    "scale:scale(scalar:float=,vector:list[float, float, float], list[float]=)->[list[float]]"
+                    "scale:scale(scalar:float, vector:list[float]) -> list[float]"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_3() {
+        public async Task TypingModuleDocumentationExample_03() {
             await TypingModuleDocumentationExampleAsync(@"from typing import Dict, Tuple, List
 
 ConnectionOptions = Dict[str, str]
@@ -416,13 +416,13 @@ def broadcast_message(
 ",
                 new[] {
                     // Two matching functions means only one overload is returned
-                    "broadcast_message:broadcast_message(message:str=,servers:list[tuple[tuple[str, int], dict[str, str]]]=)->[]"
+                    "broadcast_message:broadcast_message(message:str, servers:list[tuple[tuple[str, int], dict[str, str]]]) -> None"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_4() {
+        public async Task TypingModuleDocumentationExample_04() {
             await TypingModuleDocumentationExampleAsync(@"from typing import NewType
 
 UserId = NewType('UserId', int)
@@ -438,13 +438,13 @@ user_a = get_user_name(UserId(42351))
 user_b = get_user_name(-1)
 ",
                 new[] {
-                    "get_user_name:get_user_name(user_id:int, UserId=)->[str]"
+                    "get_user_name:get_user_name(user_id:int) -> str"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_5() {
+        public async Task TypingModuleDocumentationExample_05() {
             await TypingModuleDocumentationExampleAsync(@"from typing import NewType
 
 UserId = NewType('UserId', int)
@@ -458,13 +458,13 @@ def f(u : UserId, a : AdminUserId, p : ProUserId):
     return p
 ",
                 new[] {
-                    "f:f(u:UserId=,a:AdminUserId=,p:ProUserId=)->[ProUserId]"
+                    "f:f(u:UserId, a:AdminUserId, p:ProUserId) -> ProUserId"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_6() {
+        public async Task TypingModuleDocumentationExample_06() {
             await TypingModuleDocumentationExampleAsync(@"from typing import Callable
 
 def feeder(get_next_item: Callable[[], str]) -> None:
@@ -478,14 +478,14 @@ def async_query(on_success: Callable[[int], None],
 
 ",
                 new[] {
-                    "feeder:feeder(get_next_item:function() -> str=)->[]",
-                    "async_query:async_query(on_success:function(int)=,on_error:function(int, Exception)=)->[]"
+                    "feeder:feeder(get_next_item:function() -> str) -> None",
+                    "async_query:async_query(on_success:function(int), on_error:function(int, Exception)) -> None"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_7() {
+        public async Task TypingModuleDocumentationExample_07() {
             await TypingModuleDocumentationExampleAsync(@"from typing import Mapping, Sequence
 
 class Employee: pass
@@ -494,13 +494,13 @@ def notify_by_email(employees: Sequence[Employee],
                     overrides: Mapping[str, str]) -> None: ...
 ",
                 new[] {
-                    "notify_by_email:notify_by_email(employees:list[Employee]=,overrides:dict[str, str]=)->[]"
+                    "notify_by_email:notify_by_email(employees:list[Employee], overrides:dict[str, str]) -> None"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_8() {
+        public async Task TypingModuleDocumentationExample_08() {
             await TypingModuleDocumentationExampleAsync(@"from typing import Sequence, TypeVar
 
 T = TypeVar('T')      # Declare type variable
@@ -509,13 +509,13 @@ def first(l: Sequence[T]) -> T:   # Generic function
     return l[0]
 ",
                 new[] {
-                    "first:first(l:list[T]=)->[T]"
+                    "first:first(l:list[T]) -> T"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
-        public async Task TypingModuleDocumentationExample_9() {
+        public async Task TypingModuleDocumentationExample_09() {
             await TypingModuleDocumentationExampleAsync(@"from typing import TypeVar, Generic, Iterable
 from logging import Logger
 
@@ -543,36 +543,23 @@ def zero_all_vars(vars: Iterable[LoggedVar[int]]) -> None:
         var.set(0)
 ",
                 new[] {
-                    "LoggedVar.set:set(self:LoggedVar=,new:int, T=)->[]",
-                    "zero_all_vars:zero_all_vars(vars:iterable[LoggedVar]=)->[]"
+                    "LoggedVar.set:set(self:LoggedVar, new:T) -> None",
+                    "zero_all_vars:zero_all_vars(vars:iterable[LoggedVar]) -> None"
                 }
             );
         }
 
         [TestMethod, Priority(0)]
         public async Task TypingModuleDocumentationExample_10() {
-            await TypingModuleDocumentationExampleAsync(@"from typing import TypeVar, Generic
-...
+            await TypingModuleDocumentationExampleAsync(@"from typing import NewType
 
-T = TypeVar('T')
-S = TypeVar('S', int, str)
+UserId = NewType('UserId', int)
 
-class StrangePair(Generic[T, S]):
-    ...
-
-class Pair(Generic[T, T]):   # INVALID
-    ...
-
-class LinkedList(Sized, Generic[T]):
-    ...
-
-class MyDict(Mapping[str, T]):
-    ...
-
-def f(s: StrangePair[int, int], p: Pair, l: LinkedList, m: MyDict): ...
+def f(u : UserId=345, a : float=1.0):
+    return u
 ",
                 new[] {
-                    "f:f(s:StrangePair=,p:Pair=,l:LinkedList=,m:MyDict=)->[]"
+                    "f:f(u:int=345, a:float=1.0) -> UserId"
                 }
             );
         }

--- a/src/Analysis/Engine/Test/TypeAnnotationTests.cs
+++ b/src/Analysis/Engine/Test/TypeAnnotationTests.cs
@@ -391,7 +391,7 @@ def scale(scalar: float, vector: Vector) -> Vector:
 new_vector = scale(2.0, [1.0, -4.2, 5.4])
 ",
                 new[] {
-                    "scale:scale(scalar:float, vector:list[float]) -> list[float]"
+                    "scale:scale(scalar:float, vector:list[float, float, float], list[float]) -> list[float]"
                 }
             );
         }
@@ -438,7 +438,7 @@ user_a = get_user_name(UserId(42351))
 user_b = get_user_name(-1)
 ",
                 new[] {
-                    "get_user_name:get_user_name(user_id:int) -> str"
+                    "get_user_name:get_user_name(user_id:int, UserId) -> str"
                 }
             );
         }
@@ -543,7 +543,7 @@ def zero_all_vars(vars: Iterable[LoggedVar[int]]) -> None:
         var.set(0)
 ",
                 new[] {
-                    "LoggedVar.set:set(self:LoggedVar, new:T) -> None",
+                    "LoggedVar.set:set(self:LoggedVar, new:int, T) -> None",
                     "zero_all_vars:zero_all_vars(vars:iterable[LoggedVar]) -> None"
                 }
             );
@@ -553,13 +553,13 @@ def zero_all_vars(vars: Iterable[LoggedVar[int]]) -> None:
         public async Task TypingModuleDocumentationExample_10() {
             await TypingModuleDocumentationExampleAsync(@"from typing import NewType
 
-UserId = NewType('UserId', int)
+UserId = NewType('UserId', float)
 
-def f(u : UserId=345, a : float=1.0):
+def f(u : UserId=345., a : float=1.0):
     return u
 ",
                 new[] {
-                    "f:f(u:int=345, a:float=1.0) -> UserId"
+                    "f:f(u:float, UserId=345.0, a:float=1.0) -> [float, UserId]"
                 }
             );
         }

--- a/src/Analysis/Engine/Test/TypeAnnotationTests.cs
+++ b/src/Analysis/Engine/Test/TypeAnnotationTests.cs
@@ -380,7 +380,6 @@ x = f()
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/38")]
         public async Task TypingModuleDocumentationExample_2() {
             await TypingModuleDocumentationExampleAsync(@"from typing import List
 Vector = List[float]
@@ -392,7 +391,7 @@ def scale(scalar: float, vector: Vector) -> Vector:
 new_vector = scale(2.0, [1.0, -4.2, 5.4])
 ",
                 new[] {
-                    "scale:scale(scalar:float=,vector:list[float]=)->[list,list[float]]"
+                    "scale:scale(scalar:float=,vector:list[float, float, float], list[float]=)->[list[float]]"
                 }
             );
         }

--- a/src/Analysis/Engine/Test/TypeAnnotationTests.cs
+++ b/src/Analysis/Engine/Test/TypeAnnotationTests.cs
@@ -391,7 +391,7 @@ def scale(scalar: float, vector: Vector) -> Vector:
 new_vector = scale(2.0, [1.0, -4.2, 5.4])
 ",
                 new[] {
-                    "scale:scale(scalar:float, vector:list[float, float, float], list[float]) -> list[float]"
+                    "scale:scale(scalar:float, vector:list[float]) -> list[float]"
                 }
             );
         }
@@ -438,7 +438,7 @@ user_a = get_user_name(UserId(42351))
 user_b = get_user_name(-1)
 ",
                 new[] {
-                    "get_user_name:get_user_name(user_id:int, UserId) -> str"
+                    "get_user_name:get_user_name(user_id:UserId) -> str"
                 }
             );
         }
@@ -543,7 +543,7 @@ def zero_all_vars(vars: Iterable[LoggedVar[int]]) -> None:
         var.set(0)
 ",
                 new[] {
-                    "LoggedVar.set:set(self:LoggedVar, new:int, T) -> None",
+                    "LoggedVar.set:set(self:LoggedVar, new:T) -> None",
                     "zero_all_vars:zero_all_vars(vars:iterable[LoggedVar]) -> None"
                 }
             );


### PR DESCRIPTION
- Make type overloads use same way of generating parameter types as tooltip/hover. This way get get proper short types and not something like `a:T, int` on a generic or `a:list[float, float, float], list[float]`.
- Return value should not have `[ ]` around it if it is a single type.
- If function returns nothing, then display `None` and not `[ ]`
- Prettify documentation with proper spacing
- Update all TypingModuleDocumentation* tests baselines
