### PR TITLE
Remove or disable bad diagnostics for now

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
@@ -153,10 +153,6 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         warn = true;
                     }
                 }
-            } else if (!res.Any() && !refs.IsAssigned) {
-                // Variable has no values, so if we also don't know about any
-                // definitions then warn.
-                warn = true;
             }
 
             if (addDependency && refs != null) {

--- a/src/Analysis/Engine/Impl/Values/InstanceInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/InstanceInfo.cs
@@ -122,13 +122,16 @@ namespace Microsoft.PythonTools.Analysis.Values {
                     if (callRes.Any()) {
                         res = res.Union(callRes.Call(node, unit, args, keywordArgNames));
                     } else {
-                        unit.State.AddDiagnostic(
-                            (node as CallExpression)?.Target ?? node,
-                            unit,
-                            ErrorMessages.NotCallable(ClassInfo?.ShortDescription),
-                            DiagnosticSeverity.Warning,
-                            ErrorMessages.NotCallableCode
-                        );
+                        // This diagnostic is very noisy in a lot of cases where the analyzer
+                        // can't prove that something is actually callable. Let's not add this
+                        // diagnostic until we can properly collect and filter these warnings.
+                        // unit.State.AddDiagnostic(
+                        //     (node as CallExpression)?.Target ?? node,
+                        //     unit,
+                        //     ErrorMessages.NotCallable(ClassInfo?.ShortDescription),
+                        //     DiagnosticSeverity.Warning,
+                        //     ErrorMessages.NotCallableCode
+                        // );
                     }
                 } finally {
                     Pop();


### PR DESCRIPTION
Fixes #263.
Updates #242.

This PR removes an incorrect check for undeclared variables, and disables (for now) the messages when the analyzer isn't certain something is callable.

In a future change to help with #242 and #19, these sorts of checks won't directly add a diagnostic to be displayed in the editor, instead adding them in with the other analysis to then be filtered/displayed and have code actions related to them.

Note that this has no visible change, as the diagnostics don't have any tests associated with them, nor are they visible to users since VS Code doesn't send `python.liveLinting` in the capabilities. We'll update this in the future to deal with editor settings/pylintrc/etc.