### PR TITLE
Fix invalid insertTextFormat in CompletionItem instances

### DIFF
--- a/src/Analysis/Engine/Test/CompletionTests.cs
+++ b/src/Analysis/Engine/Test/CompletionTests.cs
@@ -243,7 +243,8 @@ class oar(list):
             var completions = await server.SendCompletion(uri, 2, 8);
 
             completions.Should().HaveItem("append")
-                .Which.Should().HaveInsertText($"append(self, value):{Environment.NewLine}    return super(oar, self).append(value)");
+                .Which.Should().HaveInsertText($"append(self, value):{Environment.NewLine}    return super(oar, self).append(value)")
+                .And.HaveInsertTextFormat(InsertTextFormat.PlainText);
         }
 
         [DataRow(PythonLanguageVersion.V36, "value")]
@@ -259,7 +260,8 @@ class oar(list):
             var completions = await server.SendCompletion(uri, 2, 8);
 
             completions.Should().HaveItem("append")
-                .Which.Should().HaveInsertText($"append(self, {parameterName}):{Environment.NewLine}    return super().append({parameterName})");
+                .Which.Should().HaveInsertText($"append(self, {parameterName}):{Environment.NewLine}    return super().append({parameterName})")
+                .And.HaveInsertTextFormat(InsertTextFormat.PlainText);
         }
 
         [ServerTestMethod(LatestAvailable2X = true), Priority(0)]
@@ -417,7 +419,8 @@ Class1().
             var completion = await server.SendCompletion(uri, row, character);
 
             completion.Should().HaveItem(expectedLabel)
-                .Which.Should().HaveInsertText(expectedInsertText);
+                .Which.Should().HaveInsertText(expectedInsertText)
+                .And.HaveInsertTextFormat(InsertTextFormat.Snippet);
         }
 
         [DataRow(PythonLanguageMajorVersion.LatestV2, "foo(self):{0}    return super(B, self).foo()")]
@@ -438,7 +441,8 @@ class B(A):
             var completion = await server.SendCompletion(uri, 6, 9);
 
             completion.Should().HaveItem("foo")
-                .Which.Should().HaveInsertText(expectedInsertText);
+                .Which.Should().HaveInsertText(expectedInsertText)
+                .And.HaveInsertTextFormat(InsertTextFormat.PlainText);
         }
 
         [TestMethod, Priority(0)]
@@ -499,7 +503,8 @@ class B(A):
             var completion = await server.SendCompletion(uri, 0, 22);
 
             completion.Should().HaveItem("right")
-                .Which.Should().HaveInsertText("right");
+                .Which.Should().HaveInsertText("right")
+                .And.HaveInsertTextFormat(InsertTextFormat.PlainText);
         }
 
         [DataRow(true)]
@@ -1008,7 +1013,7 @@ class Simple(unittest.TestCase):
         public async Task WithWhitespaceAroundDot() {
             using (var s = await CreateServerAsync()) {
                 var u = await s.OpenDefaultDocumentAndGetUriAsync("import sys\nsys  .  version\n");
-                await AssertCompletion(s, u, new[] { "argv" }, null, new SourceLocation(2, 7), 
+                await AssertCompletion(s, u, new[] { "argv" }, null, new SourceLocation(2, 7),
                     new CompletionContext { triggerCharacter = ".", triggerKind = CompletionTriggerKind.TriggerCharacter });
             }
         }

--- a/src/Analysis/Engine/Test/CompletionTests.cs
+++ b/src/Analysis/Engine/Test/CompletionTests.cs
@@ -1051,7 +1051,7 @@ class Simple(unittest.TestCase):
                 items.Select(i => i.Item1).Should().Contain(contains);
 
                 if (allFormat != null) {
-                    items.Select(i => i.Item2).Should().AllBeEquivalentTo(allFormat);
+                    items.Where(i => contains.Contains(i.Item1)).Select(i => i.Item2).Should().AllBeEquivalentTo(allFormat);
                 }
             }
 

--- a/src/Analysis/Engine/Test/FluentAssertions/CompletionItemAssertions.cs
+++ b/src/Analysis/Engine/Test/FluentAssertions/CompletionItemAssertions.cs
@@ -41,6 +41,15 @@ namespace Microsoft.PythonTools.Analysis.FluentAssertions {
         }
 
         [CustomAssertion]
