### PR TITLE
[WIP] Wrap all RPC methods with exception logging

### DIFF
--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         [JsonRpcMethod("workspace/executeCommand")]
         public Task<object> ExecuteCommand(JToken token, CancellationToken cancellationToken) => LogOnException(() =>
             _server.ExecuteCommand(ToObject<ExecuteCommandParams>(token), cancellationToken)
-        )
+        );
         #endregion
 
         #region TextDocument
@@ -197,7 +197,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             using (await _prioritizer.DocumentChangePriorityAsync(cancellationToken)) {
                 await _server.DidOpenTextDocument(ToObject<DidOpenTextDocumentParams>(token), cancellationToken);
             }
-        })
+        });
 
         [JsonRpcMethod("textDocument/didChange")]
         public Task DidChangeTextDocument(JToken token, CancellationToken cancellationToken) => LogOnException(async () => {
@@ -291,7 +291,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         [JsonRpcMethod("completionItem/resolve")]
         public Task<CompletionItem> CompletionItemResolve(JToken token, CancellationToken cancellationToken) => LogOnException(() =>
-            _server.CompletionItemResolve(ToObject<CompletionItem>(token), cancellationToken);
+            _server.CompletionItemResolve(ToObject<CompletionItem>(token), cancellationToken)
         );
 
         [JsonRpcMethod("textDocument/hover")]

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -464,7 +464,9 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             try {
                 await func();
             } catch (Exception e) {
-                _server.LogMessage(MessageType.Error, e.ToString());
+                if (!(e is TaskCanceledException)) {
+                    _server.LogMessage(MessageType.Error, e.ToString());
+                }
                 throw;
             }
         }

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -464,9 +464,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             try {
                 await func();
             } catch (Exception e) {
-                if (!(e is TaskCanceledException)) {
-                    _server.LogMessage(MessageType.Error, e.ToString());
-                }
+                LogUnexpectedException(e);
                 throw;
             }
         }
@@ -475,9 +473,19 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             try {
                 return await func();
             } catch (Exception e) {
-                _server.LogMessage(MessageType.Error, e.ToString());
+                LogUnexpectedException(e);
                 throw;
             }
+        }
+
+        private void LogUnexpectedException(Exception e) {
+            switch (e) {
+                case TaskCanceledException _:
+                case OperationCanceledException _:
+                    return;
+            }
+
+            _server.LogMessage(MessageType.Error, e.ToString());
         }
 
         private class Prioritizer : IDisposable {


### PR DESCRIPTION
Adding this PR to get some feedback (do not merge). Leading into #246.

Right now, any exceptions thrown while handing an RPC method bubble back up to the RPC. They're encoded as a standard JSON RPC error message, which the editor does print. However, the RPC library we use only gives `Exception.Message` directly, instead supplying the stack trace in the RPC error's `data` member, which VS Code does _not_ print. This leads to not-so-helpful errors like #23 which only show the message text and nothing else.

My first attempt subclassed `JsonRpc` to override the methods that invoke the different handlers, but sending logs/telemetry is also RPC that calls those methods, which means that reporting anything led to infinite recursion, so I threw that away.

Instead, I've written a function `LogOnException` which each function with attribute `JsonRpcMethod` calls manually. Exceptions are captured, sent back over RPC as an error, then rethrown as to not change the overall code flow. I have not included actual telemetry calls until I figure out the right schema for the object to send, and what information to omit.

Example before, if I just throw an exception from LineFormatter:

```
[Error - 1:06:46 PM] Request textDocument/onTypeFormatting failed.
  Message: this is a test
  Code: -32000 
[object Object]
```

And what this code shows:

```
[Error - 1:06:46 PM] System.Exception: this is a test
   at Microsoft.Python.LanguageServer.Implementation.LineFormatter.FormatLine(Int32 line) in C:\Users\jabaile\python-language-server\src\LanguageServer\Impl\Implementation\LineFormatter.cs:line 102
   at Microsoft.Python.LanguageServer.Implementation.Server.DocumentOnTypeFormatting(DocumentOnTypeFormattingParams params, CancellationToken cancellationToken) in C:\Users\jabaile\python-language-server\src\LanguageServer\Impl\Implementation\Server.OnTypeFormatting.cs:line 52
   at Microsoft.Python.LanguageServer.Implementation.LanguageServer.<>c__DisplayClass54_0.<<DocumentOnTypeFormatting>b__0>d.MoveNext() in C:\Users\jabaile\python-language-server\src\LanguageServer\Impl\LanguageServer.cs:line 371
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Python.LanguageServer.Implementation.LanguageServer.LogOnException[TResult](Func`1 func) in C:\Users\jabaile\python-language-server\src\LanguageServer\Impl\LanguageServer.cs:line 458
[Error - 1:06:46 PM] Request textDocument/onTypeFormatting failed.
  Message: this is a test
  Code: -32000 
[object Object]
```

Any thoughts on this?