### PR TITLE
Fix unwanted spacing around equals in override completion

### DIFF
--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -444,6 +444,16 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
+        public async Task CompletionForOverrideArgs() {
+            using (var s = await CreateServer()) {
+                var u = await AddModule(s, "class A:\n    def bar(arg=None): pass\n\nclass B(A):\n    def b");
+
+                await AssertNoCompletion(s, u, new SourceLocation(2, 9));
+                await AssertCompletion(s, u, new[] { "bar(arg=None):\r\n    return super().bar()" }, new[] { "bar(arg = None):\r\n    return super().bar()" }, new SourceLocation(5, 10));
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public async Task CompletionInDecorator() {
             var s = await CreateServer();
             var u = await AddModule(s, "@dec\ndef f(): pass\n\nx = a @ b");

--- a/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
+++ b/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
@@ -876,7 +876,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         private static string GetSafeParameterName(ParameterResult result, int index) {
             if (!string.IsNullOrEmpty(result.DefaultValue)) {
-                return GetSafeArgumentName(result, index) + " = " + result.DefaultValue;
+                return GetSafeArgumentName(result, index) + "=" + result.DefaultValue;
             }
             return GetSafeArgumentName(result, index);
         }


### PR DESCRIPTION
This resolves #145, but with the catch that LS seems to drop the type information before getting to the code I fixed, so repeating the example in #145 with the following base class:

```python
class Foo:
    def bar(arg: int = 5):
        pass
```

Will complete out to:

```python
class Bar(Foo):
    def bar(arg=5):
        return super().bar()
```

When it would be preferable to produce:

```python
class Bar(Foo):
    def bar(arg: int = 5):
        return super().bar()
```

Making that improvement may take more investigation.