### PR TITLE
Fix References_GrammarTest_Statements

### DIFF
--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -27,7 +27,6 @@ using Microsoft.Python.LanguageServer.Implementation;
 using Microsoft.Python.UnitTests.Core.MSTest;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Analysis.FluentAssertions;
-using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Analysis.Values;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.PythonTools.Interpreter.Ast;
@@ -2994,7 +2993,7 @@ def f(abc):
 
                 // External module 'abc', URI varies depending on install
                 var externalUri = references[1].uri;
-                externalUri.LocalPath.Should().Contain("abc.py");
+                externalUri.LocalPath.Should().EndWith("abc.py");
  
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 9), ReferenceKind.Definition),

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -2936,7 +2936,6 @@ f(abc = 123)
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/40")]
         public async Task References_GrammarTest_Statements() {
             using (var server = await CreateServerAsync(PythonVersions.LatestAvailable2X)) {
                 var uri = TestData.GetDefaultModuleUri();
@@ -2992,12 +2991,19 @@ def f(abc):
                 await server.SendDidOpenTextDocument(uri, text);
 
                 var references = await server.SendFindReferences(uri, 3, 12);
+
+                // External module 'abc', URI varies depending on install
+                var externalUri = references[1].uri;
+                externalUri.LocalPath.Should().Contain("abc.py");
+ 
                 references.Should().OnlyHaveReferences(
                     (uri, (1, 6, 1, 9), ReferenceKind.Definition),
-                    (uri, (3, 11, 3, 14), ReferenceKind.Reference),
-                    (uri, (6, 22, 6, 25), ReferenceKind.Definition),
+                    (externalUri, (0, 0, 0, 0), ReferenceKind.Definition),
 
-                    (uri, (8, 4, 8, 7), ReferenceKind.Definition),
+                    (uri, (3, 11, 3, 14), ReferenceKind.Reference),
+                    (uri, (6, 22, 6, 25), ReferenceKind.Reference),
+
+                    (uri, (8, 4, 8, 7), ReferenceKind.Reference),
                     (uri, (9, 4, 9, 7), ReferenceKind.Reference),
                     (uri, (10, 4, 10, 7), ReferenceKind.Reference),
                     (uri, (11, 4, 11, 7), ReferenceKind.Reference),

--- a/src/Analysis/Engine/Test/AstAnalysisTests.cs
+++ b/src/Analysis/Engine/Test/AstAnalysisTests.cs
@@ -726,7 +726,6 @@ class BankAccount(object):
 
 
         [TestMethod, TestCategory("60s"), Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/64")]
         public async Task FullStdLibV36() {
             var v = PythonVersions.Python36 ?? PythonVersions.Python36_x64;
             await FullStdLibTest(v);


### PR DESCRIPTION
Fixes #40 

Code is pretty confusing, with reassignments and import names same as variable names. Various apps behave differently. Basically the fix is

- Keep any reference to external files as definition (so use can navigate there)
- Keep `import abc` as reference (so use can find all usages of 'abc').