### PR TITLE
Fix nullref in SpecializedNamespace and arg-null ProtocolInfo dict access

### DIFF
--- a/src/Analysis/Engine/Impl/Values/ProtocolInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/ProtocolInfo.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PythonTools.Analysis.Values {
 
         public override IEnumerable<ILocationInfo> Locations {
             get {
-                if (!_references.TryGetValue(DeclaringModule, out var defns)) {
+                if (DeclaringModule == null || !_references.TryGetValue(DeclaringModule, out var defns)) {
                     return Enumerable.Empty<ILocationInfo>();
                 }
                 return defns.Definitions.Select(l => l.GetLocationInfo()).ExcludeDefault();

--- a/src/Analysis/Engine/Impl/Values/SpecializedNamespace.cs
+++ b/src/Analysis/Engine/Impl/Values/SpecializedNamespace.cs
@@ -209,15 +209,15 @@ namespace Microsoft.PythonTools.Analysis.Values {
             return _original.IsOfType(klass);
         }
 
-        public override IEnumerable<ILocationInfo> Locations => _original?.Locations?.MaybeEnumerate();
+        public override IEnumerable<ILocationInfo> Locations => _original?.Locations.MaybeEnumerate();
 
         public override string Name => _original == null ? base.Name : _original.Name;
 
-        public override IEnumerable<OverloadResult> Overloads =>_original.Overloads.MaybeEnumerate();
+        public override IEnumerable<OverloadResult> Overloads => _original?.Overloads.MaybeEnumerate();
 
         public override IPythonType PythonType => _original?.PythonType;
 
-        internal override IEnumerable<ILocationInfo> References => _original.References?.MaybeEnumerate();
+        internal override IEnumerable<ILocationInfo> References => _original?.References.MaybeEnumerate();
 
         public override PythonMemberType MemberType => _original == null ? PythonMemberType.Unknown : _original.MemberType;
 


### PR DESCRIPTION
Fixes #449.

Also fixes an ArgumentNullException in a dictionary TryGetValue in ProtocolInfo. I'm not sure why that one is happening, but it's also showing up as frequently as the SpecializedNamespace issue.