### PR TITLE
Improve diagnostic generation/handling, enable diagnostics with setting

### DIFF
--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -618,10 +618,6 @@ namespace Microsoft.PythonTools.Analysis {
         public bool EnableDiagnostics { get; set; }
 
         public void AddDiagnostic(Node node, AnalysisUnit unit, string message, DiagnosticSeverity severity, string code = null) {
-            if (!EnableDiagnostics) {
-                return;
-            }
-
             lock (_diagnostics) {
                 if (!_diagnostics.TryGetValue(unit.ProjectEntry, out var diags)) {
                     _diagnostics[unit.ProjectEntry] = diags = new Dictionary<Node, Diagnostic>();
@@ -656,10 +652,6 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         public void ClearDiagnostic(Node node, AnalysisUnit unit, string code = null) {
-            if (!EnableDiagnostics) {
-                return;
-            }
-
             lock (_diagnostics) {
                 if (_diagnostics.TryGetValue(unit.ProjectEntry, out var diags) && diags.TryGetValue(node, out var d)) {
                     if (code == null || d.code == code) {

--- a/src/LanguageServer/Impl/Definitions/ServerSettings.cs
+++ b/src/LanguageServer/Impl/Definitions/ServerSettings.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Python.LanguageServer {
             public int symbolsHierarchyDepthLimit = 10;
             public int symbolsHierarchyMaxSymbols = 1000;
 
-            public string[] errors { get; } = Array.Empty<string>();
-            public string[] warnings { get; } = Array.Empty<string>();
-            public string[] information { get; } = Array.Empty<string>();
-            public string[] disabled { get; } = Array.Empty<string>();
+            public string[] errors { get; private set; } = Array.Empty<string>();
+            public string[] warnings { get; private set; } = Array.Empty<string>();
+            public string[] information { get; private set; } = Array.Empty<string>();
+            public string[] disabled { get; private set; } = Array.Empty<string>();
 
             public DiagnosticSeverity GetEffectiveSeverity(string code, DiagnosticSeverity defaultSeverity)
                 => _map.TryGetValue(code, out var severity) ? severity : defaultSeverity;
@@ -50,6 +50,11 @@ namespace Microsoft.Python.LanguageServer {
                 foreach (var x in disabled) {
                     _map[x] = DiagnosticSeverity.Unspecified;
                 }
+
+                this.errors = errors;
+                this.warnings = warnings;
+                this.information = information;
+                this.disabled = disabled;
             }
         }
         public readonly PythonAnalysisOptions analysis = new PythonAnalysisOptions();

--- a/src/LanguageServer/Impl/Definitions/ServerSettings.cs
+++ b/src/LanguageServer/Impl/Definitions/ServerSettings.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Python.LanguageServer {
             public int symbolsHierarchyDepthLimit = 10;
             public int symbolsHierarchyMaxSymbols = 1000;
 
+            public bool diagnostics;
+
             public string[] errors { get; private set; } = Array.Empty<string>();
             public string[] warnings { get; private set; } = Array.Empty<string>();
             public string[] information { get; private set; } = Array.Empty<string>();

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -696,12 +696,8 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 return true;
             }
 
-            if (newSettings.analysis.openFilesOnly != oldSettings.analysis.openFilesOnly) {
-                _editorFiles.UpdateDiagnostics();
-                return false;
-            }
-
-            if (!newSettings.analysis.errors.SetEquals(oldSettings.analysis.errors) ||
+            if (newSettings.analysis.openFilesOnly != oldSettings.analysis.openFilesOnly ||
+                !newSettings.analysis.errors.SetEquals(oldSettings.analysis.errors) ||
                 !newSettings.analysis.warnings.SetEquals(oldSettings.analysis.warnings) ||
                 !newSettings.analysis.information.SetEquals(oldSettings.analysis.information) ||
                 !newSettings.analysis.disabled.SetEquals(oldSettings.analysis.disabled)) {

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -250,6 +250,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             var reanalyze = true;
             if (@params.settings != null) {
                 if (@params.settings is ServerSettings settings) {
+                    Analyzer.EnableDiagnostics = settings.analysis.diagnostics;
                     reanalyze = HandleConfigurationChanges(settings);
                 } else {
                     LogMessage(MessageType.Error, "change configuration notification sent unsupported settings");
@@ -700,7 +701,8 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 !newSettings.analysis.errors.SetEquals(oldSettings.analysis.errors) ||
                 !newSettings.analysis.warnings.SetEquals(oldSettings.analysis.warnings) ||
                 !newSettings.analysis.information.SetEquals(oldSettings.analysis.information) ||
-                !newSettings.analysis.disabled.SetEquals(oldSettings.analysis.disabled)) {
+                !newSettings.analysis.disabled.SetEquals(oldSettings.analysis.disabled) ||
+                newSettings.analysis.diagnostics != oldSettings.analysis.diagnostics) {
                 _editorFiles.UpdateDiagnostics();
             }
 

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -14,17 +14,17 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.LanguageServer.Services;
 using Microsoft.PythonTools.Analysis;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Python.LanguageServer.Implementation {
     /// <summary>
@@ -424,15 +424,15 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
                 if (_server.Settings.analysis.diagnostics) {
                     diagnostics = kvp.Value
-                    .Select(d => new Diagnostic {  // Copy the diagnostic so we aren't just modifying the severity for everyone who has access.
-                        range = d.range,
-                        severity = _server.Settings.analysis.GetEffectiveSeverity(d.code, d.severity),
-                        code = d.code,
-                        source = d.source,
-                        message = d.message,
-                    })
-                    .Where(d => d.severity != DiagnosticSeverity.Unspecified) // Don't send unspecified/disabled diagnostics.
-                    .ToArray();
+                        .Select(d => new Diagnostic {  // Copy the diagnostic so we aren't just modifying the severity for everyone who has access.
+                            range = d.range,
+                            severity = _server.Settings.analysis.GetEffectiveSeverity(d.code, d.severity),
+                            code = d.code,
+                            source = d.source,
+                            message = d.message,
+                        })
+                        .Where(d => d.severity != DiagnosticSeverity.Unspecified) // Don't send unspecified/disabled diagnostics.
+                        .ToArray();
                 } else {
                     // If diagnostics are disabled globally, don't send any diagnostics,
                     // except for the explicitly empty ones which are used to clear.

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 settings.diagnosticPublishDelay = GetSetting(analysis, "diagnosticPublishDelay", 1000);
                 settings.symbolsHierarchyDepthLimit = GetSetting(analysis, "symbolsHierarchyDepthLimit", 10);
                 settings.symbolsHierarchyMaxSymbols = GetSetting(analysis, "symbolsHierarchyMaxSymbols", 1000);
-                settings.analysis.diagnostics = GetSetting(analysis, "diagnostics", false);
+                settings.analysis.diagnostics = GetSetting(analysis, "diagnostics", true);
 
                 _ui.SetLogLevel(GetLogLevel(analysis));
 


### PR DESCRIPTION
Fixes #242.

This does the following:
- Fixes diagnostics when settings are changed at runtime. Previously, only the mapping from `code` to `severity` was updated, not the actual listing, so diagnostics were never re-run even when settings were changed.
- Moves all severity decision and diagnostic filtering upward into the LS. This means all generated diagnostics will be published as-is, and any future additions (i.e. import code actions) can be generated when new diagnostics are published.
- Adds a setting called `python.analysis.diagnostics` which is true when diagnostics should be published altogether (and also triggers an update when changed). ~The default behavior remains the same; users will not see any diagnostics until VSC adds the setting to its `package.json`. Devs (us) can set this in the JSON just like we set `downloadLanguageServer` even though it's undocumented.~ Default will be enabled, as per PR comments.

Looking for feedback on:
- The naming of `python.analysis.diagnostics`.
- Whether or not I should be removing `EnableDiagnostics` now that the toggle is focused on deciding whether or not to publish diagnostics, not whether or not to collect them.