### PR TITLE
Two path resolution bug fixes

### DIFF
--- a/src/Analysis/Engine/Impl/Analyzer/DDG.cs
+++ b/src/Analysis/Engine/Impl/Analyzer/DDG.cs
@@ -296,6 +296,9 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
                 case ImportNotFound notFound:
                     MakeUnresolvedImport(notFound.FullName, node.Root);
                     return false;
+                case NoKnownParentPackage _:
+                    MakeNoKnownParentPackageImport(node.Root);
+                    return false;
                 default:
                     return false;
             }
@@ -462,6 +465,10 @@ namespace Microsoft.PythonTools.Analysis.Analyzer {
         private void MakeUnresolvedImport(string name, Node spanNode) {
             _unit.DeclaringModule.AddUnresolvedModule(name);
             ProjectState.AddDiagnostic(spanNode, _unit, ErrorMessages.UnresolvedImport(name), DiagnosticSeverity.Warning, ErrorMessages.UnresolvedImportCode);
+        }
+
+        private void MakeNoKnownParentPackageImport(Node spanNode) {
+            ProjectState.AddDiagnostic(spanNode, _unit, Resources.ErrorRelativeImportNoPackage, DiagnosticSeverity.Warning, ErrorMessages.UnresolvedImportCode);
         }
 
         private void ImportModule(in ImportStatement node, in IModule module, in DottedName moduleImportExpression, in NameExpression asNameExpression) {

--- a/src/Analysis/Engine/Impl/DependencyResolution/NoKnownParentPackage.cs
+++ b/src/Analysis/Engine/Impl/DependencyResolution/NoKnownParentPackage.cs
@@ -1,0 +1,19 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.PythonTools.Analysis.DependencyResolution {
+    internal class NoKnownParentPackage : IImportSearchResult { }
+}

--- a/src/Analysis/Engine/Impl/DependencyResolution/PathResolverSnapshot.cs
+++ b/src/Analysis/Engine/Impl/DependencyResolution/PathResolverSnapshot.cs
@@ -186,16 +186,11 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
                 return default;
             }
 
-            if (parentCount > lastEdge.PathLength) {
-                // Can't get outside of the root
-                return default;
-            }
-
             var fullNameList = relativePath.ToList();
             if (lastEdge.IsNonRooted) {
                 // Handle relative imports only for modules in the same folder
                 if (parentCount > 1) {
-                    return default;
+                    return new NoKnownParentPackage();
                 }
 
                 if (parentCount == 1 && fullNameList.Count == 1 && lastEdge.Start.TryGetChild(fullNameList[0], out var nameNode)) {
@@ -208,12 +203,27 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
                     .ToString());
             }
 
+            var relativeInWorkDirectory = false;
+            if (parentCount > lastEdge.PathLength - 2) {
+                relativeInWorkDirectory = _workDirectory.EqualsOrdinal(lastEdge.FirstEdge.End.Name, IgnoreCaseInPaths);
+
+                // Relative path must be only inside package
+                // Exception for working directory cause it can be a root directory of the package
+                if (!relativeInWorkDirectory) {
+                    return new NoKnownParentPackage();
+                }
+            }
+
             var relativeParentEdge = lastEdge.GetPrevious(parentCount);
 
             var rootEdges = new List<Edge>();
-            for (var i = 0; i < _roots.Count; i++) {
-                if (RootContains(i, relativeParentEdge, out var rootEdge)) {
-                    rootEdges.Add(rootEdge);
+            if (relativeInWorkDirectory) {
+                rootEdges.Add(lastEdge.FirstEdge);
+            } else {
+                for (var i = 0; i < _roots.Count; i++) {
+                    if (RootContains(i, relativeParentEdge, out var rootEdge)) {
+                        rootEdges.Add(rootEdge);
+                    }
                 }
             }
 
@@ -225,7 +235,13 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
                 return default;
             }
 
-            var fullName = GetFullModuleNameBuilder(relativeParentEdge).Append(".", fullNameList).ToString();
+            var fullNameBuilder = GetFullModuleNameBuilder(relativeParentEdge);
+            if (!relativeParentEdge.IsFirst) {
+                AppendName(fullNameBuilder, relativeParentEdge.End.Name);
+                fullNameBuilder.Append(".");
+            }
+            var fullName = fullNameBuilder.Append(".", fullNameList).ToString();
+
             return new ImportNotFound(fullName);
         }
 
@@ -249,7 +265,7 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
             => TryCreateModuleImport(lastEdge.FirstEdge.End, lastEdge.End, out moduleImport);
 
         private static bool TryCreateModuleImport(Node rootNode, Node moduleNode, out ModuleImport moduleImport) {
-            if (moduleNode.TryGetChild("__init__", out var initPyNode) && initPyNode.IsModule) {
+            if (IsPackageWithInitPy(moduleNode, out var initPyNode)) {
                 moduleImport = new ModuleImport(moduleNode.Name, initPyNode.FullModuleName, rootNode.Name, initPyNode.ModulePath, false);
                 return true;
             }
@@ -516,7 +532,7 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
         private static bool TryFindName(in Edge edge, in IEnumerable<string> nameParts, out Edge lastEdge) {
             lastEdge = edge;
             foreach (var name in nameParts) {
-                if (lastEdge.End.IsModule) {
+                if (lastEdge.End.IsModule && !IsPackageWithInitPy(lastEdge.End, out _)) {
                     return false;
                 }
                 var index = lastEdge.End.GetChildIndex(name);
@@ -652,7 +668,7 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
             while (edge != lastEdge) {
                 AppendName(sb, edge.End.Name);
                 edge = edge.Next;
-            };
+            }
 
             return sb;
         }
@@ -742,6 +758,9 @@ namespace Microsoft.PythonTools.Analysis.DependencyResolution {
 
         private static int GetModuleNameEnd(string rootedModulePath) 
             => IsPythonCompiled(rootedModulePath) ? rootedModulePath.IndexOf('.', GetModuleNameStart(rootedModulePath)) : rootedModulePath.LastIndexOf('.');
+
+        private static bool IsPackageWithInitPy(Node node, out Node initPyNode)
+            => node.TryGetChild("__init__", out initPyNode) && initPyNode.IsModule;
 
         private static bool IsNotInitPy(string name)
             => !name.EqualsOrdinal("__init__");

--- a/src/Analysis/Engine/Impl/Infrastructure/Extensions/StringExtensions.cs
+++ b/src/Analysis/Engine/Impl/Infrastructure/Extensions/StringExtensions.cs
@@ -195,6 +195,9 @@ namespace Microsoft.PythonTools.Analysis.Infrastructure {
         public static bool EqualsOrdinal(this string s, string other)
             => string.Equals(s, other, StringComparison.Ordinal);
 
+        public static bool EqualsOrdinal(this string s, string other, bool ignoreCase)
+            => string.Equals(s, other, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
         public static bool EqualsOrdinal(this string s, int index, string other, int otherIndex, int length, bool ignoreCase = false)
             => string.Compare(s, index, other, otherIndex, length, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == 0;
 

--- a/src/Analysis/Engine/Impl/Resources.Designer.cs
+++ b/src/Analysis/Engine/Impl/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.PythonTools.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to attempted relative import with no known parent package.
+        /// </summary>
+        internal static string ErrorRelativeImportNoPackage {
+            get {
+                return ResourceManager.GetString("ErrorRelativeImportNoPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to unresolved import &apos;{0}&apos;.
         /// </summary>
         internal static string ErrorUnresolvedImport {

--- a/src/Analysis/Engine/Impl/Resources.resx
+++ b/src/Analysis/Engine/Impl/Resources.resx
@@ -312,6 +312,9 @@
   <data name="ErrorUnresolvedImport" xml:space="preserve">
     <value>unresolved import '{0}'</value>
   </data>
+  <data name="ErrorRelativeImportNoPackage" xml:space="preserve">
+    <value>attempted relative import with no known parent package</value>
+  </data>
   <data name="ErrorUseBeforeDef" xml:space="preserve">
     <value>'{0}' used before definition</value>
   </data>

--- a/src/Analysis/Engine/Test/AddTestSpecificSearchPathAttribute.cs
+++ b/src/Analysis/Engine/Test/AddTestSpecificSearchPathAttribute.cs
@@ -1,0 +1,28 @@
+// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+
+namespace AnalysisTests {
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class AddTestSpecificSearchPathAttribute : Attribute {
+        public string RelativeSearchPath { get; }
+
+        public AddTestSpecificSearchPathAttribute(string relativeSearchPath) {
+            RelativeSearchPath = relativeSearchPath;
+        }
+    }
+}

--- a/src/Analysis/Engine/Test/EventTaskSources.cs
+++ b/src/Analysis/Engine/Test/EventTaskSources.cs
@@ -37,6 +37,11 @@ namespace AnalysisTests {
                 new EventTaskSource<Microsoft.Python.LanguageServer.Implementation.Server, Microsoft.Python.LanguageServer.ParseCompleteEventArgs>(
                     (o, e) => o.OnParseComplete += e,
                     (o, e) => o.OnParseComplete -= e);
+
+            public static readonly EventTaskSource<Microsoft.Python.LanguageServer.Implementation.Server, Microsoft.Python.LanguageServer.PublishDiagnosticsEventArgs> OnPublishDiagnostics =
+                new EventTaskSource<Microsoft.Python.LanguageServer.Implementation.Server, Microsoft.Python.LanguageServer.PublishDiagnosticsEventArgs>(
+                    (o, e) => o.OnPublishDiagnostics += e,
+                    (o, e) => o.OnPublishDiagnostics -= e);
         }
     }
 }

--- a/src/Analysis/Engine/Test/ServerTestMethodAttribute.cs
+++ b/src/Analysis/Engine/Test/ServerTestMethodAttribute.cs
@@ -15,6 +15,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Python.LanguageServer.Implementation;
 using Microsoft.PythonTools.Analysis;
@@ -45,6 +46,7 @@ namespace AnalysisTests {
         private TestResult ExecuteWithServer(ITestMethod testMethod) {
             var arguments = ExtendArguments(testMethod.Arguments);
             var filesToCreate = testMethod.GetAttributes<CreateTestSpecificFileAttribute>(false);
+            var searchPathToAdd = testMethod.GetAttributes<AddTestSpecificSearchPathAttribute>(false);
 
             TestEnvironmentImpl.AddBeforeAfterTest(async () => {
                 var interpreterConfiguration = GetInterpreterConfiguration(arguments);
@@ -53,7 +55,8 @@ namespace AnalysisTests {
                     await TestData.CreateTestSpecificFileAsync(file.RelativeFilePath, file.Content);
                 }
 
-                var server = await new Server().InitializeAsync(interpreterConfiguration, rootUri);
+                var searchPaths = searchPathToAdd.Select(a => TestData.GetTestSpecificPath(a.RelativeSearchPath));
+                var server = await new Server().InitializeAsync(interpreterConfiguration, rootUri, searchPaths);
                 if (DefaultTypeshedPath) {
                     var limits = server.Analyzer.Limits;
                     limits.UseTypeStubPackages = true;


### PR DESCRIPTION
- Fix #509: PLS doesn't flag error in a relative import if it is found in another root directory
- Fix #510: PLS doesn't resolve relative paths correctly