### PR TITLE
Don't modify the DDG scope when analyzing the comprehension

### DIFF
--- a/src/Analysis/Engine/Impl/AnalysisUnit.cs
+++ b/src/Analysis/Engine/Impl/AnalysisUnit.cs
@@ -478,14 +478,9 @@ namespace Microsoft.PythonTools.Analysis {
 
         internal override void AnalyzeWorker(DDG ddg, CancellationToken cancel) {
             var comp = (Comprehension)Ast;
-            var forComp = comp.Iterators[0] as ComprehensionFor;
 
-            if (forComp != null) {
-                // evaluate the 1st iterator in the outer scope
-                ddg.Scope = _outerUnit.InterpreterScope;
+            if (comp.Iterators[0] is ComprehensionFor forComp) {
                 var listTypes = ddg._eval.Evaluate(forComp.List);
-                ddg.Scope = InterpreterScope;
-
                 ddg._eval.AssignTo(comp, forComp.Left, listTypes.GetEnumeratorTypes(comp, this));
             }
 

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -384,6 +384,21 @@ def f(b: None) -> None:
             }
         }
 
+        [DataRow("mylist = [1, 2, 3, 4]\nx = [[a for a in range(item)] for item in mylist]")]
+        [DataRow("mydict = {1: 2, 3: 4}\nx = [[a for a in range(v)] for k, v in mydict.items()]")]
+        [DataRow("myset = set([1, 2, 3, 4])\nx = [[a for a in range(item)] for item in myset]")]
+        [DataRow("mydict = {1: 2, 3: 4}\nx = {k: [a for a in range(v)] for k, v in mydict.items()}")]
+        [DataTestMethod, Priority(0)]
+        public async Task NestedComprehensionDiagnostic(string code) {
+            var diags = new Dictionary<Uri, PublishDiagnosticsEventArgs>();
+            using (var s = await CreateServer((Uri)null, null, diags)) {
+                var u = await s.OpenDefaultDocumentAndGetUriAsync(code);
+
+                await s.WaitForCompleteAnalysisAsync(CancellationToken.None);
+                GetDiagnostics(diags, u).Should().BeEmpty();
+            }
+        }
+
         [TestMethod, Priority(0)]
         public async Task OnTypeFormattingLine() {
             using (var s = await CreateServer()) {


### PR DESCRIPTION
Fixes #387.

I'm not sure why the old code modified `ddg.Scope`. I'm not a DDG expert yet, but this is the only place where the scope gets explicitly changed by something other than the DDG class itself, which feels wrong (especially given that it doesn't put it back the way it was, instead changing it to some other scope entirely).

The code I'm removing was added in: https://github.com/Microsoft/PTVS/commit/861e1e4e3559d165615631733cfc3953292a52ff#diff-20d37dda723b616a828c08df50fc739b

If I'm missing something obvious here, let me know.