### PR TITLE
Allows to use .pyi file annotations supplement to .py files in analysis core

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -77,6 +77,8 @@ csharp_new_line_before_members_in_anonymous_types = false
 
 csharp_new_line_before_members_in_object_initializers = false
 
+csharp_prefer_braces = true:error
+
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none

--- a/src/Analysis/Engine/Impl/AnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/AnalysisUnit.cs
@@ -351,8 +351,9 @@ namespace Microsoft.PythonTools.Analysis {
 
         private AnalysisUnit GetExternalAnalysisUnitImpl() {
             string analysisModuleName = ProjectEntry.ModuleName + PythonAnalyzer.AnnotationsModuleSuffix;
-            if (!ProjectEntry.ProjectState.Modules.TryImport(analysisModuleName, out var analysisModuleReference))
+            if (!ProjectEntry.ProjectState.Modules.TryImport(analysisModuleName, out var analysisModuleReference)) {
                 return null;
+            }
 
             return analysisModuleReference.AnalysisModule?.AnalysisUnit;
         }
@@ -479,15 +480,19 @@ namespace Microsoft.PythonTools.Analysis {
 
         protected internal override AnalysisUnit GetExternalAnnotationAnalysisUnit() {
             var parentAnnotation = _outerUnit.GetExternalAnnotationAnalysisUnit();
-            if (parentAnnotation == null)
+            if (parentAnnotation == null) {
                 return null;
-            if (!parentAnnotation.Scope.TryGetVariable(Ast.Name, out var annotationVariable))
+            }
+
+            if (!parentAnnotation.Scope.TryGetVariable(Ast.Name, out var annotationVariable)) {
                 return null;
-            if (annotationVariable.Types is ClassInfo classAnnotation)
+            }
+            
+            if (annotationVariable.Types is ClassInfo classAnnotation) {
                 return classAnnotation.AnalysisUnit;
-            if (annotationVariable.Types.OnlyOneOrDefault() is ClassInfo nestedAnnotation)
-                return nestedAnnotation.AnalysisUnit;
-            return null;
+            }
+
+            return (annotationVariable.Types.OnlyOneOrDefault() as ClassInfo)?.AnalysisUnit;
         }
     }
 

--- a/src/Analysis/Engine/Impl/AnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/AnalysisUnit.cs
@@ -59,8 +59,9 @@ namespace Microsoft.PythonTools.Analysis {
         internal AnalysisUnit(Node ast, PythonAst tree, IScope scope, bool forEval) {
             Ast = ast;
             Tree = tree;
-            if (ast == tree)
+            if (ast == tree) {
                 _externalAnnotationAnalysisUnit = new Lazy<AnalysisUnit>(GetExternalAnalysisUnitImpl);
+            }
             _scope = scope;
             ForEval = forEval;
         }
@@ -346,14 +347,9 @@ namespace Microsoft.PythonTools.Analysis {
         ILocationResolver ILocationResolver.GetAlternateResolver() => AlternateResolver;
 
         readonly Lazy<AnalysisUnit> _externalAnnotationAnalysisUnit;
-        protected internal virtual AnalysisUnit GetExternalAnnotationAnalysisUnit() {
-            if (Ast != Tree)
-                return null;
+        protected internal virtual AnalysisUnit GetExternalAnnotationAnalysisUnit() => _externalAnnotationAnalysisUnit?.Value;
 
-            return _externalAnnotationAnalysisUnit.Value;
-        }
-
-        AnalysisUnit GetExternalAnalysisUnitImpl() {
+        private AnalysisUnit GetExternalAnalysisUnitImpl() {
             string analysisModuleName = ProjectEntry.ModuleName + PythonAnalyzer.AnnotationsModuleSuffix;
             if (!ProjectEntry.ProjectState.Modules.TryImport(analysisModuleName, out var analysisModuleReference))
                 return null;

--- a/src/Analysis/Engine/Impl/AnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/AnalysisUnit.cs
@@ -59,6 +59,8 @@ namespace Microsoft.PythonTools.Analysis {
         internal AnalysisUnit(Node ast, PythonAst tree, IScope scope, bool forEval) {
             Ast = ast;
             Tree = tree;
+            if (ast == tree)
+                _externalAnnotationAnalysisUnit = new Lazy<AnalysisUnit>(GetExternalAnalysisUnitImpl);
             _scope = scope;
             ForEval = forEval;
         }
@@ -343,10 +345,15 @@ namespace Microsoft.PythonTools.Analysis {
 
         ILocationResolver ILocationResolver.GetAlternateResolver() => AlternateResolver;
 
+        readonly Lazy<AnalysisUnit> _externalAnnotationAnalysisUnit;
         protected internal virtual AnalysisUnit GetExternalAnnotationAnalysisUnit() {
             if (Ast != Tree)
                 return null;
 
+            return _externalAnnotationAnalysisUnit.Value;
+        }
+
+        AnalysisUnit GetExternalAnalysisUnitImpl() {
             string analysisModuleName = ProjectEntry.ModuleName + PythonAnalyzer.AnnotationsModuleSuffix;
             if (!ProjectEntry.ProjectState.Modules.TryImport(analysisModuleName, out var analysisModuleReference))
                 return null;

--- a/src/Analysis/Engine/Impl/Analyzer/DDG.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/DDG.cs
@@ -127,8 +127,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 if (ProjectState.Modules.TryGetImportedModule(annotationModuleName, out annotationsReference)) {
                     FinishImportModuleOrMember(annotationsReference, attribute: null, name: "__pyi__",
                         addRef: true, node: node, nameReference: new NameExpression("__pyi__"));
-                } else
+                } else {
                     Debug.Fail($"Failed to get module {annotationModuleName} we just imported");
+                }
             }
 
             return base.Walk(node);

--- a/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
@@ -236,8 +236,20 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                     }
                 }
             }
+
+            IAnalysisSet ann = null;
             if (Ast.ReturnAnnotation != null) {
-                var ann = ddg._eval.EvaluateAnnotation(Ast.ReturnAnnotation);
+                ann = ddg._eval.EvaluateAnnotation(Ast.ReturnAnnotation);
+            } else if (functionAnnotation?.ReturnAnnotation != null) {
+                try {
+                    ddg.SetCurrentUnit(annotationAnalysis);
+                    ann = ddg._eval.EvaluateAnnotation(functionAnnotation.ReturnAnnotation);
+                } finally {
+                    ddg.SetCurrentUnit(this);
+                }
+            }
+
+            if (ann != null) {
                 var resType = ann;
                 if (Ast.IsGenerator) {
                     if (ann.Split<ProtocolInfo>(out var gens, out resType)) {

--- a/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/FunctionAnalysisUnit.cs
@@ -74,15 +74,19 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
 
         protected internal override AnalysisUnit GetExternalAnnotationAnalysisUnit() {
             var parentAnnotation = _declUnit.GetExternalAnnotationAnalysisUnit();
-            if (parentAnnotation == null)
+            if (parentAnnotation == null) {
                 return null;
-            if (!parentAnnotation.Scope.TryGetVariable(Ast.Name, out var annotationVariable))
+            }
+
+            if (!parentAnnotation.Scope.TryGetVariable(Ast.Name, out var annotationVariable)) {
                 return null;
-            if (annotationVariable.Types is FunctionInfo functionAnnotation)
+            }
+
+            if (annotationVariable.Types is FunctionInfo functionAnnotation) {
                 return functionAnnotation.AnalysisUnit;
-            if (annotationVariable.Types.OnlyOneOrDefault() is FunctionInfo nestedAnnotation)
-                return nestedAnnotation.AnalysisUnit;
-            return null;
+            }
+
+            return (annotationVariable.Types.OnlyOneOrDefault() as FunctionInfo)?.AnalysisUnit;
         }
 
         internal override void AnalyzeWorker(DDG ddg, CancellationToken cancel) {
@@ -199,8 +203,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
             var scope = (FunctionScope)Scope;
             var annotationAnalysis = GetExternalAnnotationAnalysisUnit() as FunctionAnalysisUnit;
             var functionAnnotation = annotationAnalysis?.Function.FunctionDefinition;
-            if (functionAnnotation?.Parameters.Length != Ast.Parameters.Length)
+            if (functionAnnotation?.Parameters.Length != Ast.Parameters.Length) {
                 functionAnnotation = null;
+            }
             for (var i = 0; i < Ast.Parameters.Length; ++i) {
                 var p = Ast.Parameters[i];
                 var annotation = p.Annotation;

--- a/src/Analysis/Engine/Impl/Infrastructure/Extensions/EnumerableExtensions.cs
+++ b/src/Analysis/Engine/Impl/Infrastructure/Extensions/EnumerableExtensions.cs
@@ -60,6 +60,22 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
         public static IEnumerable<T> Keys<T, U>(this IEnumerable<KeyValuePair<T, U>> source) => source.Select(GetKey);
         public static IEnumerable<T> ExcludeDefault<T>(this IEnumerable<T> source) => source.Where(i => !Equals(i, default(T)));
 
+        /// <summary>
+        /// Returns the only element of sequence, or the default value of <typeparamref name="T"/>, if sequence has &lt;&gt; 1 elements.
+        /// </summary>
+        public static T OnlyOneOrDefault<T>(this IEnumerable<T> source) {
+            using (var enumerator = source.GetEnumerator()) {
+                if (!enumerator.MoveNext())
+                    return default(T);
+
+                T result = enumerator.Current;
+
+                if (enumerator.MoveNext())
+                    return default(T);
+
+                return result;
+            }
+        }
 
         public static IEnumerable<T> TraverseBreadthFirst<T>(this T root, Func<T, IEnumerable<T>> selectChildren) {
             var items = new Queue<T>();

--- a/src/Analysis/Engine/Impl/Infrastructure/Extensions/EnumerableExtensions.cs
+++ b/src/Analysis/Engine/Impl/Infrastructure/Extensions/EnumerableExtensions.cs
@@ -65,13 +65,15 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
         /// </summary>
         public static T OnlyOneOrDefault<T>(this IEnumerable<T> source) {
             using (var enumerator = source.GetEnumerator()) {
-                if (!enumerator.MoveNext())
+                if (!enumerator.MoveNext()) {
                     return default(T);
+                }
 
                 T result = enumerator.Current;
 
-                if (enumerator.MoveNext())
+                if (enumerator.MoveNext()) {
                     return default(T);
+                }
 
                 return result;
             }

--- a/src/Analysis/Engine/Impl/ProjectEntry.cs
+++ b/src/Analysis/Engine/Impl/ProjectEntry.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PythonTools.Analysis {
         private readonly HashSet<AggregateProjectEntry> _aggregates = new HashSet<AggregateProjectEntry>();
 
         private TaskCompletionSource<IModuleAnalysis> _analysisTcs = new TaskCompletionSource<IModuleAnalysis>();
-        private AnalysisUnit _unit;
+        internal AnalysisUnit _unit;
         private readonly ManualResetEventSlim _pendingParse = new ManualResetEventSlim(true);
         private long _expectedParseVersion;
         private long _expectedAnalysisVersion;

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -36,6 +36,7 @@ namespace Microsoft.PythonTools.Analysis {
     /// </summary>
     public partial class PythonAnalyzer : IPythonAnalyzer, IDisposable {
         public const string PythonAnalysisSource = "Python (analysis)";
+        internal const string AnnotationsModuleSuffix = "__pyi__";
         private static object _nullKey = new object();
 
         private readonly bool _disposeInterpreter;
@@ -210,6 +211,33 @@ namespace Microsoft.PythonTools.Analysis {
 
                 DoDelayedSpecialization(moduleName);
             }
+            if (filePath != null) {
+                ModulesByFilename[filePath] = entry.MyScope;
+            }
+            return entry;
+        }
+
+        /// <summary>
+        /// Adds a new annotations file to the list of available annotation files and returns a ProjectEntry object.
+        /// 
+        /// This method is thread safe.
+        /// </summary>
+        /// <param name="moduleName">The name of the module; used to associate with imports</param>
+        /// <param name="filePath">The path to the file on disk</param>
+        /// <param name="cookie">An application-specific identifier for the module</param>
+        /// <returns>The project entry for the new module.</returns>
+        public IPythonProjectEntry AddModuleAnnotations(string moduleName, string filePath, Uri documentUri = null, IAnalysisCookie cookie = null) {
+            if (moduleName == null)
+                throw new ArgumentNullException(nameof(moduleName));
+
+            moduleName += AnnotationsModuleSuffix;
+            var entry = new ProjectEntry(this, moduleName, filePath, documentUri, cookie);
+
+            var moduleRef = Modules.GetOrAdd(moduleName);
+            moduleRef.Module = entry.MyScope;
+
+            DoDelayedSpecialization(moduleName);
+
             if (filePath != null) {
                 ModulesByFilename[filePath] = entry.MyScope;
             }

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -227,8 +227,9 @@ namespace Microsoft.PythonTools.Analysis {
         /// <param name="cookie">An application-specific identifier for the module</param>
         /// <returns>The project entry for the new module.</returns>
         public IPythonProjectEntry AddModuleAnnotations(string moduleName, string filePath, Uri documentUri = null, IAnalysisCookie cookie = null) {
-            if (moduleName == null)
+            if (moduleName == null) {
                 throw new ArgumentNullException(nameof(moduleName));
+            }
 
             moduleName += AnnotationsModuleSuffix;
             var entry = new ProjectEntry(this, moduleName, filePath, documentUri, cookie);

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -227,22 +227,9 @@ namespace Microsoft.PythonTools.Analysis {
         /// <param name="cookie">An application-specific identifier for the module</param>
         /// <returns>The project entry for the new module.</returns>
         public IPythonProjectEntry AddModuleAnnotations(string moduleName, string filePath, Uri documentUri = null, IAnalysisCookie cookie = null) {
-            if (moduleName == null) {
-                throw new ArgumentNullException(nameof(moduleName));
-            }
+            Check.ArgumentNotNull(nameof(moduleName), moduleName);
 
-            moduleName += AnnotationsModuleSuffix;
-            var entry = new ProjectEntry(this, moduleName, filePath, documentUri, cookie);
-
-            var moduleRef = Modules.GetOrAdd(moduleName);
-            moduleRef.Module = entry.MyScope;
-
-            DoDelayedSpecialization(moduleName);
-
-            if (filePath != null) {
-                ModulesByFilename[filePath] = entry.MyScope;
-            }
-            return entry;
+            return AddModule(moduleName + AnnotationsModuleSuffix, filePath, documentUri, cookie);
         }
 
         /// <summary>

--- a/src/Analysis/Engine/Impl/Values/ModuleInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/ModuleInfo.cs
@@ -123,6 +123,8 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public ModuleInfo ParentPackage { get; set; }
 
+        public override AnalysisUnit AnalysisUnit => _projectEntry._unit;
+
         public void AddChildPackage(ModuleInfo childPackage, AnalysisUnit curUnit, string realName = null) {
             realName = realName ?? childPackage.Name;
             int lastDot;


### PR DESCRIPTION
`PythonAnalyzer.AddModuleAnnotations` allows to add a special kind of module, that is external type annotation. In this change, internally those are tracked as ordinary modules with a special name suffix `__pyi__` (not `.__pyi__`! That is required for relative imports to work).

These modules are analyzed just like any other module.

For every normal module `DDG` creates a reference to corresponding `.pyi`, if one exists, to create a dependency.

Now that both are analyzed, `FunctionAnalysisUnit` needs to find its counterpart from supplemental annotations. For this purpose, `AnalysisUnit` implements `GetExternalAnnotationAnalysisUnit`. For module, it looks for the annotations module in `ProjectState`. For class and function, unit simply descends into the scope by class/function name.

Once `FunctionAnalysisUnit` has it annotations counterpart, it can read analyzed annotations from it, if the local annotations are missing.

This change only applies to the core analysis engine. Language server will need to be updated separately to take advantage of it.