### PR TITLE
Resource-ify diagnostic messages, rename some codes, remove "(...)"

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/ErrorMessages.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ErrorMessages.cs
@@ -20,13 +20,13 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
     static class ErrorMessages {
         public static string NotCallableCode { get; } = "not-callable";
         public static string NotCallable(string target) => string.IsNullOrEmpty(target) ?
-            Resources.DiagnosticNotCallableEmpty :
-            Resources.DiagnosticNotCallable.FormatUI(target);
+            Resources.ErrorNotCallableEmpty :
+            Resources.ErrorNotCallable.FormatUI(target);
 
         public static string UseBeforeDefCode { get; } = "use-before-def";
-        public static string UseBeforeDef(string name) => Resources.DiagnosticUseBeforeDef.FormatUI(name);
+        public static string UseBeforeDef(string name) => Resources.ErrorUseBeforeDef.FormatUI(name);
 
         public static string UnresolvedImportCode { get; } = "unresolved-import";
-        public static string UnresolvedImport(string name) => Resources.DiagnosticUnresolvedImport.FormatUI(name);
+        public static string UnresolvedImport(string name) => Resources.ErrorUnresolvedImport.FormatUI(name);
     }
 }

--- a/src/Analysis/Engine/Impl/Analyzer/ErrorMessages.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ErrorMessages.cs
@@ -20,13 +20,13 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
     static class ErrorMessages {
         public static string NotCallableCode { get; } = "not-callable";
         public static string NotCallable(string target) => string.IsNullOrEmpty(target) ?
-            "object may not be callable" :
-            "'{0}' may not be callable".FormatUI(target);
+            Resources.DiagnosticNotCallableEmpty :
+            Resources.DiagnosticNotCallable.FormatUI(target);
 
-        public static string UsedBeforeAssignmentCode { get; } = "used-before-assignment";
-        public static string UsedBeforeAssignment(string name) => "unknown variable '{0}'".FormatUI(name);
+        public static string UseBeforeDefCode { get; } = "use-before-def";
+        public static string UseBeforeDef(string name) => Resources.DiagnosticUseBeforeDef.FormatUI(name);
 
         public static string UnresolvedImportCode { get; } = "unresolved-import";
-        public static string UnresolvedImport(string name) => "Unable to resolve '{0}'. IntelliSense may be missing for this module.".FormatUI(name);
+        public static string UnresolvedImport(string name) => Resources.DiagnosticUnresolvedImport.FormatUI(name);
     }
 }

