### PR TITLE
Fix max length of short descriptions and tuple names

### DIFF
--- a/src/Analysis/Engine/Impl/AnalysisLimits.cs
+++ b/src/Analysis/Engine/Impl/AnalysisLimits.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.Analysis {
             limits.DictKeyTypes = 5;
             limits.DictValueTypes = 10;
             limits.IndexTypes = 5;
-            limits.AssignedTypes = 5;
+            limits.AssignedTypes = 10;
             limits.UnifyCallsToNew = true;
             limits.ProcessCustomDecorators = true;
             return limits;
@@ -67,7 +67,7 @@ namespace Microsoft.PythonTools.Analysis {
             DictKeyTypes = 5;
             DictValueTypes = 10;
             IndexTypes = 6;
-            AssignedTypes = 5;
+            AssignedTypes = 10;
             UnifyCallsToNew = true;
             ProcessCustomDecorators = true;
             UseTypeStubPackages = true;

--- a/src/Analysis/Engine/Impl/AnalysisLimits.cs
+++ b/src/Analysis/Engine/Impl/AnalysisLimits.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PythonTools.Analysis {
             limits.DictKeyTypes = 5;
             limits.DictValueTypes = 10;
             limits.IndexTypes = 5;
-            limits.AssignedTypes = 20;
+            limits.AssignedTypes = 5;
             limits.UnifyCallsToNew = true;
             limits.ProcessCustomDecorators = true;
             return limits;
@@ -67,7 +67,7 @@ namespace Microsoft.PythonTools.Analysis {
             DictKeyTypes = 5;
             DictValueTypes = 10;
             IndexTypes = 6;
-            AssignedTypes = 30;
+            AssignedTypes = 5;
             UnifyCallsToNew = true;
             ProcessCustomDecorators = true;
             UseTypeStubPackages = true;

--- a/src/Analysis/Engine/Impl/AnalysisValue.cs
+++ b/src/Analysis/Engine/Impl/AnalysisValue.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PythonTools.Analysis {
                     }
                     _shortDescription = sb.ToString();
                 }
-                return _shortDescription ?? string.Empty;
+                return _shortDescription ?? Description;
             }
         }
 

--- a/src/Analysis/Engine/Impl/Analyzer/InterpreterScope.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/InterpreterScope.cs
@@ -160,7 +160,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         protected static bool AssignVariableWorker(Node location, AnalysisUnit unit, IAnalysisSet values, VariableDef vars) {
             vars.AddAssignment(location, unit);
             vars.MakeUnionStrongerIfMoreThan(unit.State.Limits.AssignedTypes, values);
-            return vars.AddTypes(unit, values);
+            return vars.Types.Count < unit.State.Limits.AssignedTypes
+                    ? vars.AddTypes(unit, values)
+                    : false;
         }
 
         public VariableDef AddLocatedVariable(string name, Node location, AnalysisUnit unit) {

--- a/src/Analysis/Engine/Impl/Values/IterableInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/IterableInfo.cs
@@ -255,7 +255,6 @@ namespace Microsoft.PythonTools.Analysis.Values {
                 }
 
                 var pi = new ProtocolInfo(DeclaringModule, ProjectState);
-                var actualType = unit.State.GetAnalysisValueFromObjects(ClassInfo.TypeId);
                 pi.AddProtocol(new IterableProtocol(pi, union));
                 if (ClassInfo.TypeId == BuiltinTypeId.Tuple) {
                     newTypes = VariableDef.Generator.Take(IndexTypes.Length).ToArray();

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
     }
 
     class TupleProtocol : IterableProtocol {
-        private const int MaxNameLength = 96;
+        private const int MaxDescriptionLength = 96;
         private readonly IAnalysisSet[] _values;
 
         public TupleProtocol(ProtocolInfo self, IEnumerable<IAnalysisSet> values) : base(self, AnalysisSet.UnionAll(values)) {
@@ -398,7 +398,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
             // Enumerate manually since SelectMany drops empty/unknown values
             var sb = new StringBuilder("tuple[");
             for (var i = 0; i < _values.Length; i++) {
-                if (sb.Length >= MaxNameLength) {
+                if (sb.Length >= MaxDescriptionLength) {
                     sb.AppendIf(sb[sb.Length - 1] != '.', "...");
                     break;
                 }
@@ -417,7 +417,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
             sb.AppendIf(sets.Length > 1, "[");
             for (var i = 0; i < sets.Length; i++) {
-                if (sb.Length >= MaxNameLength) {
+                if (sb.Length >= MaxDescriptionLength) {
                     sb.Append("...");
                     break;
                 }

--- a/src/Analysis/Engine/Impl/Values/Protocols.cs
+++ b/src/Analysis/Engine/Impl/Values/Protocols.cs
@@ -386,6 +386,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
     }
 
     class TupleProtocol : IterableProtocol {
+        private const int MaxNameLength = 96;
         private readonly IAnalysisSet[] _values;
 
         public TupleProtocol(ProtocolInfo self, IEnumerable<IAnalysisSet> values) : base(self, AnalysisSet.UnionAll(values)) {
@@ -397,8 +398,12 @@ namespace Microsoft.PythonTools.Analysis.Values {
             // Enumerate manually since SelectMany drops empty/unknown values
             var sb = new StringBuilder("tuple[");
             for (var i = 0; i < _values.Length; i++) {
-               sb.AppendIf(i > 0, ", ");
-               AppendParameterString(sb, _values[i].ToArray());
+                if (sb.Length >= MaxNameLength) {
+                    sb.AppendIf(sb[sb.Length - 1] != '.', "...");
+                    break;
+                }
+                sb.AppendIf(i > 0, ", ");
+                AppendParameterString(sb, _values[i].ToArray());
             }
             sb.Append(']');
             return sb.ToString();
@@ -412,8 +417,13 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
             sb.AppendIf(sets.Length > 1, "[");
             for (var i = 0; i < sets.Length; i++) {
+                if (sb.Length >= MaxNameLength) {
+                    sb.Append("...");
+                    break;
+                }
                 sb.AppendIf(i > 0, ", ");
-                sb.Append(sets[i] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[i].ShortDescription);
+                var text = sets[i] is IHasQualifiedName qn ? qn.FullyQualifiedName : sets[i].ShortDescription;
+                sb.Append(text);
             }
             sb.AppendIf(sets.Length > 1, "]");
         }
@@ -603,7 +613,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public override string Name => "generator";
         public override BuiltinTypeId TypeId => BuiltinTypeId.Generator;
-        
+
         public IAnalysisSet Yielded => _yielded;
         public IAnalysisSet Sent { get; }
         public IAnalysisSet Returned { get; }
@@ -752,7 +762,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
     class DictProtocol : MappingProtocol {
         protected readonly AnalysisValue _actualType;
 
-        public DictProtocol(ProtocolInfo self, AnalysisValue actualType, IAnalysisSet keyTypes, IAnalysisSet valueTypes, IAnalysisSet items) 
+        public DictProtocol(ProtocolInfo self, AnalysisValue actualType, IAnalysisSet keyTypes, IAnalysisSet valueTypes, IAnalysisSet items)
             : base(self, keyTypes, valueTypes, items) {
             _actualType = actualType;
         }

--- a/src/Analysis/Engine/Test/AnalysisTest.cs
+++ b/src/Analysis/Engine/Test/AnalysisTest.cs
@@ -568,7 +568,7 @@ s = y['x']['y']['value']
         }
 
         [TestMethod, Priority(0)]
-        [Ignore("https://github.com/Microsoft/python-language-server/issues/50")]
+
         public async Task RecursiveTuples() {
             var code = @"class A(object):
     def __init__(self):


### PR DESCRIPTION
Fixes #50

- Recursive tuples analysis produced huge description string. Limit that.
- Reduce number of stored types (we don't really need to store various combinations of arguments and return types at all, but that's a different issue). 