### PR TITLE
Fix None being reported as not defined in type hints

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         res = refs.Types;
                     } else {
                         // ... warn the user
-                        warn = true;
+                        warn = !(node is ConstantExpression); // Don't warn when None.
                     }
                 }
             }

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -364,6 +364,27 @@ def f(a = 2, b): pass
         }
 
         [TestMethod, Priority(0)]
+        public async Task TypeHintNoneDiagnostic() {
+            if (this is LanguageServerTests_V2) {
+                // No type hints in Python 2.
+                return;
+            }
+
+            var code = @"
+def f(b: None) -> None:
+    b: None
+";
+
+            var diags = new Dictionary<Uri, PublishDiagnosticsEventArgs>();
+            using (var s = await CreateServer((Uri)null, null, diags)) {
+                var u = await s.OpenDefaultDocumentAndGetUriAsync(code);
+
+                await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
+                GetDiagnostics(diags, u).Should().BeEmpty();
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public async Task OnTypeFormattingLine() {
             using (var s = await CreateServer()) {
                 var uri = await AddModule(s, "def foo  ( ) :\n    x = a + b\n    x+= 1");


### PR DESCRIPTION
Fixes #335.

I'm not sure if it's good or bad that a `ConstantExpression` is making it into `LookupAnalysisSetByName`, but checking for it before warning will prevent user-visible weirdness.