### PR TITLE
RELEASE: Fix frequent module reloading

### DIFF
--- a/src/LanguageServer/Impl/PathsWatcher.cs
+++ b/src/LanguageServer/Impl/PathsWatcher.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Python.LanguageServer {
 
             _onChanged = onChanged;
 
-            var list = new List<FileSystemWatcher>();
             var reduced = ReduceToCommonRoots(paths);
             foreach (var p in reduced) {
                 try {
@@ -59,12 +58,10 @@ namespace Microsoft.Python.LanguageServer {
                         NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName
                     };
 
-                    fsw.Changed += OnChanged;
                     fsw.Created += OnChanged;
                     fsw.Deleted += OnChanged;
 
                     _disposableBag
-                        .Add(() => fsw.Changed -= OnChanged)
                         .Add(() => fsw.Created -= OnChanged)
                         .Add(() => fsw.Deleted -= OnChanged)
                         .Add(() => fsw.EnableRaisingEvents = false)


### PR DESCRIPTION
Fix additional issues with paths watcher:
- It was incorrectly checking for 'changed' (fix the flag check)
- It gets notified on file changes in the user folder (exclude `.` or other non-rooted paths) 
- Remove notifications on 'changed', leaving deleted/added only
- Add notification filter on name/directory ignoring other notifications