### PR TITLE
Docstring converter

### DIFF
--- a/src/Core/Impl/Extensions/StringExtensions.cs
+++ b/src/Core/Impl/Extensions/StringExtensions.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Python.Core {
             return true;
         }
 
-        public static int IndexOfOrdinal(this string s, string value, int startIndex = 0, bool ignoreCase = false) 
+        public static int IndexOfOrdinal(this string s, string value, int startIndex = 0, bool ignoreCase = false)
             => s?.IndexOf(value, startIndex, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? -1;
 
         public static bool EqualsIgnoreCase(this string s, string other)
@@ -265,6 +265,19 @@ namespace Microsoft.Python.Core {
             var nextSeparatorIndex = s.IndexOf(separator, start);
             span = (start, nextSeparatorIndex == -1 || nextSeparatorIndex >= substringLength ? substringLength - start : nextSeparatorIndex - start);
             return true;
+        }
+
+        public static string[] SplitLines(this string s, params string[] lineEndings) {
+            if (lineEndings == null || lineEndings.Length == 0) {
+                lineEndings = new[] { "\r\n", "\r", "\n" };
+            }
+
+            return s.Split(lineEndings, StringSplitOptions.None);
+        }
+
+        public static string NormalizeLineEndings(this string s, string lineEnding = null) {
+            lineEnding = lineEnding ?? Environment.NewLine;
+            return string.Join(lineEnding, s.SplitLines());
         }
     }
 }

