### PR TITLE
Catch exceptions when importing from search paths

### DIFF
--- a/src/Analysis/Engine/Impl/Interpreter/Ast/AstModuleResolution.cs
+++ b/src/Analysis/Engine/Impl/Interpreter/Ast/AstModuleResolution.cs
@@ -205,6 +205,12 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                 } catch (OperationCanceledException) {
                     _log?.Log(TraceLevel.Error, "ImportTimeout", name, "ImportFromSearchPaths");
                     return TryImportModuleResult.Timeout;
+                } catch (Exception ex) when (
+                    ex is IOException // FileNotFoundException, DirectoryNotFoundException, PathTooLongException, etc 
+                    || ex is UnauthorizedAccessException
+                ) {
+                    _log?.Log(TraceLevel.Error, "ImportException", name, "ImportFromSearchPaths", ex.GetType().Name, ex.Message);
+                    return TryImportModuleResult.ModuleNotFound;
                 }
             }
 

--- a/src/Analysis/Engine/Impl/Interpreter/Ast/AstModuleResolution.cs
+++ b/src/Analysis/Engine/Impl/Interpreter/Ast/AstModuleResolution.cs
@@ -210,7 +210,7 @@ namespace Microsoft.PythonTools.Interpreter.Ast {
                     || ex is UnauthorizedAccessException
                 ) {
                     _log?.Log(TraceLevel.Error, "ImportException", name, "ImportFromSearchPaths", ex.GetType().Name, ex.Message);
-                    return TryImportModuleResult.ModuleNotFound;
+                    return TryImportModuleResult.NeedRetry;
                 }
             }
 


### PR DESCRIPTION
Fixes #522.

Did this quick this morning, figured I'd PR instead of letting it sit around.

@AlexanderSher 	Curious how you'd test this. Tried my hand for a bit but couldn't easily see a way to trigger this. I wanted to spawn a server, add a file in the test-specific root, then delete it, and then call `ImportModuleAsync` to see that I get ModuleNotFound, but I don't think I had the search paths setup correctly. Feel free to absorb this into a different PR if it's easier.