### PR TITLE
Fix empty signature tooltip after function call

### DIFF
--- a/src/LanguageServer/Impl/Sources/SignatureSource.cs
+++ b/src/LanguageServer/Impl/Sources/SignatureSource.cs
@@ -90,6 +90,10 @@ namespace Microsoft.Python.LanguageServer.Sources {
                                       ?.Item2 ?? -1;
             }
 
+            activeSignature = activeSignature >= 0
+                ? activeSignature
+                : (signatures.Length > 0 ? 0 : -1);
+
             return new SignatureHelp {
                 signatures = signatures.ToArray(),
                 activeSignature = activeSignature,


### PR DESCRIPTION
Fixes #614.

Pulled this from the old LS; it wasn't carried over.