### PR TITLE
mark abstract functions as such

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
@@ -109,17 +109,21 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 switch (d.Name) {
                     case "abstractmethod":
                         res = true;
+                        Function.IsAbstract = true;
                         break;
                     case "abstractstaticmethod":
                         Function.IsStatic = true;
+                        Function.IsAbstract = true;
                         res = true;
                         break;
                     case "abstractclassmethod":
                         Function.IsClassMethod = true;
+                        Function.IsAbstract = true;
                         res = true;
                         break;
                     case "abstractproperty":
                         Function.IsProperty = true;
+                        Function.IsAbstract = true;
                         res = true;
                         break;
                 }

--- a/src/Analysis/Engine/Impl/Values/Definitions/IFunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/Definitions/IFunctionInfo.cs
@@ -25,4 +25,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
         bool IsClosure { get; }
         IPythonProjectEntry ProjectEntry { get; }
     }
+
+    public interface IFunctionInfo2 : IFunctionInfo {
+        bool IsAbstract { get; }
+    }
 }

--- a/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
@@ -25,7 +25,7 @@ using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.PythonTools.Analysis.Values {
-    internal class FunctionInfo : AnalysisValue, IFunctionInfo, IHasRichDescription, IHasQualifiedName {
+    internal class FunctionInfo : AnalysisValue, IFunctionInfo2, IHasRichDescription, IHasQualifiedName {
         private Dictionary<AnalysisValue, IAnalysisSet> _methods;
         private Dictionary<string, VariableDef> _functionAttrs;
         private readonly FunctionAnalysisUnit _analysisUnit;
@@ -84,6 +84,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         public bool IsStatic { get; set; }
         public bool IsClassMethod { get; set; }
         public bool IsProperty { get; set; }
+        public bool IsAbstract { get; internal set; }
         public bool IsClosure => _callsWithClosure != null;
 
         public override IAnalysisSet Call(Node node, AnalysisUnit unit, IAnalysisSet[] args, NameExpression[] keywordArgNames) {


### PR DESCRIPTION
Adds `IsAbstract` property to `IFunctionInfo` and `FunctionInfo`, that tells if the function is abstract or not.

Note: should we consider using tri-state `bool?` here? During analysis, until all decorators are analyzed, `IsAbstract` may return `false`, when the final analysis result will be `true` (it is the case right now, as in many cases imports of `abc` are processed after functions).