### PR TITLE
Modify editorconfig to add newline to end of files

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -7,7 +7,7 @@ indent_size = 4
 
 indent_style = space
 
-insert_final_newline = false
+insert_final_newline = true
 
 tab_width = 4
 


### PR DESCRIPTION
Not having one seems to break sonar (plus arguably sources files should do this anyway).

This doesn't seem to fix it in VS from what I can tell (even with Format Document), but does work in VS Code with the EditorConfig extension.