+        public AndConstraint<CompletionItemAssertions> HaveInsertTextFormat(InsertTextFormat insertTextFormat, string because = "", params object[] reasonArgs) {
+            Execute.Assertion.ForCondition(Subject.insertTextFormat == insertTextFormat)
+                .BecauseOf(because, reasonArgs)
+                .FailWith($"Expected '{Subject.label}' completion to have insert text format '{insertTextFormat}'{{reason}}, but it has '{Subject.insertTextFormat}'");
+
+            return new AndConstraint<CompletionItemAssertions>(this);
+        }
+
+        [CustomAssertion]
         public AndConstraint<CompletionItemAssertions> HaveDocumentation(string documentation, string because = "", params object[] reasonArgs) {
             Execute.Assertion.BecauseOf(because, reasonArgs)
                 .AssertIsNotNull(Subject.documentation, $"'{Subject.label}' completion", "documentation", "\'CompletionItem.documentation\'")

--- a/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
+++ b/src/LanguageServer/Impl/Implementation/CompletionAnalysis.cs
@@ -200,8 +200,8 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                         return null;
                     }
 
-                    return addMetadataArg 
-                        ? GetCompletionsFromTopLevel().Append(MetadataArgCompletion) 
+                    return addMetadataArg
+                        ? GetCompletionsFromTopLevel().Append(MetadataArgCompletion)
                         : GetCompletionsFromTopLevel();
 
                 case ForStatement forStatement when TryGetCompletionsInForStatement(forStatement, out var result):
@@ -269,7 +269,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             return GetModules();
         }
 
-        private IEnumerable<CompletionItem> GetModules() 
+        private IEnumerable<CompletionItem> GetModules()
             => Analysis.ProjectState.GetModules().Select(ToCompletionItem);
 
         private IEnumerable<CompletionItem> GetModulesFromNode(DottedName name, bool includeMembers = false) => GetModules(GetNamesFromDottedName(name), includeMembers);
@@ -410,6 +410,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             return new CompletionItem {
                 label = o.Name,
                 insertText = MakeOverrideCompletionString(indent, o, cd.Name),
+                insertTextFormat = InsertTextFormat.PlainText,
                 kind = CompletionItemKind.Method
             };
         }
@@ -799,10 +800,11 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             var doc = _textBuilder.GetDocumentation(m.Values, string.Empty);
             var kind = ToCompletionItemKind(m.MemberType);
-            
+
             var res = new CompletionItem {
                 label = m.Name,
                 insertText = completion,
+                insertTextFormat = InsertTextFormat.PlainText,
                 documentation = string.IsNullOrWhiteSpace(doc) ? null : new MarkupContent {
                     kind = _textBuilder.DisplayOptions.preferredFormat,
                     value = doc
@@ -825,6 +827,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             return new CompletionItem {
                 label = label ?? text,
                 insertText = text,
+                insertTextFormat = InsertTextFormat.PlainText,
                 // Place regular items first, advanced entries last
                 sortText = char.IsLetter(text, 0) ? "1" : "2",
                 kind = ToCompletionItemKind(type),

--- a/src/LanguageServer/Impl/Implementation/Server.Completion.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Completion.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     filterText = x.filterText,
                     preselect = x.preselect,
                     insertText = x.insertText,
+                    insertTextFormat = (PythonTools.Analysis.LanguageServer.InsertTextFormat)x.insertTextFormat,
                 }).ToArray()
             };
 
@@ -169,6 +170,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 filterText = x.filterText,
                 preselect = x.preselect,
                 insertText = x.insertText,
+                insertTextFormat = (InsertTextFormat)x.insertTextFormat,
                 textEdit = x.textEdit.HasValue
                     ? new TextEdit {
                         range = new Range {


### PR DESCRIPTION
Fixes #342.

All places where `insertText` is set, `insertTextFormat` is now also set. Tests which check `insertText` directly also now check `insertTextFormat`. Most tests use AssertCompletion, which I have modified to also check that every matching completion has a specific format. VS complains about the tuple because I used `Item#` instead of an inferred name to access it, which I'd like to do but cannot because this project seems to only be on C# 7.0, not 7.1.

I think it would be better for the classes that use these sorts of enums to explicitly define the default value (especially given so many LSP enums do not contain 0), but there are quite a few enums and a load of duplication in the two Structures.cs files that I'm not going to try to attempt it now.