### PR TITLE
Improve line formatter behavior with unmatched close brackets, log warning

### DIFF
--- a/src/LanguageServer/Impl/Implementation/Server.OnTypeFormatting.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.OnTypeFormatting.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
                 if (unmatchedToken != null) {
                     var message = Resources.LineFormatter_UnmatchedToken.FormatInvariant(unmatchedToken.Value.token, unmatchedToken.Value.line + 1);
-                    ShowMessage(MessageType.Warning, message);
+                    LogMessage(MessageType.Warning, message);
                 }
 
                 return edits;

--- a/src/LanguageServer/Impl/Implementation/Server.OnTypeFormatting.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.OnTypeFormatting.cs
@@ -18,6 +18,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PythonTools.Analysis;
+using Microsoft.PythonTools.Analysis.Infrastructure;
 
 namespace Microsoft.Python.LanguageServer.Implementation {
     public sealed partial class Server {
@@ -49,7 +50,15 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 }
 
                 var lineFormatter = new LineFormatter(reader, Analyzer.LanguageVersion);
-                return lineFormatter.FormatLine(targetLine);
+                var edits = lineFormatter.FormatLine(targetLine);
+                var unmatchedToken = lineFormatter.UnmatchedToken(targetLine);
+
+                if (unmatchedToken != null) {
+                    var message = Resources.LineFormatter_UnmatchedToken.FormatInvariant(unmatchedToken.Value.token, unmatchedToken.Value.line + 1);
+                    ShowMessage(MessageType.Warning, message);
+                }
+
+                return edits;
             }
         }
     }

--- a/src/LanguageServer/Impl/Resources.Designer.cs
+++ b/src/LanguageServer/Impl/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.Python.LanguageServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unmatched token &apos;{0}&apos; on line {1}; line formatting may not be accurate..
+        /// </summary>
+        internal static string LineFormatter_UnmatchedToken {
+            get {
+                return ResourceManager.GetString("LineFormatter_UnmatchedToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Reloading modules... .
         /// </summary>
         internal static string ReloadingModules {

--- a/src/LanguageServer/Impl/Resources.resx
+++ b/src/LanguageServer/Impl/Resources.resx
@@ -132,6 +132,9 @@
   <data name="LanguageServerVersion" xml:space="preserve">
     <value>Microsoft Python Language Server version {0}</value>
   </data>
+  <data name="LineFormatter_UnmatchedToken" xml:space="preserve">
+    <value>Unmatched token '{0}' on line {1}; line formatting may not be accurate.</value>
+  </data>
   <data name="ReloadingModules" xml:space="preserve">
     <value>Reloading modules... </value>
   </data>


### PR DESCRIPTION
Fixes #388.

Instead of throwing a generic exception, keep track of the unmatched token for later use, and just ignore it. When the line formatting is done, DocumentOnTypeFormatting can check to see if an unmatched token occurred before or in the line being formatted and report to the user a warning about the bad behavior.

I also fixed the comment strings that claimed that the line formatter worked with one-indexed lines, which is no longer true after Alex's changes to this code.