### PR TITLE
Include assembly version number in telemetry event properties, standardize TelemetryEvent creation

### DIFF
--- a/src/LanguageServer/Impl/Telemetry.cs
+++ b/src/LanguageServer/Impl/Telemetry.cs
@@ -23,26 +23,10 @@ using StreamJsonRpc;
 namespace Microsoft.Python.LanguageServer.Implementation {
     internal class Telemetry {
         private const string EventPrefix = "python_language_server/";
-        private static readonly string PLSVersion = GetPLSVersion();
 
-        public static TelemetryEvent CreateEvent(string eventName) {
-            var e = new TelemetryEvent {
-                EventName = EventPrefix + eventName,
-            };
-            e.Properties["plsVersion"] = PLSVersion;
-
-            return e;
-        }
-
-        private static string GetPLSVersion() {
-            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-
-#if DEBUG
-            version += "-debug";  // Add a suffix so we can more easily ignore non-release versions.
-#endif
-
-            return version;
-        }
+        public static TelemetryEvent CreateEvent(string eventName) => new TelemetryEvent {
+            EventName = EventPrefix + eventName,
+        };
     }
 
     internal class TelemetryRpcTraceListener : TraceListener {

--- a/src/LanguageServer/Impl/Telemetry.cs
+++ b/src/LanguageServer/Impl/Telemetry.cs
@@ -47,17 +47,9 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
     internal class TelemetryRpcTraceListener : TraceListener {
         private readonly ITelemetryService2 _telemetryService;
-        private readonly string _version;
 
         public TelemetryRpcTraceListener(ITelemetryService2 telemetryService) {
             _telemetryService = telemetryService;
-
-            // This file is a part of the LanguageServer assembly, so this is the correct version.
-            _version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-
-#if DEBUG
-            _version += "-debug";  // Add a suffix so we can more easily ignore non-release versions.
-#endif
         }
 
         // See JsonRpc.CreateError.

--- a/src/LanguageServer/Impl/TelemetryRpcTraceListener.cs
+++ b/src/LanguageServer/Impl/TelemetryRpcTraceListener.cs
@@ -23,9 +23,17 @@ using StreamJsonRpc;
 namespace Microsoft.Python.LanguageServer.Implementation {
     internal class TelemetryRpcTraceListener : TraceListener {
         private readonly ITelemetryService2 _telemetryService;
+        private readonly string _version;
 
         public TelemetryRpcTraceListener(ITelemetryService2 telemetryService) {
             _telemetryService = telemetryService;
+
+            // This file is a part of the LanguageServer assembly, so this is the correct version.
+            _version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+
+#if DEBUG
+            _version += "-debug";  // Add a suffix so we can more easily ignore non-release versions.
+#endif
         }
 
         // See JsonRpc.CreateError.
@@ -70,6 +78,9 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             e.Properties["method"] = method;
             e.Properties["name"] = exception.GetType().Name;
             e.Properties["stackTrace"] = exception.StackTrace;
+
+            // TODO: Move this into a shared function, similarly to EventName.
+            e.Properties["version"] = _version;
 
             _telemetryService.SendTelemetry(e).DoNotWait();
         }


### PR DESCRIPTION
Fixes #373.

The "default" version for the assembly is 1.0.0.0 (which shows up when running a locally built copy), so I've added the suffix `-debug` when `DEBUG` is set in order to distinguish events if we reach a 1.0.0.0 release.