### PR TITLE
[WIP] Ensure DocumentationBuilder never has a null preferred MarkupKind

### DIFF
--- a/src/Analysis/Engine/Impl/Documentation/DocumentationBuilder.cs
+++ b/src/Analysis/Engine/Impl/Documentation/DocumentationBuilder.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PythonTools.Analysis.Documentation {
 
         public static DocumentationBuilder Create(InformationDisplayOptions displayOptions) {
             displayOptions = displayOptions ?? DefaultDisplayOptions;
+            displayOptions.preferredFormat = displayOptions.preferredFormat ?? MarkupKind.PlainText; // MarkupKind should never be null.
 
             if (displayOptions.preferredFormat == MarkupKind.Markdown) {
                 return new MarkdownDocumentationBuilder(displayOptions);

--- a/src/Analysis/Engine/Test/CompletionTests.cs
+++ b/src/Analysis/Engine/Test/CompletionTests.cs
@@ -27,6 +27,7 @@ using Microsoft.Python.LanguageServer.Extensions;
 using Microsoft.Python.LanguageServer.Implementation;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Analysis.Documentation;
 using Microsoft.PythonTools.Analysis.FluentAssertions;
 using Microsoft.PythonTools.Analysis.Infrastructure;
 using Microsoft.PythonTools.Interpreter;
@@ -1009,6 +1010,22 @@ class Simple(unittest.TestCase):
                 var u = await s.OpenDefaultDocumentAndGetUriAsync("import sys\nsys  .  version\n");
                 await AssertCompletion(s, u, new[] { "argv" }, null, new SourceLocation(2, 7), 
                     new CompletionContext { triggerCharacter = ".", triggerKind = CompletionTriggerKind.TriggerCharacter });
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MarkupKindValid() {
+            using (var s = await CreateServerAsync()) {
+                var u = await s.OpenDefaultDocumentAndGetUriAsync("import sys\nsys.\n");
+
+                await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
+                var res = await s.Completion(new CompletionParams {
+                    textDocument = new TextDocumentIdentifier { uri = u },
+                    position = new SourceLocation(2, 5),
+                    context = new CompletionContext { triggerCharacter = ".", triggerKind = CompletionTriggerKind.TriggerCharacter },
+                }, CancellationToken.None);
+
+                res.items?.Select(i => i.documentation.kind).Should().NotBeEmpty().And.BeSubsetOf(new[] { MarkupKind.PlainText, MarkupKind.Markdown });
             }
         }
 

--- a/src/Analysis/Engine/Test/HoverTests.cs
+++ b/src/Analysis/Engine/Test/HoverTests.cs
@@ -25,6 +25,7 @@ using Microsoft.Python.LanguageServer.Implementation;
 using Microsoft.Python.Tests.Utilities.FluentAssertions;
 using Microsoft.PythonTools;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Analysis.Documentation;
 using Microsoft.PythonTools.Analysis.FluentAssertions;
 using Microsoft.PythonTools.Interpreter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -140,6 +141,21 @@ class Derived(Base):
                 var uri = await s.OpenDefaultDocumentAndGetUriAsync(text);
                 await AssertHover(s, uri, new SourceLocation(3, 19), "class module.Base(object)", null, new SourceSpan(2, 7, 2, 11));
                 await AssertHover(s, uri, new SourceLocation(8, 8), "class module.Derived(Base)", null, new SourceSpan(6, 7, 6, 14));
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MarkupKindValid() {
+            using (var s = await CreateServerAsync()) {
+                var u = await s.OpenDefaultDocumentAndGetUriAsync("123");
+
+                await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
+                var hover = await s.Hover(new TextDocumentPositionParams {
+                    textDocument = new TextDocumentIdentifier { uri = u },
+                    position = new SourceLocation(1, 1),
+                }, CancellationToken.None);
+
+                hover.contents.kind.Should().BeOneOf(MarkupKind.PlainText, MarkupKind.Markdown);
             }
         }
 

--- a/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
+++ b/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 label = m.Name,
                 insertText = completion,
                 documentation = string.IsNullOrWhiteSpace(doc) ? null : new MarkupContent {
-                    kind = _textBuilder.DisplayOptions.preferredFormat ?? MarkupKind.PlainText,
+                    kind = _textBuilder.DisplayOptions.preferredFormat,
                     value = doc
                 },
                 // Place regular items first, advanced entries last

--- a/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
+++ b/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 label = m.Name,
                 insertText = completion,
                 documentation = string.IsNullOrWhiteSpace(doc) ? null : new MarkupContent {
-                    kind = _textBuilder.DisplayOptions.preferredFormat,
+                    kind = _textBuilder.DisplayOptions.preferredFormat ?? MarkupKind.PlainText,
                     value = doc
                 },
                 // Place regular items first, advanced entries last


### PR DESCRIPTION
Fixes #305.

I opted to move this up into DocumentationBuilder. Hover seems to avoid this problem as it's able to use the helper method `GetMarkupContent`, which ensures that the kind is set properly.

Completion documentation generation lives in `CompletionAnalysis`, and seems to be the only user of `preferredFormat`. Before merging this PR, I'm going to investigate and see how much trouble it'd be to rework doc generation into using the capability-sent list of supported MarkupKinds, so I've marked this as [WIP] for now.