### PR TITLE
Set process priority to "below normal"

### DIFF
--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -28,7 +28,9 @@ using StreamJsonRpc.Protocol;
 namespace Microsoft.Python.LanguageServer.Server {
     internal static class Program {
         public static void Main(string[] args) {
+#if RELEASE
             Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+#endif
 
             CheckDebugMode();
             using (CoreShell.Create()) {

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -28,6 +28,8 @@ using StreamJsonRpc.Protocol;
 namespace Microsoft.Python.LanguageServer.Server {
     internal static class Program {
         public static void Main(string[] args) {
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+
             CheckDebugMode();
             using (CoreShell.Create()) {
                 var services = CoreShell.Current.ServiceManager;


### PR DESCRIPTION
I'm submitting this since I had it sitting around. Let me know what you think.

This was suggested in #479. Doing this lowers the priority of the process to "below normal", which on UNIX-y systems is implemented as nice level 10. It may help yield CPU time to other things on the system if the analyzer is stuck somewhere using 100% of a core.

I checked the Roslyn analyzer after noticing it was set to below normal priority in my process list ([see here](https://github.com/dotnet/roslyn/blob/fab7134296816fc80019c60b0f5bef7400cf23ea/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs#L83-L89)), hence this PR. They additionally have the notion of a "[user operation booster](https://github.com/dotnet/roslyn/blob/fab7134296816fc80019c60b0f5bef7400cf23ea/src/Workspaces/Remote/ServiceHub/UserOperationBooster.cs)", which temporarily brings the process back to the normal priority, then back down again when disposed. Unfortunately, I don't believe this would work cross platform, as on UNIX-y systems users are not allowed to lower a nice value after increasing it without being `root`, even with processes they own, even to values that had previously been set.

I don't really like having to put this in `Program.cs`, as it'd be better served to be set after `Initialize` has occurred (and have it configurable), but that'd deprioritize the process during unit tests which I don't think is desirable. Perhaps enabling it when in release mode only would be a better choice.

A downside in general is that the CPU usage problem is going to be gone anyway as the old analysis that gets stuck won't exist. This would be a short-lived patch (which may or may not end up helping in the meantime).