### PR TITLE
Ignore LanguageServerException in telemetry

### DIFF
--- a/src/LanguageServer/Impl/TelemetryRpcTraceListener.cs
+++ b/src/LanguageServer/Impl/TelemetryRpcTraceListener.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             switch (exception) {
                 case EditorOperationException _:
                 case NotImplementedException _:
+                case LanguageServerException _:
                     return;
             }
 


### PR DESCRIPTION
This class of exceptions gets thrown a lot, and should't be recorded.