### PR TITLE
Make tuples with different arguments different types

### DIFF
--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -415,7 +415,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return AnalysisSet.UnionAll(constants.Select(GetItem));
         }
 
-        public override string Name => "tuple";
+        public override string Name => "tuple[{0}]".FormatInvariant(string.Join(", ", _values.Select(v => v.GetShortDescriptions())));
 
         public override IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             if (_values.Any()) {

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -389,7 +389,9 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public TupleProtocol(ProtocolInfo self, IEnumerable<IAnalysisSet> values) : base(self, AnalysisSet.UnionAll(values)) {
             _values = values.Select(s => s.AsUnion(1)).ToArray();
-            Name = "tuple[{0}]".FormatInvariant(string.Join(", ", _values.Select(v => v.GetShortDescriptions())));
+
+            var argTypes = _values.SelectMany(e => e.Select(v => v is IHasQualifiedName qn ? qn.FullyQualifiedName : v.ShortDescription));
+            Name = "tuple[{0}]".FormatInvariant(string.Join(", ", argTypes));
         }
 
         protected override void EnsureMembers(IDictionary<string, IAnalysisSet> members) {

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -385,10 +385,11 @@ namespace Microsoft.PythonTools.Analysis.Values {
     }
 
     class TupleProtocol : IterableProtocol {
-        internal readonly IAnalysisSet[] _values;
+        private readonly IAnalysisSet[] _values;
 
         public TupleProtocol(ProtocolInfo self, IEnumerable<IAnalysisSet> values) : base(self, AnalysisSet.UnionAll(values)) {
             _values = values.Select(s => s.AsUnion(1)).ToArray();
+            Name = "tuple[{0}]".FormatInvariant(string.Join(", ", _values.Select(v => v.GetShortDescriptions())));
         }
 
         protected override void EnsureMembers(IDictionary<string, IAnalysisSet> members) {
@@ -415,7 +416,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return AnalysisSet.UnionAll(constants.Select(GetItem));
         }
 
-        public override string Name => "tuple[{0}]".FormatInvariant(string.Join(", ", _values.Select(v => v.GetShortDescriptions())));
+        public override string Name { get; }
 
         public override IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             if (_values.Any()) {


### PR DESCRIPTION
Fixes #173

Tuple protocols are compared by name which makes tuples with different types the same, which causes trouble in analysis hash set when it merges types of function parameters in overloads.