### PR TITLE
Send telemetry on unhandled exceptions inside the AnalysisQueue

### DIFF
--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -465,8 +465,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             }
 
             var te = Telemetry.CreateEventWithException("analyzer.unhandledException", ex);
-            te.Properties["isTerminating"] = e.IsTerminating.ToString();
-
             _telemetry.SendTelemetry(te).DoNotWait();
         }
 

--- a/src/LanguageServer/Impl/Telemetry.cs
+++ b/src/LanguageServer/Impl/Telemetry.cs
@@ -30,22 +30,20 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         public static TelemetryEvent CreateEventWithException(string eventName, Exception e) {
             var te = CreateEvent(eventName);
+
+            if (e is AggregateException ae && ae.InnerException != null) {
+                te.Properties["outerName"] = e.GetType().Name;
+                te.Properties["outerStackTrace"] = e.StackTrace;
+
+                e = ae.Flatten();
+
+                while (e.InnerException != null) {
+                    e = e.InnerException;
+                }
+            }
+
             te.Properties["name"] = e.GetType().Name;
             te.Properties["stackTrace"] = e.StackTrace;
-
-            var inner = e.InnerException;
-            if (inner != null) {
-                if (inner is AggregateException ae) {
-                    inner = ae.Flatten();
-                }
-
-                while (inner.InnerException != null) {
-                    inner = inner.InnerException;
-                }
-
-                te.Properties["innerName"] = inner.GetType().Name;
-                te.Properties["innerStackTrace"] = inner.StackTrace;
-            }
 
             return te;
         }


### PR DESCRIPTION
Fixes #445.

I've also reworked the telemetry for exception-type events to a common place. If the exception is an AggregateException, then the first inner exception is the "main" exception reported. The outer exception is also included, but in different fields. This makes it easier to group events by where the first exception thrown actually occurs rather than special casing it in some query later.

AggregateExceptions can of course contain more than one inner exception, but because the telemetry properties must be strings, we can't really represent them without encoding something to JSON first and then re-parsing it later. I'd rather not bother until we have a good reason to send a big blob in the telemetry events.

One thing I want feedback on: Is `analyzer.unhandledException` alright for the event name?