### PR TITLE
Fix TopLevelCompletions test on Mac

### DIFF
--- a/src/Analysis/Engine/Test/CompletionTests.cs
+++ b/src/Analysis/Engine/Test/CompletionTests.cs
@@ -443,7 +443,7 @@ class B(A):
         [TestMethod, Priority(0)]
         public async Task TopLevelCompletions() {
             using (var s = await CreateServerAsync(PythonVersions.LatestAvailable3X)) {
-                var uri = GetDocument(@"TestData\AstAnalysis\TopLevelCompletions.py");
+                var uri = GetDocument(Path.Combine("TestData", "AstAnalysis", "TopLevelCompletions.py"));
                 await s.LoadFileAsync(uri);
 
                 await AssertCompletion(


### PR DESCRIPTION
Fixes #310
Somehow backslashes creeped back in.