### PR TITLE
Special case known good names for use-before-def

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
@@ -150,7 +150,18 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         res = refs.Types;
                     } else {
                         // ... warn the user
-                        warn = !(node is ConstantExpression); // Don't warn when None.
+                        // "atom" in Python grammar.
+                        switch (name) {
+                            case "None":
+                            case "False":
+                            case "True":
+                            case "...":
+                            case string _ when node is ConstantExpression:
+                                break;
+                            default:
+                                warn = true;
+                                break;
+                        }
                     }
                 }
             }

--- a/src/Analysis/Engine/Test/LanguageServerTests.cs
+++ b/src/Analysis/Engine/Test/LanguageServerTests.cs
@@ -363,17 +363,14 @@ def f(a = 2, b): pass
             }
         }
 
-        [TestMethod, Priority(0)]
-        public async Task TypeHintNoneDiagnostic() {
+        [DataRow("def f(b: None) -> None:\n    b: None")]
+        [DataRow("from typing import Generator\ndef fun() -> Generator[int, None, None]:\n    yield from range(10)")]
+        [DataTestMethod, Priority(0)]
+        public async Task TypeHintNoneDiagnostic(string code) {
             if (this is LanguageServerTests_V2) {
                 // No type hints in Python 2.
                 return;
             }
-
-            var code = @"
-def f(b: None) -> None:
-    b: None
-";
 
             var diags = new Dictionary<Uri, PublishDiagnosticsEventArgs>();
             using (var s = await CreateServer((Uri)null, null, diags)) {


### PR DESCRIPTION
Fixes #391.

Sort of a hack, but these hardcoded names are pulled from the list of atoms in the Python grammar. I've still been unable to reproduce True/False being use-before-def (other than once without a debugger attached), but it shouldn't occur given that I now explicitly ignore them.

Unfortunately, this may mask a bug in `ProjectState.BuiltinModule.GetMember`, since I don't think there's a good reason why `None` should fail to be found...