### PR TITLE
Fix ApplicableSpan calculation

### DIFF
--- a/src/Analysis/Engine/Test/CompletionTests.cs
+++ b/src/Analysis/Engine/Test/CompletionTests.cs
@@ -1003,6 +1003,15 @@ class Simple(unittest.TestCase):
             }
         }
 
+        [TestMethod, Priority(0)]
+        public async Task WithWhitespaceAroundDot() {
+            using (var s = await CreateServerAsync()) {
+                var u = await s.OpenDefaultDocumentAndGetUriAsync("import sys\nsys  .  version\n");
+                await AssertCompletion(s, u, new[] { "argv" }, null, new SourceLocation(2, 7), 
+                    new CompletionContext { triggerCharacter = ".", triggerKind = CompletionTriggerKind.TriggerCharacter });
+            }
+        }
+
         private static async Task AssertCompletion(Server s, Uri uri, IReadOnlyCollection<string> contains, IReadOnlyCollection<string> excludes, Position? position = null, CompletionContext? context = null, Func<CompletionItem, string> cmpKey = null, string expr = null, Range? applicableSpan = null) {
             await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
             var res = await s.Completion(new CompletionParams {

--- a/src/LanguageServer/Impl/Implementation/Server.Completion.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Completion.cs
@@ -22,14 +22,11 @@ using System.Threading.Tasks;
 using Microsoft.Python.LanguageServer.Extensions;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Analysis;
-using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Parsing;
 using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Implementation {
     public sealed partial class Server {
-        private static CompletionList EmptyCompletion = new CompletionList();
-
         public override async Task<CompletionList> Completion(CompletionParams @params, CancellationToken cancellationToken) {
             var uri = @params.textDocument.uri;
 
@@ -40,7 +37,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             var analysis = entry != null ? await entry.GetAnalysisAsync(50, cancellationToken) : null;
             if (analysis == null) {
                 TraceMessage($"No analysis found for {uri}");
-                return EmptyCompletion;
+                return new CompletionList();
             }
 
             var opts = GetOptions(@params.context);
@@ -52,7 +49,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             if (members == null) {
                 TraceMessage($"No completions at {@params.position} in {uri}");
-                return EmptyCompletion;
+                return new CompletionList();
             }
 
             if (!Settings.completion.showAdvancedMembers) {


### PR DESCRIPTION
Fixes #23 

- With whitespace surrounding dot span of the expression can be to the right of the dot. Adjust span accordingly.
- Add test for the case (reproes only when completion context is supplied)