### PR TITLE
Fix function override completion test

### DIFF
--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -438,7 +438,7 @@ namespace AnalysisTests {
 
                 await AssertNoCompletion(s, u, new SourceLocation(2, 9));
                 await AssertCompletion(s, u, 
-                    new[] { "bar(arg=None):\r\n    return super(B, arg).bar()" }, 
+                    new[] { "bar(arg=None):\r\n    return super().bar()" },
                     new[] { "bar(arg = None):\r\n    return super().bar()" }, 
                     new SourceLocation(5, 10));
             }


### PR DESCRIPTION
Bisected the failing `CompletionForOverrideArgs` test back to #176. `super()` shouldn't be getting called with args here.