### PR TITLE
add hack to prevent True/False/None/... from being use-before-def

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/ExpressionEvaluator.cs
@@ -149,8 +149,19 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                         refs = createIn.CreateVariable(node, _unit, name, addRef);
                         res = refs.Types;
                     } else {
-                        // ... warn the user
-                        warn = true;
+                        switch (name) {
+                            // "atom" in Python grammar.
+                            case "True":
+                            case "False":
+                            case "None":
+                            case "...":
+                                Debug.Fail($"Known good name '{name}' not found in scope");
+                                break;
+                            default:
+                                // ... warn the user
+                                warn = true;
+                                break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a hack to "fix" #391. This isn't in the milestone, but it'd be nice to no longer show these messages in the next release while we find the real problem. If we get it while debugging, it'll at least do a `Debug.Fail`.