### PR TITLE
Only enable diagnostics and fix settings change detection

### DIFF
--- a/src/LanguageServer/Impl/Definitions/ServerSettings.cs
+++ b/src/LanguageServer/Impl/Definitions/ServerSettings.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Python.LanguageServer {
             public int symbolsHierarchyDepthLimit = 10;
             public int symbolsHierarchyMaxSymbols = 1000;
 
-            public string[] errors { get; } = Array.Empty<string>();
-            public string[] warnings { get; } = Array.Empty<string>();
-            public string[] information { get; } = Array.Empty<string>();
-            public string[] disabled { get; } = Array.Empty<string>();
+            public string[] errors { get; private set; } = Array.Empty<string>();
+            public string[] warnings { get; private set; } = Array.Empty<string>();
+            public string[] information { get; private set; } = Array.Empty<string>();
+            public string[] disabled { get; private set; } = Array.Empty<string>();
 
             public DiagnosticSeverity GetEffectiveSeverity(string code, DiagnosticSeverity defaultSeverity)
                 => _map.TryGetValue(code, out var severity) ? severity : defaultSeverity;
@@ -50,6 +50,11 @@ namespace Microsoft.Python.LanguageServer {
                 foreach (var x in disabled) {
                     _map[x] = DiagnosticSeverity.Unspecified;
                 }
+
+                this.errors = errors;
+                this.warnings = warnings;
+                this.information = information;
+                this.disabled = disabled;
             }
         }
         public readonly PythonAnalysisOptions analysis = new PythonAnalysisOptions();

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _traceLogging = @params.initializationOptions.traceLogging;
             _analysisUpdates = @params.initializationOptions.analysisUpdates;
 
-            Analyzer.EnableDiagnostics = _clientCaps?.python?.liveLinting ?? false;
+            Analyzer.EnableDiagnostics = _clientCaps?.python?.liveLinting ?? true;
             _reloadModulesQueueItem = new ReloadModulesQueueItem(this);
 
             if (@params.initializationOptions.displayOptions != null) {

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -421,7 +421,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             foreach (var kvp in list) {
                 var parameters = new PublishDiagnosticsParams {
                     uri = kvp.Key,
-                    diagnostics = kvp.Value
+                    diagnostics = kvp.Value.Where(d => d.severity != DiagnosticSeverity.Unspecified).ToArray()
                 };
                 _rpc.NotifyWithParameterObjectAsync("textDocument/publishDiagnostics", parameters).DoNotWait();
             }


### PR DESCRIPTION
Fixes #242.

#289 causes a few issues to do with parser-generated diagnostics, and there are more diagnostics I wasn't aware of coming from ErrorSink. This is a simplified PR that does the minimum to enable diagnostics (ignoring "Unspecified" at publish time) and fixes the setting change bug.

We'll have to revisit where diagnostics should be stored to access via code actions in a different PR. There are only two diagnostics that actually come out of the server which can be disabled with `python.analysis.disabled` for now.

I'll close #289 in favor of this one.