### PR TITLE
Fix invalid cast in GetBuiltinType

### DIFF
--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -596,10 +596,11 @@ namespace Microsoft.PythonTools.Analysis {
 
         internal BuiltinInstanceInfo GetInstance(IPythonType type) => GetBuiltinType(type).Instance;
 
-        internal BuiltinClassInfo GetBuiltinType(IPythonType type) =>
-            (BuiltinClassInfo)GetCached(type,
-                () => MakeBuiltinType(type)
-            ) ?? ClassInfos[BuiltinTypeId.Object];
+        internal BuiltinClassInfo GetBuiltinType(IPythonType type)
+            // Cached value may or may not be a class info. Previous calls to GetAnalysisValueFromObjects
+            // may have cached a different object for the type. For example, IPythonFunction would cache
+            // BuiltinFunctionInfo and not BuiltinClassInfo. Therefore, don't use direct cast.
+            => GetCached(type, () => MakeBuiltinType(type)) as BuiltinClassInfo ?? MakeBuiltinType(type);
 
         private BuiltinClassInfo MakeBuiltinType(IPythonType type) {
             switch (type.TypeId) {


### PR DESCRIPTION
Fixes #470 

Cached value may or may not be a class info. Previous calls to `GetAnalysisValueFromObjects` may have cached a different object for the type. For example, `IPythonFunction` would cache `BuiltinFunctionInfo` and not `BuiltinClassInfo`.

Before https://github.com/Microsoft/python-language-server/pull/439 it worked since `IPythonFunction` and `IPythonClass` were not `IPythonType` and in `GetAnalysisValueFromObjects` `IPythonType` was handled first so the cache would always contain item created for `IPythonType` as the first in the order of processing. This is no longer true. 

The fix is not ideal, another approach is to create different caches for different types.