--- a/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
@@ -160,9 +160,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             }
 
             if (warn) {
-                ProjectState.AddDiagnostic(node, _unit, ErrorMessages.UsedBeforeAssignment(name), DiagnosticSeverity.Warning, ErrorMessages.UsedBeforeAssignmentCode);
+                ProjectState.AddDiagnostic(node, _unit, ErrorMessages.UseBeforeDef(name), DiagnosticSeverity.Warning, ErrorMessages.UseBeforeDefCode);
             } else {
-                ProjectState.ClearDiagnostic(node, _unit, ErrorMessages.UsedBeforeAssignmentCode);
+                ProjectState.ClearDiagnostic(node, _unit, ErrorMessages.UseBeforeDefCode);
             }
 
             return res;

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PythonTools.Analysis {
     /// Performs analysis of multiple Python code files and enables interrogation of the resulting analysis.
     /// </summary>
     public partial class PythonAnalyzer : IPythonAnalyzer, IDisposable {
-        public const string PythonAnalysisSource = "Python (analysis)";
+        public const string PythonAnalysisSource = "Python";
         private static object _nullKey = new object();
 
         private readonly bool _disposeInterpreter;

--- a/src/Analysis/Engine/Impl/Resources.Designer.cs
+++ b/src/Analysis/Engine/Impl/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PythonTools.Analysis {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -84,6 +84,42 @@ namespace Microsoft.PythonTools.Analysis {
         internal static string CalculatingDocumentation {
             get {
                 return ResourceManager.GetString("CalculatingDocumentation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; may not be callable.
+        /// </summary>
+        internal static string ErrorNotCallable {
+            get {
+                return ResourceManager.GetString("ErrorNotCallable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to object may not be callable.
+        /// </summary>
+        internal static string ErrorNotCallableEmpty {
+            get {
+                return ResourceManager.GetString("ErrorNotCallableEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unresolved import &apos;{0}&apos;.
+        /// </summary>
+        internal static string ErrorUnresolvedImport {
+            get {
+                return ResourceManager.GetString("ErrorUnresolvedImport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; used before definition.
+        /// </summary>
+        internal static string ErrorUseBeforeDef {
+            get {
+                return ResourceManager.GetString("ErrorUseBeforeDef", resourceCulture);
             }
         }
         

--- a/src/Analysis/Engine/Impl/Resources.resx
+++ b/src/Analysis/Engine/Impl/Resources.resx
@@ -303,4 +303,16 @@
   <data name="CalculatingDocumentation" xml:space="preserve">
     <value>Documentation is still being calculated, please try again soon.</value>
   </data>
+  <data name="ErrorNotCallable" xml:space="preserve">
+    <value>'{0}' may not be callable</value>
+  </data>
+  <data name="ErrorNotCallableEmpty" xml:space="preserve">
+    <value>object may not be callable</value>
+  </data>
+  <data name="ErrorUnresolvedImport" xml:space="preserve">
+    <value>unresolved import '{0}'</value>
+  </data>
+  <data name="ErrorUseBeforeDef" xml:space="preserve">
+    <value>'{0}' used before definition</value>
+  </data>
 </root>

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -280,12 +280,12 @@ def f(a = 2, b): pass
             var u = await AddModule(s, "def f(/)\n    error text\n");
 
             GetDiagnostics(diags, u).Should().OnlyContain(
-                "Error;unexpected token '/';Python (parser);0;6;7",
-                "Error;invalid parameter;Python (parser);0;6;7",
-                "Error;unexpected token '<newline>';Python (parser);0;8;4",
-                "Error;unexpected indent;Python (parser);1;4;9",
-                "Error;unexpected token 'text';Python (parser);1;10;14",
-                "Error;unexpected token '<dedent>';Python (parser);1;14;0"
+                "Error;unexpected token '/';Python;0;6;7",
+                "Error;invalid parameter;Python;0;6;7",
+                "Error;unexpected token '<newline>';Python;0;8;4",
+                "Error;unexpected indent;Python;1;4;9",
+                "Error;unexpected token 'text';Python;1;10;14",
+                "Error;unexpected token '<dedent>';Python;1;14;0"
             );
         }
 
@@ -320,7 +320,7 @@ def f(a = 2, b): pass
                 if (tc == DiagnosticSeverity.Unspecified) {
                     messages.Should().BeEmpty();
                 } else {
-                    messages.Should().OnlyContain($"{tc};inconsistent whitespace;Python (parser);2;0;1");
+                    messages.Should().OnlyContain($"{tc};inconsistent whitespace;Python;2;0;1");
                 }
 
                 await s.UnloadFileAsync(mod);
@@ -335,9 +335,9 @@ def f(a = 2, b): pass
             var u = await AddModule(s, "y\nx x");
 
             GetDiagnostics(diags, u).Should().OnlyContain(
-                "Warning;unknown variable 'y';Python (analysis);0;0;1",
-                "Warning;unknown variable 'x';Python (analysis);1;0;1",
-                "Error;unexpected token 'x';Python (parser);1;2;3"
+                "Warning;'y' used before definition;Python;0;0;1",
+                "Warning;'x' used before definition;Python;1;0;1",
+                "Error;unexpected token 'x';Python;1;2;3"
             );
         }
 
@@ -350,12 +350,12 @@ def f(a = 2, b): pass
 
                 await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
                 GetDiagnostics(diags, u).Should().OnlyContain(
-                    "Warning;Unable to resolve 'foo'. IntelliSense may be missing for this module.;Python (analysis);0;7;10",
-                    "Warning;unknown variable 'y';Python (analysis);1;4;5"
+                    "Warning;unresolved import 'foo';Python;0;7;10",
+                    "Warning;'y' used before definition;Python;1;4;5"
                 );
 
                 var newSettings = new ServerSettings();
-                newSettings.analysis.SetErrorSeverityOptions(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), new[] { ErrorMessages.UsedBeforeAssignmentCode, ErrorMessages.UnresolvedImportCode });
+                newSettings.analysis.SetErrorSeverityOptions(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), new[] { ErrorMessages.UseBeforeDefCode, ErrorMessages.UnresolvedImportCode });
                 await s.SendDidChangeConfiguration(newSettings);
 
                 await s.WaitForCompleteAnalysisAsync(CancellationToken.None);

--- a/src/LanguageServer/Impl/Implementation/ParseQueue.cs
+++ b/src/LanguageServer/Impl/Implementation/ParseQueue.cs
@@ -30,7 +30,7 @@ using Microsoft.PythonTools.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Implementation {
     class ParseQueue: IDisposable {
-        public const string PythonParserSource = "Python (parser)";
+        public const string PythonParserSource = "Python";
         private const string TaskCommentSource = "Task comment";
 
         private readonly ConcurrentDictionary<Uri, ParseTask> _parsing;


### PR DESCRIPTION
Closes #299. (Specifically the naming part in the comments.)

Strings have been moved into Resources. `(parser)` and `(analysis)` have been removed from the diagnostic source strings. I also renamed one of the codes to be more representative of what it actually means (while we have the ability to change something like this without breaking users).

The tests I modified in LanguageServerTests are not well-written (hardcoded strings rather than a table of actual things to compare), but I just made them pass for now and could fix them later.