### PR TITLE
Propagate known parameter types to derived functions

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -76,3 +76,7 @@ csharp_new_line_before_finally = false
 csharp_new_line_before_members_in_anonymous_types = false
 
 csharp_new_line_before_members_in_object_initializers = false
+
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:none
+dotnet_style_qualification_for_method = false:none

--- a/src/Analysis/Engine/Impl/Analyzer/DDG.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/DDG.cs
@@ -474,7 +474,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             InterpreterScope funcScope;
             if (_unit.InterpreterScope.TryGetNodeScope(node, out funcScope)) {
                 var function = ((FunctionScope)funcScope).Function;
-                var analysisUnit = (FunctionAnalysisUnit)((FunctionScope)funcScope).Function.AnalysisUnit;
+                var analysisUnit = (FunctionAnalysisUnit)function.AnalysisUnit;
 
                 var curClass = Scope as ClassScope;
                 if (curClass != null) {
@@ -488,6 +488,10 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         foreach (var overload in method.Function.Overloads) {
                             function.UpdateDefaultParameters(_unit, overload.GetParameters());
                         }
+                    }
+
+                    foreach (var @base in bases.OfType<FunctionInfo>()) {
+                        @base.AddDerived(function);
                     }
                 }
             }

--- a/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
@@ -27,6 +27,7 @@ using Microsoft.PythonTools.Parsing.Ast;
 namespace Microsoft.PythonTools.Analysis.Values {
     internal class FunctionInfo : AnalysisValue, IFunctionInfo, IHasRichDescription, IHasQualifiedName {
         private Dictionary<AnalysisValue, IAnalysisSet> _methods;
+        private HashSet<FunctionInfo> _derived;
         private Dictionary<string, VariableDef> _functionAttrs;
         private readonly FunctionAnalysisUnit _analysisUnit;
         private ReferenceDict _references;
@@ -94,6 +95,12 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
 
             var res = DoCall(node, unit, _analysisUnit, callArgs);
+            if (_derived != null) {
+                foreach (FunctionInfo derived in _derived) {
+                    var derivedResult = derived.DoCall(node, unit, derived._analysisUnit, callArgs);
+                    res = res.Union(derivedResult);
+                }
+            }
 
             if (_callsWithClosure != null) {
                 var chain = new CallChain(node, unit, _callDepthLimit);
@@ -156,6 +163,16 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
 
             return agg;
+        }
+
+        internal bool AddDerived(FunctionInfo derived) {
+            if (derived == null) throw new ArgumentNullException(nameof(derived));
+
+            _derived = _derived ?? new HashSet<FunctionInfo>();
+
+            bool @new = _derived.Add(derived);
+            // TODO: do we need to re-queue this function analysis if a new derived was added?
+            return @new;
         }
 
         internal void AddParameterReference(Node node, AnalysisUnit unit, string name) {

--- a/src/Analysis/Engine/Test/InheritanceTests.cs
+++ b/src/Analysis/Engine/Test/InheritanceTests.cs
@@ -66,34 +66,27 @@ b = a.virt";
         }
 
         [TestMethod]
-        public async Task ParameterTypesPropagateDownAndBackUp() {
+        public async Task ParameterTypesPropagateToDerivedFunctions() {
             var code = @"
 class Baze:
   def foo(self, x):
     pass
 
-class Derived1(Baze):
+class Derived(Baze):
   def foo(self, x):
     pass
 
-class Derived2(Baze):
-  def foo(self, x):
-    pass
-
-Derived2().foo(42)
+Baze().foo(42)
 ";
 
             using (var server = await new Server().InitializeAsync(PythonVersions.Required_Python36X)) {
                 var analysis = await server.OpenDefaultDocumentAndGetAnalysisAsync(code);
 
                 // the class, for which we know parameter type initially
-                analysis.Should().HaveClass("Derived2").WithFunction("foo")
-                    .WithParameter("x").OfType(BuiltinTypeId.Int);
-                // its most base class with the same function
                 analysis.Should().HaveClass("Baze").WithFunction("foo")
                     .WithParameter("x").OfType(BuiltinTypeId.Int);
-                // all the classes, derived from the base
-                analysis.Should().HaveClass("Derived1").WithFunction("foo")
+                // its derived class
+                analysis.Should().HaveClass("Derived").WithFunction("foo")
                     .WithParameter("x").OfType(BuiltinTypeId.Int);
             }
         }


### PR DESCRIPTION
Adds a set of derived functions to `FunctionInfo`. Fills the set when `DDG` encounters a `FunctionDefinition`.

Whenever a call to some function is analyzed, it looks at the list of derived functions, and passes the call info along to them.

Also added some styles to .editorconfig

Fixes #194 .
Seems to reduce the total number of failing test cases (local run shows 32->29).

I could not understand if I needed to also requeue anything for analysis. Left a comment about it in the code.

The change might be incomplete, as the new code was not added to the case when `_callsWithClosure != null` in `FunctionInfo.Call`. I could not quickly understand that code.