### PR TITLE
Clean Python versions in tests

### DIFF
--- a/src/Analysis/Engine/Impl/Parsing/PythonLanguageVersion.cs
+++ b/src/Analysis/Engine/Impl/Parsing/PythonLanguageVersion.cs
@@ -36,7 +36,8 @@ namespace Microsoft.PythonTools.Parsing {
         V34 = 0x0304,
         V35 = 0x0305,
         V36 = 0x0306,
-        V37 = 0x0307
+        V37 = 0x0307,
+        V38 = 0x0308
     }
 
     public static class PythonLanguageVersionExtensions {

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -1286,8 +1286,10 @@ b = next(a)
 
 
         [DataRow(PythonLanguageVersion.V27)]
-        [DataRow(PythonLanguageVersion.V33)]
+        [DataRow(PythonLanguageVersion.V35)]
         [DataRow(PythonLanguageVersion.V36)]
+        [DataRow(PythonLanguageVersion.V37)]
+        [DataRow(PythonLanguageVersion.V38)]
         [DataTestMethod, Priority(0)]
         public async Task LambdaInComprehension(PythonLanguageVersion version) {
             var text = "x = [(lambda a:[a**i for i in range(a+1)])(j) for j in range(5)]";

--- a/src/Analysis/Engine/Test/AstAnalysisTests.cs
+++ b/src/Analysis/Engine/Test/AstAnalysisTests.cs
@@ -525,22 +525,7 @@ class BankAccount(object):
         public void AstBuiltinScrapeV35() => AstBuiltinScrape(PythonVersions.Python35_x64 ?? PythonVersions.Python35);
 
         [TestMethod, Priority(0)]
-        public void AstBuiltinScrapeV34() => AstBuiltinScrape(PythonVersions.Python34_x64 ?? PythonVersions.Python34);
-
-        [TestMethod, Priority(0)]
-        public void AstBuiltinScrapeV33() => AstBuiltinScrape(PythonVersions.Python33_x64 ?? PythonVersions.Python33);
-
-        [TestMethod, Priority(0)]
-        public void AstBuiltinScrapeV32() => AstBuiltinScrape(PythonVersions.Python32_x64 ?? PythonVersions.Python32);
-
-        [TestMethod, Priority(0)]
-        public void AstBuiltinScrapeV31() => AstBuiltinScrape(PythonVersions.Python31_x64 ?? PythonVersions.Python31);
-
-        [TestMethod, Priority(0)]
         public void AstBuiltinScrapeV27() => AstBuiltinScrape(PythonVersions.Python27_x64 ?? PythonVersions.Python27);
-
-        [TestMethod, Priority(0)]
-        public void AstBuiltinScrapeV26() => AstBuiltinScrape(PythonVersions.Python26_x64 ?? PythonVersions.Python26);
 
         [TestMethod, Priority(0)]
         public void AstBuiltinScrapeIPy27() => AstBuiltinScrape(PythonVersions.IronPython27_x64 ?? PythonVersions.IronPython27);
@@ -601,6 +586,9 @@ class BankAccount(object):
         }
 
         [TestMethod, Priority(0)]
+        public void AstNativeBuiltinScrapeV38x64() => AstNativeBuiltinScrape(PythonVersions.Python38_x64);
+
+        [TestMethod, Priority(0)]
         public void AstNativeBuiltinScrapeV37x64() => AstNativeBuiltinScrape(PythonVersions.Python37_x64);
 
         [TestMethod, Priority(0)]
@@ -610,22 +598,10 @@ class BankAccount(object):
         public void AstNativeBuiltinScrapeV35x64() => AstNativeBuiltinScrape(PythonVersions.Python35_x64);
 
         [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV34x64() => AstNativeBuiltinScrape(PythonVersions.Python34_x64);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV33x64() => AstNativeBuiltinScrape(PythonVersions.Python33_x64);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV32x64() => AstNativeBuiltinScrape(PythonVersions.Python32_x64);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV31x64() => AstNativeBuiltinScrape(PythonVersions.Python31_x64);
-
-        [TestMethod, Priority(0)]
         public void AstNativeBuiltinScrapeV27x64() => AstNativeBuiltinScrape(PythonVersions.Python27_x64);
 
         [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV26x64() => AstNativeBuiltinScrape(PythonVersions.Python26_x64);
+        public void AstNativeBuiltinScrapeV38x86() => AstNativeBuiltinScrape(PythonVersions.Python38);
 
         [TestMethod, Priority(0)]
         public void AstNativeBuiltinScrapeV37x86() => AstNativeBuiltinScrape(PythonVersions.Python37);
@@ -636,24 +612,9 @@ class BankAccount(object):
         [TestMethod, Priority(0)]
         public void AstNativeBuiltinScrapeV35x86() => AstNativeBuiltinScrape(PythonVersions.Python35);
 
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV34x86() => AstNativeBuiltinScrape(PythonVersions.Python34);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV33x86() => AstNativeBuiltinScrape(PythonVersions.Python33);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV32x86() => AstNativeBuiltinScrape(PythonVersions.Python32);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV31x86() => AstNativeBuiltinScrape(PythonVersions.Python31);
 
         [TestMethod, Priority(0)]
         public void AstNativeBuiltinScrapeV27x86() => AstNativeBuiltinScrape(PythonVersions.Python27);
-
-        [TestMethod, Priority(0)]
-        public void AstNativeBuiltinScrapeV26x86() => AstNativeBuiltinScrape(PythonVersions.Python26);
-
 
         private void AstNativeBuiltinScrape(InterpreterConfiguration configuration) {
             configuration.AssertInstalled();
@@ -720,6 +681,12 @@ class BankAccount(object):
         }
 
         [TestMethod, TestCategory("60s"), Priority(0)]
+        public async Task FullStdLibV38() {
+            var v = PythonVersions.Python38 ?? PythonVersions.Python38_x64;
+            await FullStdLibTest(v);
+        }
+
+        [TestMethod, TestCategory("60s"), Priority(0)]
         public async Task FullStdLibV37() {
             var v = PythonVersions.Python37 ?? PythonVersions.Python37_x64;
             await FullStdLibTest(v);
@@ -740,38 +707,8 @@ class BankAccount(object):
         }
 
         [TestMethod, TestCategory("60s"), Priority(0)]
-        public async Task FullStdLibV34() {
-            var v = PythonVersions.Python34 ?? PythonVersions.Python34_x64;
-            await FullStdLibTest(v);
-        }
-
-        [TestMethod, TestCategory("60s"), Priority(0)]
-        public async Task FullStdLibV33() {
-            var v = PythonVersions.Python33 ?? PythonVersions.Python33_x64;
-            await FullStdLibTest(v);
-        }
-
-        [TestMethod, TestCategory("60s"), Priority(0)]
-        public async Task FullStdLibV32() {
-            var v = PythonVersions.Python31 ?? PythonVersions.Python32_x64;
-            await FullStdLibTest(v);
-        }
-
-        [TestMethod, TestCategory("60s"), Priority(0)]
-        public async Task FullStdLibV31() {
-            var v = PythonVersions.Python31 ?? PythonVersions.Python32_x64;
-            await FullStdLibTest(v);
-        }
-
-        [TestMethod, TestCategory("60s"), Priority(0)]
         public async Task FullStdLibV27() {
             var v = PythonVersions.Python27 ?? PythonVersions.Python27_x64;
-            await FullStdLibTest(v);
-        }
-
-        [TestMethod, TestCategory("60s"), Priority(0)]
-        public async Task FullStdLibV26() {
-            var v = PythonVersions.Python26 ?? PythonVersions.Python26_x64;
             await FullStdLibTest(v);
         }
 

--- a/src/Analysis/Engine/Test/MutateStdLibTest.cs
+++ b/src/Analysis/Engine/Test/MutateStdLibTest.cs
@@ -35,38 +35,8 @@ namespace AnalysisTests {
 
         [TestMethod, Priority(2)]
         [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV26() {
-            TestMutateStdLib(PythonVersions.Python26_x64 ?? PythonVersions.Python26);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
         public void TestMutateStdLibV27() {
             TestMutateStdLib(PythonVersions.Python27_x64 ?? PythonVersions.Python27);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV31() {
-            TestMutateStdLib(PythonVersions.Python31_x64 ?? PythonVersions.Python31);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV32() {
-            TestMutateStdLib(PythonVersions.Python32_x64 ?? PythonVersions.Python32);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV33() {
-            TestMutateStdLib(PythonVersions.Python33_x64 ?? PythonVersions.Python33);
-        }
-
-        [TestMethod, Priority(2)]
-        [TestCategory("10s"), TestCategory("60s")]
-        public void TestMutateStdLibV34() {
-            TestMutateStdLib(PythonVersions.Python34_x64 ?? PythonVersions.Python34);
         }
 
         [TestMethod, Priority(2)]
@@ -79,6 +49,18 @@ namespace AnalysisTests {
         [TestCategory("10s"), TestCategory("60s")]
         public void TestMutateStdLibV36() {
             TestMutateStdLib(PythonVersions.Python36_x64 ?? PythonVersions.Python36);
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("10s"), TestCategory("60s")]
+        public void TestMutateStdLibV37() {
+            TestMutateStdLib(PythonVersions.Python37_x64 ?? PythonVersions.Python37);
+        }
+
+        [TestMethod, Priority(2)]
+        [TestCategory("10s"), TestCategory("60s")]
+        public void TestMutateStdLibV38() {
+            TestMutateStdLib(PythonVersions.Python38_x64 ?? PythonVersions.Python38);
         }
 
         private void TestMutateStdLib(InterpreterConfiguration configuration) {

--- a/src/Analysis/Engine/Test/PythonVersions.cs
+++ b/src/Analysis/Engine/Test/PythonVersions.cs
@@ -23,25 +23,17 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.PythonTools.Analysis {
     public static class PythonVersions {
-        public static readonly InterpreterConfiguration Python26 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration Python27 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x86);
-        public static readonly InterpreterConfiguration Python31 = GetCPythonVersion(PythonLanguageVersion.V31, InterpreterArchitecture.x86);
-        public static readonly InterpreterConfiguration Python32 = GetCPythonVersion(PythonLanguageVersion.V32, InterpreterArchitecture.x86);
-        public static readonly InterpreterConfiguration Python33 = GetCPythonVersion(PythonLanguageVersion.V33, InterpreterArchitecture.x86);
-        public static readonly InterpreterConfiguration Python34 = GetCPythonVersion(PythonLanguageVersion.V34, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration Python35 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration Python36 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration Python37 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x86);
+        public static readonly InterpreterConfiguration Python38 = GetCPythonVersion(PythonLanguageVersion.V38, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration IronPython27 = GetIronPythonVersion(false);
-        public static readonly InterpreterConfiguration Python26_x64 = GetCPythonVersion(PythonLanguageVersion.V26, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Python27_x64 = GetCPythonVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
-        public static readonly InterpreterConfiguration Python31_x64 = GetCPythonVersion(PythonLanguageVersion.V31, InterpreterArchitecture.x64);
-        public static readonly InterpreterConfiguration Python32_x64 = GetCPythonVersion(PythonLanguageVersion.V32, InterpreterArchitecture.x64);
-        public static readonly InterpreterConfiguration Python33_x64 = GetCPythonVersion(PythonLanguageVersion.V33, InterpreterArchitecture.x64);
-        public static readonly InterpreterConfiguration Python34_x64 = GetCPythonVersion(PythonLanguageVersion.V34, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Python35_x64 = GetCPythonVersion(PythonLanguageVersion.V35, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Python36_x64 = GetCPythonVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Python37_x64 = GetCPythonVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x64);
+        public static readonly InterpreterConfiguration Python38_x64 = GetCPythonVersion(PythonLanguageVersion.V38, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Anaconda27 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration Anaconda27_x64 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Anaconda36 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
@@ -56,101 +48,72 @@ namespace Microsoft.PythonTools.Analysis {
             Anaconda27_x64);
 
         public static IEnumerable<InterpreterConfiguration> Versions => GetVersions(
-            Python26,
-            Python26_x64,
             Python27,
             Python27_x64,
             IronPython27,
             IronPython27_x64,
-            Python31,
-            Python31_x64,
-            Python32,
-            Python32_x64,
-            Python33,
-            Python33_x64,
-            Python34,
-            Python34_x64,
             Python35,
             Python35_x64,
             Python36,
             Python36_x64,
             Python37,
             Python37_x64,
-            Jython27);
+            Python38,
+            Python38_x64, Jython27);
 
         public static InterpreterConfiguration Required_Python27X => Python27 ?? Python27_x64 ?? NotInstalled("v2.7");
-        public static InterpreterConfiguration Required_Python31X => Python31 ?? Python31_x64 ?? NotInstalled("v3.1");
-        public static InterpreterConfiguration Required_Python32X => Python32 ?? Python32_x64 ?? NotInstalled("v3.2");
-        public static InterpreterConfiguration Required_Python33X => Python33 ?? Python33_x64 ?? NotInstalled("v3.3");
-        public static InterpreterConfiguration Required_Python34X => Python34 ?? Python34_x64 ?? NotInstalled("v3.4");
         public static InterpreterConfiguration Required_Python35X => Python35 ?? Python35_x64 ?? NotInstalled("v3.5");
         public static InterpreterConfiguration Required_Python36X => Python36 ?? Python36_x64 ?? NotInstalled("v3.6");
+        public static InterpreterConfiguration Required_Python37X => Python37 ?? Python37_x64 ?? NotInstalled("v3.7");
+        public static InterpreterConfiguration Required_Python38X => Python38 ?? Python38_x64 ?? NotInstalled("v3.8");
 
         public static InterpreterConfiguration LatestAvailable => LatestAvailable3X ?? LatestAvailable2X;
 
         public static InterpreterConfiguration LatestAvailable3X => GetVersions(
+            Python38,
+            Python38_x64,
             Python37,
             Python37_x64,
             Python36,
             Python36_x64,
             Python35,
-            Python35_x64,
-            Python34,
-            Python34_x64,
-            Python33,
-            Python33_x64,
-            Python32,
-            Python32_x64,
-            Python31,
-            Python31_x64).FirstOrDefault() ?? NotInstalled("v3");
+            Python35_x64).FirstOrDefault() ?? NotInstalled("v3");
 
         public static InterpreterConfiguration LatestAvailable2X => GetVersions(
             Python27,
-            Python27_x64,
-            Python26,
-            Python26_x64).FirstOrDefault() ?? NotInstalled("v2");
+            Python27_x64).FirstOrDefault() ?? NotInstalled("v2");
 
         public static InterpreterConfiguration EarliestAvailable => EarliestAvailable2X ?? EarliestAvailable3X;
 
         public static InterpreterConfiguration EarliestAvailable3X => GetVersions(
-            Python31,
-            Python31_x64,
-            Python32,
-            Python32_x64,
-            Python33,
-            Python33_x64,
-            Python34,
-            Python34_x64,
             Python35,
             Python35_x64,
             Python36,
             Python36_x64,
             Python37,
-            Python37_x64).FirstOrDefault() ?? NotInstalled("v3");
+            Python37_x64,
+            Python38,
+            Python38_x64).FirstOrDefault() ?? NotInstalled("v3");
 
         public static InterpreterConfiguration EarliestAvailable2X => GetVersions(
-            Python26,
-            Python26_x64,
             Python27,
             Python27_x64).FirstOrDefault() ?? NotInstalled("v2");
 
-        public static InterpreterConfiguration GetRequiredCPythonConfiguration(PythonLanguageVersion version) 
+        public static InterpreterConfiguration GetRequiredCPythonConfiguration(PythonLanguageVersion version)
             => GetCPythonVersion(version, InterpreterArchitecture.x86) ?? GetCPythonVersion(version, InterpreterArchitecture.x64) ?? NotInstalled(version.ToString());
 
         private static IEnumerable<InterpreterConfiguration> GetVersions(params InterpreterConfiguration[] configurations) => configurations.Where(v => v != null);
 
-        private static InterpreterConfiguration GetCPythonVersion(PythonLanguageVersion version, InterpreterArchitecture arch) {            
-            return PythonInstallPathResolver.Instance.GetCorePythonConfiguration(arch, version.ToVersion());
-        }
-        
-        private static InterpreterConfiguration GetAnacondaVersion(PythonLanguageVersion version, InterpreterArchitecture arch) {
-            return PythonInstallPathResolver.Instance.GetCondaPythonConfiguration(arch, version.ToVersion());
-        }
-        
+        private static InterpreterConfiguration GetCPythonVersion(PythonLanguageVersion version, InterpreterArchitecture arch)
+            => PythonInstallPathResolver.Instance.GetCorePythonConfiguration(arch, version.ToVersion());
+
+        private static InterpreterConfiguration GetAnacondaVersion(PythonLanguageVersion version, InterpreterArchitecture arch)
+            => PythonInstallPathResolver.Instance.GetCondaPythonConfiguration(arch, version.ToVersion());
+
         private static InterpreterConfiguration GetIronPythonVersion(bool x64) {
             return PythonInstallPathResolver.Instance.GetIronPythonConfiguration(x64);
         }
-        
+
         private static InterpreterConfiguration GetJythonVersion(PythonLanguageVersion version) {
             var candidates = new List<DirectoryInfo>();
             var ver = version.ToVersion();


### PR DESCRIPTION
Fixes #268

- Add 3.7 and 3.8 to available versions
- Add 3.7 and 3.8 to the full std library test
- Remove tests dedicated to 3.1 - 3.4

