### PR TITLE
Make sure tuple protocol name does not ignore unknown parameter types

### DIFF
--- a/src/Analysis/Engine/Impl/Infrastructure/Extensions/StringBuilderExtensions.cs
+++ b/src/Analysis/Engine/Impl/Infrastructure/Extensions/StringBuilderExtensions.cs
@@ -37,7 +37,15 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
             if (whiteSpaceCount > 0) {
                 sb.Append(' ', whiteSpaceCount);
             }
-            
+
+            return sb;
+        }
+
+        public static StringBuilder AppendIf(this StringBuilder sb, bool condition, string value) {
+            if (condition) {
+                sb.Append(value);
+            }
+
             return sb;
         }
     }

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -410,17 +410,12 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 return;
             }
 
-            if (sets.Length == 1) {
-                sb.Append(sets[0] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[0].ShortDescription);
-                return;
-            }
-
-            sb.Append('[');
+            sb.AppendIf(sets.Length > 1, "[");
             for (var i = 0; i < sets.Length; i++) {
                 sb.AppendIf(i > 0, ", ");
                 sb.Append(sets[i] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[i].ShortDescription);
             }
-            sb.Append(']');
+            sb.AppendIf(sets.Length > 1, "]");
         }
 
         protected override void EnsureMembers(IDictionary<string, IAnalysisSet> members) {

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -397,34 +397,30 @@ namespace Microsoft.PythonTools.Analysis.Values {
             // Enumerate manually since SelectMany drops empty/unknown values
             var sb = new StringBuilder("tuple[");
             for (var i = 0; i < _values.Length; i++) {
-                if (i > 0) {
-                    sb.Append(", ");
-                }
-                sb.Append(GetParameterString(_values[i].ToArray()));
+               sb.AppendIf(i > 0, ", ");
+               AppendParameterString(sb, _values[i].ToArray());
             }
             sb.Append(']');
             return sb.ToString();
         }
 
-        private string GetParameterString(AnalysisValue[] sets) {
+        private void AppendParameterString(StringBuilder sb, AnalysisValue[] sets) {
             if (sets.Length == 0) {
-                return "?";
+                sb.Append('?');
+                return;
             }
-            var sb = new StringBuilder();
-            if (sets.Length > 1) {
-                sb.Append('[');
+
+            if (sets.Length == 1) {
+                sb.Append(sets[0] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[0].ShortDescription);
+                return;
             }
+
+            sb.Append('[');
             for (var i = 0; i < sets.Length; i++) {
-                if (i > 0) {
-                    sb.Append(", ");
-                }
-                var desc = sets[i] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[i].ShortDescription;
-                sb.Append(desc);
+                sb.AppendIf(i > 0, ", ");
+                sb.Append(sets[i] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[i].ShortDescription);
             }
-            if (sets.Length > 1) {
-                sb.Append(']');
-            }
-            return sb.ToString();
+            sb.Append(']');
         }
 
         protected override void EnsureMembers(IDictionary<string, IAnalysisSet> members) {

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -436,7 +436,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             }
         }
 
-        protected override bool Equals(Protocol other) => 
+        protected override bool Equals(Protocol other) =>
             other is TupleProtocol tp &&
             _values.Zip(tp._values, (x, y) => x.SetEquals(y)).All(b => b);
 
@@ -523,6 +523,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         public override string Name => "dict";
+        public override BuiltinTypeId TypeId => BuiltinTypeId.Dict;
 
         public override IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             if (_valueType.Any()) {
@@ -575,14 +576,13 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         public override string Name => "generator";
-
+        public override BuiltinTypeId TypeId => BuiltinTypeId.Generator;
+        
         public IAnalysisSet Yielded => _yielded;
         public IAnalysisSet Sent { get; }
         public IAnalysisSet Returned { get; }
 
-        public override IAnalysisSet GetReturnForYieldFrom(Node node, AnalysisUnit unit) {
-            return Returned;
-        }
+        public override IAnalysisSet GetReturnForYieldFrom(Node node, AnalysisUnit unit) => Returned;
 
         public override IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             if (_yielded.Any() || Sent.Any() || Returned.Any()) {

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -389,9 +389,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public TupleProtocol(ProtocolInfo self, IEnumerable<IAnalysisSet> values) : base(self, AnalysisSet.UnionAll(values)) {
             _values = values.Select(s => s.AsUnion(1)).ToArray();
-
-            var argTypes = _values.SelectMany(e => e.Select(v => v is IHasQualifiedName qn ? qn.FullyQualifiedName : v.ShortDescription));
-            Name = "tuple[{0}]".FormatInvariant(string.Join(", ", argTypes));
+            Name = "tuple[{0}]".FormatInvariant(string.Join(", ", _values.Select(v => v.GetShortDescriptions())));
         }
 
         protected override void EnsureMembers(IDictionary<string, IAnalysisSet> members) {
@@ -419,6 +417,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
         }
 
         public override string Name { get; }
+        public override BuiltinTypeId TypeId => BuiltinTypeId.Tuple;
 
         public override IEnumerable<KeyValuePair<string, string>> GetRichDescription() {
             if (_values.Any()) {


### PR DESCRIPTION
Additional fix for https://github.com/Microsoft/python-language-server/issues/173 since 'SelectMany' drops empty sequences and tuples lose arguments of unknown type making them look like they have fewer arguments.