### PR TITLE
Added an option to propagate parameter types to base methods

### DIFF
--- a/src/Analysis/Engine/Impl/AnalysisLimits.cs
+++ b/src/Analysis/Engine/Impl/AnalysisLimits.cs
@@ -181,6 +181,12 @@ namespace Microsoft.PythonTools.Analysis {
         public bool ProcessCustomDecorators { get; set; }
 
         /// <summary>
+        /// <c>True</c> to propagate parameter types to base methods.
+        /// Parameter types always propagate to derived methods.
+        /// </summary>
+        public bool PropagateParameterTypeToBaseMethods { get; set; }
+
+        /// <summary>
         /// True to read information from type stub packages.
         /// </summary>
         public bool UseTypeStubPackages { get; set; }

--- a/src/Analysis/Engine/Impl/Analyzer/DDG.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/DDG.cs
@@ -454,7 +454,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             return false;
         }
 
-        internal List<AnalysisValue> LookupBaseMethods(string name, IEnumerable<IAnalysisSet> mro, Node node, AnalysisUnit unit) {
+        internal static List<AnalysisValue> LookupBaseMethods(string name, IEnumerable<IAnalysisSet> mro, Node node, AnalysisUnit unit) {
             var result = new List<AnalysisValue>();
             foreach (var @class in mro.Skip(1)) {
                 foreach (var curType in @class) {

--- a/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/FunctionInfo.cs
@@ -103,6 +103,14 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 }
             }
 
+            if (_analysisUnit.State.Limits.PropagateParameterTypeToBaseMethods
+                && _analysisUnit.Scope.OuterScope is ClassScope parentClass) {
+                var baseMethods = DDG.LookupBaseMethods(Name, parentClass.Class.Mro, AnalysisUnit.Ast, AnalysisUnit);
+                foreach (FunctionInfo baseMethod in baseMethods.OfType<FunctionInfo>()) {
+                    baseMethod.DoCall(node, unit, baseMethod._analysisUnit, callArgs);
+                }
+            }
+
             if (_callsWithClosure != null) {
                 var chain = new CallChain(node, unit, _callDepthLimit);
                 var aggregate = GetAggregate(unit);


### PR DESCRIPTION
It is similar #194, in that the same types parameter types might be OK for base methods. It could happen when we just don't have any examples in the current code, that would give that kind of information to analyzer.

By default set to `false` to keep conservative behavior.

```python
class Base:
  def foo(x):
    ...

class Derived(Base):
  def foo(x):
    ...

Derived().foo(42)

# Base().foo(42) is actually also called, but not in this project
```