--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Python.LanguageServer.Documentation {
 
                 if (i > 0) {
                     _insideInlineCode = !_insideInlineCode;
-                    Append("`");
+                    Append('`');
                 }
 
                 if (_insideInlineCode) {
@@ -408,6 +408,11 @@ namespace Microsoft.Python.LanguageServer.Documentation {
 
         private void Append(string text) {
             _builder.Append(text);
+            _skipAppendEmptyLine = false;
+        }
+
+        private void Append(char c) {
+            _builder.Append(c);
             _skipAppendEmptyLine = false;
         }
 

--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Python.LanguageServer.Documentation {
             line = PreprocessTextLine(line);
 
             // Hack: attempt to put directives lines into their own paragraphs.
+            // This should be removed once proper list-like parsing is written.
             if (!_insideInlineCode && Regex.IsMatch(line, @"^:(param|type|return|rtype|copyright|license)")) {
                 AppendLine();
             }
@@ -194,16 +195,16 @@ namespace Microsoft.Python.LanguageServer.Documentation {
                 }
 
                 // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references
-                part = Regex.Replace(part, @"^_+", "");
+                // part = Regex.Replace(part, @"^_+", "");
                 // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-internal-targets
-                part = Regex.Replace(part, @"_+$", "");
+                // part = Regex.Replace(part, @"_+$", "");
 
                 // TODO: Strip footnote/citation references.
 
                 // TODO: Expand
 
-                // Escape _ and *, but ignore things like ":param \*\*kwargs:".
-                part = Regex.Replace(part, @"[^\\]([_*])", @"\$1");
+                // Escape _, *, and ~, but ignore things like ":param \*\*kwargs:".
+                part = Regex.Replace(part, @"(?<=^|[^\\])([_*~])", @"\$1");
 
                 Append(part);
             }

--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Python.LanguageServer.Documentation {
                 TrimOutputAndAppendLine("```");
             }
 
-            return _builder.ToString();
+            return _builder.ToString().Trim();
         }
 
         private void PushAndSetState(Func<bool> next) {
@@ -304,14 +304,19 @@ namespace Microsoft.Python.LanguageServer.Documentation {
 
         private bool ParseDoubleColonCode() {
             // Slightly different than doctest, wait until the first non-empty unindented line to exit.
-            if (!string.IsNullOrWhiteSpace(CurrentLine) && CurrentIndent < _blockIndent) {
+            if (string.IsNullOrWhiteSpace(CurrentLine)) {
+                AppendLine();
+                return true;
+            }
+
+            if (CurrentIndent < _blockIndent) {
                 TrimOutputAndAppendLine("```");
                 AppendLine();
                 PopState();
                 return false;
             }
 
-            AppendLine(CurrentLine.Substring(CurrentIndent));
+            AppendLine(CurrentLine.Substring(_blockIndent));
             return true;
         }
 

--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -1,0 +1,401 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Python.Core;
+
+namespace Microsoft.Python.LanguageServer.Documentation {
+    internal class DocstringConverter {
+        public static string ToPlaintext(string input) => string.Join(Environment.NewLine, SplitDocstring(input));
+        public static string ToMarkdown(string input) => new DocstringConverter(input).Convert();
+
+        private readonly StringBuilder _builder = new StringBuilder();
+        private bool _skipAppendEmptyLine = true;
+        private bool _insideInlineCode = false;
+        private bool _appendDirectiveBlock = false;
+
+        private Func<bool> _state;
+        private readonly Stack<Func<bool>> _stateStack = new Stack<Func<bool>>();
+        private int _blockIndent;
+
+        private readonly List<string> _lines;
+        private int _lineNum = 0;
+
+        private string CurrentLine => _lines.ElementAtOrDefault(_lineNum);
+        private int CurrentIndent => CurrentLine.TakeWhile(char.IsWhiteSpace).Count();
+        private string LineAt(int i) => _lines.ElementAtOrDefault(i);
+        private int NextBlockIndent
+            => _lines.Skip(_lineNum + 1).SkipWhile(string.IsNullOrWhiteSpace).FirstOrDefault()?.TakeWhile(char.IsWhiteSpace).Count() ?? 0;
+
+        private DocstringConverter(string input) {
+            _state = ParseTopText;
+            _lines = SplitDocstring(input);
+        }
+
+        private string Convert() {
+            while (CurrentLine != null) {
+                var shouldAdvance = _state();
+                if (shouldAdvance) {
+                    _lineNum++;
+                }
+            }
+
+            if (_state == ParseCodeBacktick || _state == ParseTopDoctest || _state == ParseDoubleColonCode) {
+                // Close out any outstanding code blocks.
+                TrimOutputAndAppendLine("```");
+            }
+
+            return _builder.ToString();
+        }
+
+        private void PushAndSetState(Func<bool> next) {
+            if (_state == ParseTopText) {
+                _insideInlineCode = false;
+            }
+
+            _stateStack.Push(_state);
+            _state = next;
+        }
+
+        private void PopState() {
+            _state = _stateStack.Pop();
+
+            if (_state == ParseTopText) {
+                // Terminate inline code when leaving a block.
+                _insideInlineCode = false;
+            }
+        }
+
+        private bool ParseTopText() {
+            if (string.IsNullOrWhiteSpace(CurrentLine)) {
+                _state = ParseTopEmpty;
+                return false;
+            }
+
+            if (CurrentLine.StartsWith("```")) {
+                AppendLine(CurrentLine);
+                PushAndSetState(ParseCodeBacktick);
+                return true;
+            }
+
+            if (BeginDoubleColonCode()) {
+                return false;
+            }
+
+            if (BeginTopDoctest()) {
+                return true;
+            }
+
+            if (BeginDirective()) {
+                return false;
+            }
+
+            AppendTextLine(CurrentLine);
+            return true;
+        }
+
+        private string PreprocessTextLine(string line) {
+            // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#literal-blocks
+            if (Regex.IsMatch(line, @"^\s*::$")) {
+                return string.Empty;
+            }
+            line = Regex.Replace(line, @"\s+::$", "");
+            line = Regex.Replace(line, @"(\S)\s*::$", "$1:");
+
+            // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#interpreted-text
+            line = Regex.Replace(line, @":[\w_\-+:.]+:`", "`");
+            line = Regex.Replace(line, @"`:[\w_\-+:.]+:", "`");
+
+            line = line.Replace("``", "`");
+            return line;
+        }
+
+        private void AppendTextLine(string line) {
+            line = PreprocessTextLine(line);
+
+            // Hack: attempt to put directives lines into their own paragraphs.
+            if (!_insideInlineCode && Regex.IsMatch(line, @"^:(param|type|return|rtype|copyright|license)")) {
+                AppendLine();
+            }
+
+            var parts = line.Split('`');
+
+            for (var i = 0; i < parts.Length; i++) {
+                var part = parts[i];
+
+                if (i > 0) {
+                    _insideInlineCode = !_insideInlineCode;
+                    Append("`");
+                }
+
+                if (_insideInlineCode) {
+                    Append(part);
+                    continue;
+                }
+
+                if (i == 0) {
+                    // Replace ReST style ~~~ header to prevent it being interpreted as a code block
+                    // (an alternative in Markdown to triple backtick blocks).
+                    if (parts.Length == 1 && Regex.IsMatch(part, @"^\s*~~~+$")) {
+                        Append(part.Replace('~', '-'));
+                        continue;
+                    }
+
+                    // Don't strip away asterisk-based bullet point lists.
+                    var match = Regex.Match(part, @"^(\s+\*)(.*)$");
+                    if (match.Success) {
+                        Append(match.Groups[1].Value);
+                        part = match.Groups[2].Value;
+                    }
+                }
+
+                // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references
+                part = Regex.Replace(part, @"^_+", "");
+                // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-internal-targets
+                part = Regex.Replace(part, @"_+$", "");
+
+                // TODO: Strip footnote/citation references.
+
+                // TODO: Expand
+
+                // Escape _ and *, but ignore things like ":param \*\*kwargs:".
+                part = Regex.Replace(part, @"[^\\]([_*])", @"\$1");
+
+                Append(part);
+            }
+
+            // Go straight to the builder so that AppendLine doesn't think
+            // we're actually trying to insert an extra blank line and skip
+            // future whitespace.
+            _builder.AppendLine();
+        }
+
+        private bool ParseTopEmpty() {
+            if (string.IsNullOrWhiteSpace(CurrentLine)) {
+                AppendLine();
+                return true;
+            }
+
+            // TODO: If List-like, move into list parser, push.
+
+            _state = ParseTopText;
+            return false;
+        }
+
+        private bool ParseCodeBacktick() {
+            if (CurrentLine.StartsWith("```")) {
+                AppendLine("```");
+                AppendLine();
+                PopState();
+                return true;
+            }
+
+            AppendLine(CurrentLine);
+            return true;
+        }
+
+        private void BeginConsistentCodeBlock(Func<bool> state) {
+            AppendLine("```");
+            PushAndSetState(state);
+            _blockIndent = CurrentIndent;
+        }
+
+        private bool BeginTopDoctest() {
+            if (!Regex.IsMatch(CurrentLine, @" *>>> ")) {
+                return false;
+            }
+
+            BeginConsistentCodeBlock(ParseTopDoctest);
+            AppendLine(CurrentLine.Substring(_blockIndent));
+            return true;
+        }
+
+        private bool ParseTopDoctest() {
+            // Allow doctests like:
+            // >>> ...
+            //  ...
+            // ...
+            if (CurrentIndent < _blockIndent) {
+                TrimOutputAndAppendLine("```");
+                AppendLine();
+                PopState();
+                return false;
+            }
+
+            AppendLine(CurrentLine.Substring(_blockIndent));
+            return true;
+        }
+
+        private bool BeginDoubleColonCode() {
+            // Literal blocks must have some indention.
+            if (CurrentIndent == 0) {
+                return false;
+            }
+
+            var prev = LineAt(_lineNum - 1);
+            if (prev == null) {
+                return false;
+            } else if (!string.IsNullOrWhiteSpace(prev)) {
+                return false;
+            }
+
+            // Find the previous paragraph and check that it ends with ::
+            for (var i = _lineNum - 2; i >= 0; i--) {
+                var line = LineAt(i);
+
+                if (string.IsNullOrWhiteSpace(line)) {
+                    continue;
+                }
+
+                // Safe to ignore whitespace after the :: because all lines have been TrimEnd'd.
+                if (line.EndsWith("::")) {
+                    break;
+                }
+
+                return false;
+            }
+
+            BeginConsistentCodeBlock(ParseDoubleColonCode);
+            return true;
+        }
+
+        private bool ParseDoubleColonCode() {
+            // Slightly different than doctest, wait until the first non-empty unindented line to exit.
+            if (!string.IsNullOrWhiteSpace(CurrentLine) && CurrentIndent < _blockIndent) {
+                TrimOutputAndAppendLine("```");
+                AppendLine();
+                PopState();
+                return false;
+            }
+
+            AppendLine(CurrentLine.Substring(CurrentIndent));
+            return true;
+        }
+
+
+        private bool BeginDirective() {
+            if (!Regex.IsMatch(CurrentLine, @"^\s*\.\. ")) {
+                return false;
+            }
+
+            PushAndSetState(ParseDirective);
+            _blockIndent = NextBlockIndent;
+            _appendDirectiveBlock = false;
+            return true;
+        }
+
+        private bool ParseDirective() {
+            // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#directives
+
+            var match = Regex.Match(CurrentLine, @"^\s*\.\.\s+(\w+)::\s*(.*)$");
+            if (match.Success) {
+                var directiveType = match.Groups[1].Value;
+                var directive = match.Groups[2].Value;
+
+                if (directiveType == "class") {
+                    _appendDirectiveBlock = true;
+                    AppendLine("```");
+                    AppendLine(directive);
+                    AppendLine("```");
+                }
+            }
+
+            if (_blockIndent == 0) {
+                // This is a one-liner directive, so pop back.
+                PopState();
+            } else {
+                _state = ParseDirectiveBlock;
+            }
+
+            return true;
+        }
+
+        private bool ParseDirectiveBlock() {
+            if (!string.IsNullOrWhiteSpace(CurrentLine) && CurrentIndent < _blockIndent) {
+                PopState();
+                return false;
+            }
+
+            if (_appendDirectiveBlock) {
+                // This is a bit of a hack. This just trims the text and appends it
+                // like top-level text, rather than doing actual indent-based recusion.
+                AppendTextLine(CurrentLine.TrimStart());
+            }
+
+            return true;
+        }
+
+        private void AppendLine(string line = null) {
+            if (!string.IsNullOrWhiteSpace(line)) {
+                _builder.AppendLine(line);
+                _skipAppendEmptyLine = false;
+            } else if (!_skipAppendEmptyLine) {
+                _builder.AppendLine();
+                _skipAppendEmptyLine = true;
+            }
+        }
+
+        private void Append(string text) {
+            _builder.Append(text);
+            _skipAppendEmptyLine = false;
+        }
+
+        private void TrimOutputAndAppendLine(string line = null) {
+            _builder.TrimEnd();
+            _skipAppendEmptyLine = false;
+            AppendLine();
+            AppendLine(line);
+        }
+
+        private static List<string> SplitDocstring(string docstring) {
+            // As done by inspect.cleandoc.
+            docstring = docstring.Replace("\t", "        ");
+
+            var lines = docstring.SplitLines()
+                .Select(s => s.TrimEnd())
+                .ToList();
+
+            if (lines.Count > 0) {
+                var first = lines[0].Trim();
+                if (first == string.Empty) {
+                    first = null;
+                } else {
+                    lines.RemoveAt(0);
+                }
+
+                lines = StripLeadingWhiteSpace(lines);
+
+                if (first != null) {
+                    lines.Insert(0, first);
+                }
+            }
+
+            return lines;
+        }
+
+        private static List<string> StripLeadingWhiteSpace(List<string> lines, int? trim = null) {
+            var amount = trim ?? LargestTrim(lines);
+            return lines.Select(line => amount > line.Length ? string.Empty : line.Substring(amount)).ToList();
+        }
+
+        private static int LargestTrim(IEnumerable<string> lines) => lines.Where(s => !string.IsNullOrWhiteSpace(s)).Select(CountLeadingSpaces).DefaultIfEmpty().Min();
+
+        private static int CountLeadingSpaces(string s) => s.TakeWhile(char.IsWhiteSpace).Count();
+    }
+}

--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -82,7 +83,16 @@ namespace Microsoft.Python.LanguageServer.Documentation {
 
         private string Convert() {
             while (CurrentLine != null) {
+                var before = _state;
+                var beforeLine = _lineNum;
+
                 _state();
+
+                // Parser must make progress; either the state or line number must change.
+                if (_state == before && _lineNum == beforeLine) {
+                    Debug.Fail("Infinite loop during docstring conversion");
+                    break;
+                }
             }
 
             // Close out any outstanding code blocks.

--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Python.LanguageServer.Documentation {
         private void EatLine() => _lineNum++;
 
         private string CurrentLine => _lines.ElementAtOrDefault(_lineNum);
-        private int CurrentIndent => CurrentLine.TakeWhile(char.IsWhiteSpace).Count();
+        private int CurrentIndent => CountLeadingSpaces(CurrentLine);
         private string LineAt(int i) => _lines.ElementAtOrDefault(i);
         private int NextBlockIndent
             => _lines.Skip(_lineNum + 1).SkipWhile(string.IsNullOrWhiteSpace)
@@ -184,7 +184,11 @@ namespace Microsoft.Python.LanguageServer.Documentation {
                     }
 
                     // Don't strip away asterisk-based bullet point lists.
-                    var match = Regex.Match(part, @"^(\s+\*)(.*)$");
+                    //
+                    // TODO: Replace this with real list parsing. This may have
+                    // false positives and cause random italics when the ReST list
+                    // doesn't match Markdown's specification.
+                    var match = Regex.Match(part, @"^(\s+\* )(.*)$");
                     if (match.Success) {
                         Append(match.Groups[1].Value);
                         part = match.Groups[2].Value;

--- a/src/LanguageServer/Impl/Documentation/DocumentationExtensions.cs
+++ b/src/LanguageServer/Impl/Documentation/DocumentationExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using Microsoft.Python.Analysis.Types;
+
+namespace Microsoft.Python.LanguageServer.Documentation {
+    internal static class DocumentationExtensions {
+        public static string PlaintextDoc(this IPythonType type)
+            => DocstringConverter.ToPlaintext(type.Documentation);
+
+        public static string MarkdownDoc(this IPythonType type)
+            => DocstringConverter.ToMarkdown(type.Documentation);
+    }
+}

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -122,7 +122,15 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             DisplayStartupInfo();
 
-            var ds = new PlainTextDocumentationSource();
+            // TODO: Pass different documentation sources to completion/hover/signature
+            // based on client capabilities.
+            IDocumentationSource ds;
+            if (DisplayOptions.preferredFormat == MarkupKind.Markdown) {
+                ds = new MarkdownDocumentationSource();
+            } else {
+                ds = new PlainTextDocumentationSource();
+            }
+
             _completionSource = new CompletionSource(ds, Settings.completion);
             _hoverSource = new HoverSource(ds);
             _signatureSource = new SignatureSource(ds);

--- a/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
@@ -13,8 +13,10 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
@@ -22,25 +24,25 @@ using Microsoft.Python.LanguageServer.Documentation;
 using Microsoft.Python.LanguageServer.Protocol;
 
 namespace Microsoft.Python.LanguageServer.Sources {
-    internal sealed class PlainTextDocumentationSource : IDocumentationSource {
+    internal sealed class MarkdownDocumentationSource : IDocumentationSource {
         public InsertTextFormat DocumentationFormat => InsertTextFormat.PlainText;
 
         public MarkupContent GetHover(string name, IMember member) {
             // We need to tell between instance and type.
             var type = member.GetPythonType();
             if (type.IsUnknown()) {
-                return new MarkupContent { kind = MarkupKind.PlainText, value = name };
+                return new MarkupContent { kind = MarkupKind.Markdown, value = $"```\n{name}\n```" };
             }
 
             string text;
             if (member is IPythonInstance) {
                 if (!(type is IPythonFunctionType)) {
                     text = !string.IsNullOrEmpty(name) ? $"{name}: {type.Name}" : $"{type.Name}";
-                    return new MarkupContent { kind = MarkupKind.PlainText, value = text };
+                    return new MarkupContent { kind = MarkupKind.Markdown, value = $"```\n{text}\n```" };
                 }
             }
 
-            var typeDoc = !string.IsNullOrEmpty(type.Documentation) ? $"\n\n{type.PlaintextDoc()}" : string.Empty;
+            var typeDoc = !string.IsNullOrEmpty(type.Documentation) ? $"\n---\n{type.MarkdownDoc()}" : string.Empty;
             switch (type) {
                 case IPythonPropertyType prop:
                     text = GetPropertyHoverString(prop);
@@ -51,26 +53,26 @@ namespace Microsoft.Python.LanguageServer.Sources {
                     break;
 
                 case IPythonClassType cls:
-                    var clsDoc = !string.IsNullOrEmpty(cls.Documentation) ? $"\n\n{cls.PlaintextDoc()}" : string.Empty;
-                    text = $"class {cls.Name}{clsDoc}";
+                    var clsDoc = !string.IsNullOrEmpty(cls.Documentation) ? $"\n---\n{cls.MarkdownDoc()}" : string.Empty;
+                    text = $"```\nclass {cls.Name}\n```{clsDoc}";
                     break;
 
                 case IPythonModule mod:
-                    text = !string.IsNullOrEmpty(mod.Name) ? $"module {mod.Name}{typeDoc}" : $"module{typeDoc}";
+                    text = !string.IsNullOrEmpty(mod.Name) ? $"```\nmodule {mod.Name}\n```{typeDoc}" : $"`module`{typeDoc}";
                     break;
 
                 default:
-                    text = !string.IsNullOrEmpty(name) ? $"type {name}: {type.Name}{typeDoc}" : $"{type.Name}{typeDoc}";
+                    text = !string.IsNullOrEmpty(name) ? $"```\ntype {name}: {type.Name}\n```{typeDoc}" : $"{type.Name}{typeDoc}";
                     break;
             }
 
             return new MarkupContent {
-                kind = MarkupKind.PlainText, value = text
+                kind = MarkupKind.Markdown, value = text
             };
         }
 
         public MarkupContent FormatDocumentation(string documentation) {
-            return new MarkupContent { kind = MarkupKind.PlainText, value = documentation };
+            return new MarkupContent { kind = MarkupKind.Markdown, value = DocstringConverter.ToMarkdown(documentation) };
         }
 
         public string GetSignatureString(IPythonFunctionType ft, int overloadIndex = 0) {
@@ -88,21 +90,21 @@ namespace Microsoft.Python.LanguageServer.Sources {
                 return FormatDocumentation(parameter.Documentation);
             }
             // TODO: show fully qualified type?
-            var text = parameter.Type.IsUnknown() ? parameter.Name : $"{parameter.Name}: {parameter.Type.Name}";
-            return new MarkupContent { kind = MarkupKind.PlainText, value = text };
+            var text = parameter.Type.IsUnknown() ? $"```\n{parameter.Name}\n```" : $"`{parameter.Name}: {parameter.Type.Name}`";
+            return new MarkupContent { kind = MarkupKind.Markdown, value = text };
         }
 
         private string GetPropertyHoverString(IPythonPropertyType prop, int overloadIndex = 0) {
             var decTypeString = prop.DeclaringType != null ? $"{prop.DeclaringType.Name}." : string.Empty;
-            var propDoc = !string.IsNullOrEmpty(prop.Documentation) ? $"\n\n{prop.PlaintextDoc()}" : string.Empty;
-            return $"{decTypeString}{propDoc}";
+            var propDoc = !string.IsNullOrEmpty(prop.Documentation) ? $"\n---\n{prop.MarkdownDoc()}" : string.Empty;
+            return $"```\n{decTypeString}\n```{propDoc}";
         }
 
         private string GetFunctionHoverString(IPythonFunctionType ft, int overloadIndex = 0) {
             var sigString = GetSignatureString(ft, overloadIndex);
             var decTypeString = ft.DeclaringType != null ? $"{ft.DeclaringType.Name}." : string.Empty;
-            var funcDoc = !string.IsNullOrEmpty(ft.Documentation) ? $"\n\n{ft.PlaintextDoc()}" : string.Empty;
-            return $"{decTypeString}{sigString}{funcDoc}";
+            var funcDoc = !string.IsNullOrEmpty(ft.Documentation) ? $"\n---\n{ft.MarkdownDoc()}" : string.Empty;
+            return $"```\n{decTypeString}{sigString}\n```{funcDoc}";
         }
 
         private IEnumerable<string> GetFunctionParameters(IPythonFunctionType ft, int overloadIndex = 0) {

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -14,8 +14,6 @@
 // permissions and limitations under the License.
 
 using FluentAssertions;
-using Microsoft.Python.Core;
-using Microsoft.Python.LanguageServer.Documentation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 using static Microsoft.Python.LanguageServer.Tests.FluentAssertions.DocstringAssertions;
@@ -59,6 +57,100 @@ foo
 ```
 >>> print('foo')
 foo
+```
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void DoctestIndented() {
+            var docstring = @"This is a doctest:
+
+    >>> print('foo')
+    foo
+";
+
+            var markdown = @"This is a doctest:
+
+```
+>>> print('foo')
+foo
+```
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void MarkdownStyleBacktickBlock() {
+            var docstring = @"Backtick block:
+
+```
+print(foo_bar)
+
+if True:
+    print(bar_foo)
+```
+
+And some text after.
+";
+
+            var markdown = @"Backtick block:
+
+```
+print(foo_bar)
+
+if True:
+    print(bar_foo)
+```
+
+And some text after.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void RestLiteralBlock() {
+            var docstring = @"
+Take a look at this code::
+
+    if foo:
+        print(foo)
+    else:
+        print('not foo!')
+
+This text comes after.
+";
+
+            var markdown = @"Take a look at this code:
+
+```
+if foo:
+    print(foo)
+else:
+    print('not foo!')
+```
+
+This text comes after.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void RestLiteralBlockEmptyDoubleColonLine() {
+            var docstring = @"
+::
+
+    if foo:
+        print(foo)
+    else:
+        print('not foo!')
+";
+
+            var markdown = @"```
+if foo:
+    print(foo)
+else:
+    print('not foo!')
 ```
 ";
             docstring.Should().ConvertToMarkdown(markdown);

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -155,5 +155,26 @@ else:
 ";
             docstring.Should().ConvertToMarkdown(markdown);
         }
+
+        [TestMethod, Priority(0)]
+        public void RestLiteralBlockNoIndentOneLiner() {
+            var docstring = @"
+The next code is a one-liner::
+
+print(a + foo + 123)
+
+And now it's text.
+";
+
+            var markdown = @"The next code is a one-liner:
+
+```
+print(a + foo + 123)
+```
+
+And now it's text.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
     }
 }

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -96,12 +96,64 @@ Heading 3
 
         [DataRow(@"*foo*", @"\*foo\*")]
         [DataRow(@"``*foo*``", @"`*foo*`")]
-        [DataRow(@"foo~~bar", @"foo\~\~bar")]
-        [DataRow(@"``foo~~bar``", @"`foo~~bar`")]
+        [DataRow(@"~foo~~bar~", @"\~foo\~\~bar\~")]
+        [DataRow(@"``~foo~~bar~``", @"`~foo~~bar~`")]
         [DataRow(@"__init__", @"\_\_init\_\_")]
         [DataRow(@"``__init__``", @"`__init__`")]
         [DataTestMethod, Priority(0)]
         public void EscapedCharacters(string docstring, string markdown) {
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void CopyrightAndLicense() {
+            var docstring = @"This is a test.
+
+:copyright: Fake Name
+:license: ABCv123
+";
+
+            var markdown = @"This is a test.
+
+:copyright: Fake Name
+
+:license: ABCv123
+";
+
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void CommonRestFieldLists() {
+            var docstring = @"This function does something.
+
+:param foo: This is a description of the foo parameter
+    which does something interesting.
+:type foo: Foo
+:param bar: This is a description of bar.
+:type bar: Bar
+:return: Something else.
+:rtype: Something
+:raises ValueError: If something goes wrong.
+";
+
+            var markdown = @"This function does something.
+
+:param foo: This is a description of the foo parameter
+    which does something interesting.
+
+:type foo: Foo
+
+:param bar: This is a description of bar.
+
+:type bar: Bar
+
+:return: Something else.
+
+:rtype: Something
+
+:raises ValueError: If something goes wrong.
+";
             docstring.Should().ConvertToMarkdown(markdown);
         }
 
@@ -142,6 +194,49 @@ foo
         }
 
         [TestMethod, Priority(0)]
+        public void DoctestTextAfter() {
+            var docstring = @"This is a doctest:
+
+>>> print('foo')
+foo
+
+This text comes after.
+";
+
+            var markdown = @"This is a doctest:
+
+```
+>>> print('foo')
+foo
+```
+
+This text comes after.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void DoctestIndentedTextAfter() {
+            var docstring = @"This is a doctest:
+
+    >>> print('foo')
+    foo
+  This line has a different indent.
+";
+
+            var markdown = @"This is a doctest:
+
+```
+>>> print('foo')
+foo
+```
+
+This line has a different indent.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
         public void MarkdownStyleBacktickBlock() {
             var docstring = @"Backtick block:
 
@@ -173,6 +268,36 @@ And some text after.
         public void RestLiteralBlock() {
             var docstring = @"
 Take a look at this code::
+
+    if foo:
+        print(foo)
+    else:
+        print('not foo!')
+
+This text comes after.
+";
+
+            var markdown = @"Take a look at this code:
+
+```
+if foo:
+    print(foo)
+else:
+    print('not foo!')
+```
+
+This text comes after.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void RestLiteralBlockExtraSpace() {
+            var docstring = @"
+Take a look at this code::
+
+
+
 
     if foo:
         print(foo)
@@ -234,6 +359,106 @@ print(a + foo + 123)
 ```
 
 And now it's text.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void DirectiveRemoval() {
+            var docstring = @"This is a test.
+
+.. ignoreme:: example
+
+This text is in-between.
+
+.. versionadded:: 1.0
+    Foo was added to Bar.
+
+.. admonition:: Note
+    
+    This paragraph appears inside the admonition
+    and spans multiple lines.
+
+This text comes after.
+";
+
+            var markdown = @"This is a test.
+
+This text is in-between.
+
+This text comes after.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void ClassDirective() {
+            var docstring = @"
+.. class:: FooBar()
+    This is a description of ``FooBar``.
+
+``FooBar`` is interesting.
+";
+
+            var markdown = @"```
+FooBar()
+```
+
+This is a description of `FooBar`.
+
+`FooBar` is interesting.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void UnfinishedBacktickBlock() {
+            var docstring = @"```
+something
+";
+
+            var markdown = @"```
+something
+```
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void UnfinishedInlineLiteral() {
+            var docstring = @"`oops
+";
+
+            var markdown = @"`oops`";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void DashList() {
+            var docstring = @"
+This is a list:
+  - Item 1
+  - Item 2
+";
+
+            var markdown = @"This is a list:
+  - Item 1
+  - Item 2
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void AsteriskList() {
+            var docstring = @"
+This is a list:
+  * Item 1
+  * Item 2
+";
+
+            var markdown = @"This is a list:
+  * Item 1
+  * Item 2
 ";
             docstring.Should().ConvertToMarkdown(markdown);
         }

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -100,8 +100,28 @@ Heading 3
         [DataRow(@"``~foo~~bar~``", @"`~foo~~bar~`")]
         [DataRow(@"__init__", @"\_\_init\_\_")]
         [DataRow(@"``__init__``", @"`__init__`")]
+        [DataRow(@"foo **bar", @"foo \*\*bar")]
         [DataTestMethod, Priority(0)]
         public void EscapedCharacters(string docstring, string markdown) {
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void AsterisksAtStartOfArgs() {
+            var docstring = @"Foo:
+
+    Args:
+        foo (Foo): Foo!
+        *args: These are positional args.
+        **kwargs: These are named args.
+";
+            var markdown = @"Foo:
+
+Args:
+    foo (Foo): Foo!
+    \*args: These are positional args.
+    \*\*kwargs: These are named args.
+";
             docstring.Should().ConvertToMarkdown(markdown);
         }
 

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -45,6 +45,67 @@ namespace Microsoft.Python.LanguageServer.Tests {
         }
 
         [TestMethod, Priority(0)]
+        public void NormalText() {
+            var docstring = @"This is just some normal text
+that extends over multiple lines. This will appear
+as-is without modification.
+";
+
+            var markdown = @"This is just some normal text
+that extends over multiple lines. This will appear
+as-is without modification.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void InlineLitereals() {
+            var docstring = @"This paragraph talks about ``foo``
+which is related to :something:`bar`, and probably `qux`:something_else:.
+";
+
+            var markdown = @"This paragraph talks about `foo`
+which is related to `bar`, and probably `qux`.
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
+        public void Headings() {
+            var docstring = @"Heading 1
+=========
+
+Heading 2
+---------
+
+Heading 3
+~~~~~~~~~
+";
+
+            var markdown = @"Heading 1
+=========
+
+Heading 2
+---------
+
+Heading 3
+---------
+";
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [DataRow(@"*foo*", @"\*foo\*")]
+        [DataRow(@"``*foo*``", @"`*foo*`")]
+        [DataRow(@"foo~~bar", @"foo\~\~bar")]
+        [DataRow(@"``foo~~bar``", @"`foo~~bar`")]
+        [DataRow(@"__init__", @"\_\_init\_\_")]
+        [DataRow(@"``__init__``", @"`__init__`")]
+        [DataTestMethod, Priority(0)]
+        public void EscapedCharacters(string docstring, string markdown) {
+            docstring.Should().ConvertToMarkdown(markdown);
+        }
+
+        [TestMethod, Priority(0)]
         public void Doctest() {
             var docstring = @"This is a doctest:
 

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using FluentAssertions;
+using Microsoft.Python.Core;
+using Microsoft.Python.LanguageServer.Documentation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Microsoft.Python.LanguageServer.Tests {
+    [TestClass]
+    public class DocstringConverterTests {
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [DataRow("A\nB", "A\nB")]
+        [DataRow("A\n\nB", "A\n\nB")]
+        [DataRow("A\n\nB", "A\n\nB")]
+        [DataRow("A\n    B", "A\nB")]
+        [DataRow("    A\n    B", "A\nB")]
+        [DataRow("\nA\n    B", "A\n    B")]
+        [DataRow("\n    A\n    B", "A\nB")]
+        [DataRow("\nA\nB\n", "A\nB")]
+        [DataRow("  \n\nA \n    \nB  \n    ", "A\n\nB")]
+        [DataTestMethod, Priority(0)]
+        public void PlaintextIndention(string docstring, string expected) {
+            var result = DocstringConverter.ToPlaintext(docstring.NormalizeLineEndings());
+            result.NormalizeLineEndings().Should().Be(expected.NormalizeLineEndings());
+        }
+    }
+}

--- a/src/LanguageServer/Test/DocstringConverterTests.cs
+++ b/src/LanguageServer/Test/DocstringConverterTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Python.Core;
 using Microsoft.Python.LanguageServer.Documentation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
+using static Microsoft.Python.LanguageServer.Tests.FluentAssertions.DocstringAssertions;
 
 namespace Microsoft.Python.LanguageServer.Tests {
     [TestClass]
@@ -42,8 +43,25 @@ namespace Microsoft.Python.LanguageServer.Tests {
         [DataRow("  \n\nA \n    \nB  \n    ", "A\n\nB")]
         [DataTestMethod, Priority(0)]
         public void PlaintextIndention(string docstring, string expected) {
-            var result = DocstringConverter.ToPlaintext(docstring.NormalizeLineEndings());
-            result.NormalizeLineEndings().Should().Be(expected.NormalizeLineEndings());
+            docstring.Should().ConvertToPlaintext(expected);
+        }
+
+        [TestMethod, Priority(0)]
+        public void Doctest() {
+            var docstring = @"This is a doctest:
+
+>>> print('foo')
+foo
+";
+
+            var markdown = @"This is a doctest:
+
+```
+>>> print('foo')
+foo
+```
+";
+            docstring.Should().ConvertToMarkdown(markdown);
         }
     }
 }

--- a/src/LanguageServer/Test/FluentAssertions/DocstringConverterAssertions.cs
+++ b/src/LanguageServer/Test/FluentAssertions/DocstringConverterAssertions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+using Microsoft.Python.Core;
+using Microsoft.Python.LanguageServer.Documentation;
+
+namespace Microsoft.Python.LanguageServer.Tests.FluentAssertions {
+    [ExcludeFromCodeCoverage]
+    internal static class DocstringAssertions {
+        public static AndConstraint<StringAssertions> ConvertToPlaintext(this StringAssertions a, string plaintext, string because = "", params object[] reasonArgs) {
+            DocstringConverter.ToPlaintext(a.Subject.NormalizeLineEndings()).Should().Be(plaintext.NormalizeLineEndings(), because, reasonArgs);
+            return new AndConstraint<StringAssertions>(a);
+        }
+
+        public static AndConstraint<StringAssertions> ConvertToMarkdown(this StringAssertions a, string markdown, string because = "", params object[] reasonArgs) {
+            DocstringConverter.ToMarkdown(a.Subject.NormalizeLineEndings()).Should().Be(markdown.NormalizeLineEndings(), because, reasonArgs);
+            return new AndConstraint<StringAssertions>(a);
+        }
+    }
+}

--- a/src/LanguageServer/Test/FluentAssertions/DocstringConverterAssertions.cs
+++ b/src/LanguageServer/Test/FluentAssertions/DocstringConverterAssertions.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Python.LanguageServer.Tests.FluentAssertions {
     [ExcludeFromCodeCoverage]
     internal static class DocstringAssertions {
         public static AndConstraint<StringAssertions> ConvertToPlaintext(this StringAssertions a, string plaintext, string because = "", params object[] reasonArgs) {
-            DocstringConverter.ToPlaintext(a.Subject.NormalizeLineEndings()).Should().Be(plaintext.NormalizeLineEndings(), because, reasonArgs);
+            DocstringConverter.ToPlaintext(a.Subject.NormalizeLineEndings()).Should().Be(plaintext.NormalizeLineEndings().TrimEnd(), because, reasonArgs);
             return new AndConstraint<StringAssertions>(a);
         }
 
         public static AndConstraint<StringAssertions> ConvertToMarkdown(this StringAssertions a, string markdown, string because = "", params object[] reasonArgs) {
-            DocstringConverter.ToMarkdown(a.Subject.NormalizeLineEndings()).Should().Be(markdown.NormalizeLineEndings(), because, reasonArgs);
+            DocstringConverter.ToMarkdown(a.Subject.NormalizeLineEndings()).Should().Be(markdown.NormalizeLineEndings().TrimEnd(), because, reasonArgs);
             return new AndConstraint<StringAssertions>(a);
         }
     }


### PR DESCRIPTION
Closes #548.

Still missing Google/Numpy style param/return/etc list parsing. I'm also not too happy with the code duplication in the markdown documentation source.