### PR TITLE
Mitigate some of #495 via MRO member selection and analysis set optimization

### DIFF
--- a/src/Analysis/Engine/Impl/AnalysisHashSet.cs
+++ b/src/Analysis/Engine/Impl/AnalysisHashSet.cs
@@ -275,7 +275,15 @@ namespace Microsoft.PythonTools.Analysis.AnalysisSetDetails {
                 return true;
             }
 
+            if (Count == 0 && other.Count == 0) {
+                return true;
+            }
+
             if (Comparer == other.Comparer) {
+                if (Count != other.Count) {
+                    return false;
+                }
+
                 // Quick check for any unmatched hashcodes.
                 // This can conclusively prove the sets are not equal, but cannot
                 // prove equality.
@@ -290,17 +298,16 @@ namespace Microsoft.PythonTools.Analysis.AnalysisSetDetails {
                 }
             }
 
-            var otherHc = new HashSet<AnalysisValue>(other, _comparer);
-            foreach (var key in this) {
-                if (!otherHc.Remove(key)) {
-                    return false;
-                }
-            }
-            if (otherHc.Any()) {
+            if (Count == 0 || other.Count == 0) {
                 return false;
             }
 
-            return true;
+            if (Count == 1 && other.Count == 1) {
+                return _comparer.Equals(this.First(), other.First());
+            }
+
+            var hs = new HashSet<AnalysisValue>(other, _comparer);
+            return hs.SetEquals(this);
         }
 
         /// <summary>

--- a/src/Analysis/Engine/Impl/AnalysisHashSet.cs
+++ b/src/Analysis/Engine/Impl/AnalysisHashSet.cs
@@ -275,12 +275,16 @@ namespace Microsoft.PythonTools.Analysis.AnalysisSetDetails {
                 return true;
             }
 
-            if (Count == 0 && other.Count == 0) {
+            // Only access Count once to prevent wasted time in bucket locks.
+            var lCount = Count;
+            var rCount = other.Count;
+
+            if (lCount == 0 && rCount == 0) {
                 return true;
             }
 
             if (Comparer == other.Comparer) {
-                if (Count != other.Count) {
+                if (lCount != rCount) {
                     return false;
                 }
 
@@ -298,11 +302,11 @@ namespace Microsoft.PythonTools.Analysis.AnalysisSetDetails {
                 }
             }
 
-            if (Count == 0 || other.Count == 0) {
+            if (lCount == 0 || rCount == 0) {
                 return false;
             }
 
-            if (Count == 1 && other.Count == 1) {
+            if (lCount == 1 && rCount == 1) {
                 return _comparer.Equals(this.First(), other.First());
             }
 

--- a/src/Analysis/Engine/Impl/AnalysisSet.cs
+++ b/src/Analysis/Engine/Impl/AnalysisSet.cs
@@ -534,6 +534,8 @@ namespace Microsoft.PythonTools.Analysis {
     sealed class ObjectComparer : IEqualityComparer<AnalysisValue>, IEqualityComparer<IAnalysisSet> {
         public static readonly ObjectComparer Instance = new ObjectComparer();
 
+        private ObjectComparer() { }
+
         public bool Equals(AnalysisValue x, AnalysisValue y) {
 #if FULL_VALIDATION
             if (x != null && y != null) {
@@ -574,7 +576,7 @@ namespace Microsoft.PythonTools.Analysis {
 
         public readonly int Strength;
 
-        public UnionComparer(int strength = 0) {
+        private UnionComparer(int strength = 0) {
             Strength = strength;
         }
 

--- a/src/Analysis/Engine/Impl/Intellisense/AnalysisQueue.cs
+++ b/src/Analysis/Engine/Impl/Intellisense/AnalysisQueue.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PythonTools.Intellisense {
         }
 
         private sealed class QueueItemComparer : IEqualityComparer<QueueItem> {
-            public static IEqualityComparer<QueueItem> Instance { get; } = new QueueItemComparer();
+            public static readonly IEqualityComparer<QueueItem> Instance = new QueueItemComparer();
 
             private QueueItemComparer() { }
             public bool Equals(QueueItem x, QueueItem y) => Equals(x.Key, y.Key);

--- a/src/Analysis/Engine/Impl/LocationInfo.cs
+++ b/src/Analysis/Engine/Impl/LocationInfo.cs
@@ -83,9 +83,13 @@ namespace Microsoft.PythonTools.Analysis {
         /// Provides an IEqualityComparer that compares line, column and project entries.  By
         /// default locations are equaitable based upon only line/project entry.
         /// </summary>
-        public static IEqualityComparer<ILocationInfo> FullComparer { get; } = new FullLocationComparer();
+        public static IEqualityComparer<ILocationInfo> FullComparer => FullLocationComparer.Instance;
 
         sealed class FullLocationComparer : IEqualityComparer<ILocationInfo>, IEqualityComparer<LocationInfo> {
+            public static readonly FullLocationComparer Instance = new FullLocationComparer();
+
+            private FullLocationComparer() { }
+
             public bool Equals(LocationInfo x, LocationInfo y) => Equals(x, y);
             public bool Equals(ILocationInfo x, ILocationInfo y) {
                 return x.StartLine == y.StartLine &&

--- a/src/Analysis/Engine/Impl/OverloadResult.cs
+++ b/src/Analysis/Engine/Impl/OverloadResult.cs
@@ -425,8 +425,8 @@ namespace Microsoft.PythonTools.Analysis {
     }
 
     class OverloadResultComparer : EqualityComparer<OverloadResult> {
-        public static IEqualityComparer<OverloadResult> Instance = new OverloadResultComparer(false);
-        public static IEqualityComparer<OverloadResult> WeakInstance = new OverloadResultComparer(true);
+        public static readonly IEqualityComparer<OverloadResult> Instance = new OverloadResultComparer(false);
+        public static readonly IEqualityComparer<OverloadResult> WeakInstance = new OverloadResultComparer(true);
 
         private readonly bool _weak;
 

--- a/src/Analysis/Engine/Impl/PythonAnalyzer.cs
+++ b/src/Analysis/Engine/Impl/PythonAnalyzer.cs
@@ -921,7 +921,9 @@ namespace Microsoft.PythonTools.Analysis {
         }
 
         class AggregateComparer : IEqualityComparer<IProjectEntry[]> {
-            public static AggregateComparer Instance = new AggregateComparer();
+            public static readonly AggregateComparer Instance = new AggregateComparer();
+
+            private AggregateComparer() { }
 
             public bool Equals(IProjectEntry[] x, IProjectEntry[] y) {
                 if (x.Length != y.Length) {

--- a/src/Analysis/Engine/Impl/Values/ClassInfo.cs
+++ b/src/Analysis/Engine/Impl/Values/ClassInfo.cs
@@ -831,6 +831,10 @@ namespace Microsoft.PythonTools.Analysis.Values {
                         result = result.Union(ns.GetMember(node, unit, name));
                     }
                 }
+
+                if (result != null && result.Count > 0) {
+                    break;
+                }
             }
             return result;
         }


### PR DESCRIPTION
This isn't a complete fix, but does seem to improve #495 in some cases. Adds back the early MRO return removed in #277, so now large class hierarchies won't over-propagate types (where some of the trouble with fastai happens do to the Transform class). I also optimized AnalysisHashSet a little to do length checks when possible.

There are still times when things get caught up comparing unions for a while, but it seems to be nondeterministic.