### PR TITLE
Fix function override completion test, improve behavior

### DIFF
--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -442,7 +442,7 @@ class B(A):
     def f";
 
             using (var s = await CreateServer()) {
-                var u = await AddModule(s, code);
+                var u = await s.OpenDefaultDocumentAndGetUriAsync(code);
 
                 await AssertNoCompletion(s, u, new SourceLocation(3, 9));
 


### PR DESCRIPTION
Fixes #236.

This also improves the completed override function by not repeating default values, instead referring to parameters directly.

Old behavior:

![old](https://user-images.githubusercontent.com/5341706/46824009-93721e80-cd44-11e8-844e-4c49eb67ffd1.gif)

New behavior:

![new](https://user-images.githubusercontent.com/5341706/46824012-953be200-cd44-11e8-98e3-5d9af24b84d4.gif)

This also removes the "safe" check for variable names, as I think all it seems to actually do is prevent non-ASCII identifiers from working (which are [allowed in Python 3](https://docs.python.org/3/reference/lexical_analysis.html#identifiers)).