### PR TITLE
Fix for extra paths inside workspace

### DIFF
--- a/src/Analysis/Engine/Impl/DependencyResolution/PathResolverSnapshot.cs
+++ b/src/Analysis/Engine/Impl/DependencyResolution/PathResolverSnapshot.cs
@@ -359,11 +359,11 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
                 .ToArray();
 
             var filteredInterpreterSearchPaths = interpreterSearchPaths.Select(FixPath)
-                .Except(filteredUserSearchPaths.Prepend(rootDirectory))
+                .Except(filteredUserSearchPaths.Append(rootDirectory))
                 .ToArray();
 
             userRootsCount = filteredUserSearchPaths.Length + 1;
-            nodes = AddRootsFromSearchPaths(ImmutableArray<Node>.Empty.Add(GetOrCreateRoot(rootDirectory)), filteredUserSearchPaths, filteredInterpreterSearchPaths);
+            nodes = AddRootsFromSearchPaths(rootDirectory, filteredUserSearchPaths, filteredInterpreterSearchPaths);
 
             string FixPath(string p) => Path.IsPathRooted(p) ? PathUtils.NormalizePath(p) : PathUtils.NormalizePath(Path.Combine(rootDirectory, p));
         }
@@ -381,11 +381,18 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
                 .ToArray();
 
             userRootsCount = filteredUserSearchPaths.Length;
-            nodes = AddRootsFromSearchPaths(ImmutableArray<Node>.Empty, filteredUserSearchPaths, filteredInterpreterSearchPaths);
+            nodes = AddRootsFromSearchPaths(filteredUserSearchPaths, filteredInterpreterSearchPaths);
         }
 
-        private ImmutableArray<Node> AddRootsFromSearchPaths(ImmutableArray<Node> roots, string[] userSearchPaths, string[] interpreterSearchPaths) {
-            return roots
+        private ImmutableArray<Node> AddRootsFromSearchPaths(string rootDirectory, string[] userSearchPaths, string[] interpreterSearchPaths) {
+            return ImmutableArray<Node>.Empty
+                .AddRange(userSearchPaths.Select(GetOrCreateRoot).ToArray())
+                .Add(GetOrCreateRoot(rootDirectory))
+                .AddRange(interpreterSearchPaths.Select(GetOrCreateRoot).ToArray());
+        }
+
+        private ImmutableArray<Node> AddRootsFromSearchPaths(string[] userSearchPaths, string[] interpreterSearchPaths) {
+            return ImmutableArray<Node>.Empty
                 .AddRange(userSearchPaths.Select(GetOrCreateRoot).ToArray())
                 .AddRange(interpreterSearchPaths.Select(GetOrCreateRoot).ToArray());
         }

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -129,8 +129,8 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         private void ReloadModulePaths(in IEnumerable<string> rootPaths) {
-            foreach (var modulePath in rootPaths.Where(Directory.Exists).SelectMany(p => ModulePath.GetModulesInPath(p))) {
-                _pathResolver.TryAddModulePath(modulePath.SourceFile, out _);
+            foreach (var modulePath in rootPaths.Where(Directory.Exists).SelectMany(p => PathUtils.EnumerateFiles(p))) {
+                _pathResolver.TryAddModulePath(modulePath, out _);
             }
         }
 

--- a/src/Analysis/Engine/Test/ServerExtensions.cs
+++ b/src/Analysis/Engine/Test/ServerExtensions.cs
@@ -164,6 +164,14 @@ namespace Microsoft.PythonTools.Analysis {
             }, GetCancellationToken());
         }
 
+        public static async Task<IModuleAnalysis> OpenDocumentAndGetAnalysisAsync(this Server server, string relativePath, string content, int failAfter = 30000, string languageId = null) {
+            var cancellationToken = GetCancellationToken(failAfter);
+            var uri = TestData.GetTestSpecificUri(relativePath);
+            await server.SendDidOpenTextDocument(uri, content, languageId);
+            cancellationToken.ThrowIfCancellationRequested();
+            return await server.GetAnalysisAsync(uri, cancellationToken);
+        }
+
         public static async Task<IModuleAnalysis> OpenDefaultDocumentAndGetAnalysisAsync(this Server server, string content, int failAfter = 30000, string languageId = null) {
             var cancellationToken = GetCancellationToken(failAfter);
             await server.SendDidOpenTextDocument(TestData.GetDefaultModuleUri(), content, languageId);


### PR DESCRIPTION
Fix #281: Support "go to definition" for namespace packages
Fix #466: Fix "go to definition" and resolving imports

The fix is to put user search paths in front of workspace directory so that modules inside extra paths can be used as roots for packages