### PR TITLE
Don't  squiggle new lines after incomplete member expression

### DIFF
--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -335,7 +335,12 @@ namespace Microsoft.Python.Parsing {
                 return n;
             }
 
-            ReportSyntaxError(prevTokenStart, prevTokenStart + prevTokeLength, "syntax error");
+            if (_lookahead.Token.Kind == TokenKind.NewLine) {
+                // Incomplete member expression, report dot, don't point to new line.
+                ReportSyntaxError(prevTokenStart, prevTokenStart + prevTokeLength, "syntax error");
+            } else {
+                ReportSyntaxError("syntax error");
+            }
             return Name.Empty;
         }
 

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -2274,7 +2274,7 @@ namespace Microsoft.Python.Parsing {
             var itemWhiteSpace = MakeWhiteSpaceList();
 
             var items = ImmutableArray<WithItem>.Empty
-                .Add(ParseWithItem(itemWhiteSpace)); ;
+                .Add(ParseWithItem(itemWhiteSpace));
             while (MaybeEat(TokenKind.Comma)) {
                 itemWhiteSpace?.Add(_tokenWhiteSpace);
                 items = items.Add(ParseWithItem(itemWhiteSpace));
@@ -2956,7 +2956,7 @@ namespace Microsoft.Python.Parsing {
                 if (t.Value is BigInteger) {
                     var bi = (BigInteger)t.Value;
                     if (bi == 0x80000000) {
-                        var tokenString = _tokenizer.GetTokenString(); ;
+                        var tokenString = _tokenizer.GetTokenString();
                         Debug.Assert(tokenString.Length > 0);
 
                         if (tokenString[tokenString.Length - 1] != 'L' &&

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Python.Parsing {
             return name;
         }
 
-        private Name ReadNameMaybeNone() {
+        private Name ReadNameMaybeNone(int prevTokenStart, int prevTokeLength) {
             // peek for better error recovery
             var t = PeekToken();
             if (t == Tokens.NoneToken) {
@@ -335,7 +335,7 @@ namespace Microsoft.Python.Parsing {
                 return n;
             }
 
-            ReportSyntaxError("syntax error");
+            ReportSyntaxError(prevTokenStart, prevTokenStart + prevTokeLength, "syntax error");
             return Name.Empty;
         }
 
@@ -1728,7 +1728,7 @@ namespace Microsoft.Python.Parsing {
                 while (MaybeEat(TokenKind.Dot)) {
                     var dotStart = GetStart();
                     var whitespace = _tokenWhiteSpace;
-                    name = ReadNameMaybeNone();
+                    name = ReadNameMaybeNone(dotStart, 1);
                     if (!name.HasName) {
                         decorator = Error(_verbatim ? (_tokenWhiteSpace + _token.Token.VerbatimImage + _lookaheadWhiteSpace + _lookahead.Token.VerbatimImage) : null, decorator);
                         NextToken();
@@ -3300,7 +3300,7 @@ namespace Microsoft.Python.Parsing {
                             NextToken();
                             var dotStart = GetStart();
                             whitespace = _tokenWhiteSpace;
-                            var name = ReadNameMaybeNone();
+                            var name = ReadNameMaybeNone(dotStart, 1);
                             var nameWhitespace = _tokenWhiteSpace;
                             var fe = MakeMember(ret, name);
                             fe.SetLoc(ret.StartIndex, name.HasName ? GetStart() : GetEnd(), GetEnd());

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -2709,7 +2709,7 @@ namespace Microsoft.Python.Parsing.Tests {
                     new ErrorInfo("syntax error", 7, 1, 8, 8, 1, 9),
                     new ErrorInfo("unexpected token '.'", 14, 2, 5, 15, 2, 6),
                     new ErrorInfo("syntax error", 16, 2, 7, 17, 2, 8),
-                    new ErrorInfo("syntax error", 17, 2, 7, 19, 2, 8)
+                    new ErrorInfo("syntax error", 17, 2, 8, 19, 3, 1)
                 );
             }
         }
@@ -2718,7 +2718,9 @@ namespace Microsoft.Python.Parsing.Tests {
         public void IncompleteMemberExpr() {
             foreach (var version in V2Versions) {
                 ParseErrors("IncompleteMemberExpr.py", version,
-                    new ErrorInfo("syntax error", 1, 1, 2, 2, 1, 3)
+                    new ErrorInfo("syntax error", 2, 1, 3, 3, 1, 4),
+                    new ErrorInfo("syntax error", 22, 3, 3, 24, 4, 1),
+                    new ErrorInfo("syntax error", 33, 5, 3, 33, 5, 3)
                 );
             }
         }

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -2709,7 +2709,16 @@ namespace Microsoft.Python.Parsing.Tests {
                     new ErrorInfo("syntax error", 7, 1, 8, 8, 1, 9),
                     new ErrorInfo("unexpected token '.'", 14, 2, 5, 15, 2, 6),
                     new ErrorInfo("syntax error", 16, 2, 7, 17, 2, 8),
-                    new ErrorInfo("syntax error", 17, 2, 8, 19, 3, 1)
+                    new ErrorInfo("syntax error", 17, 2, 7, 19, 2, 8)
+                );
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void IncompleteMemberExpr() {
+            foreach (var version in V2Versions) {
+                ParseErrors("IncompleteMemberExpr.py", version,
+                    new ErrorInfo("syntax error", 1, 1, 2, 2, 1, 3)
                 );
             }
         }

--- a/src/UnitTests/TestData/Grammar/IncompleteMemberExpr.py
+++ b/src/UnitTests/TestData/Grammar/IncompleteMemberExpr.py
@@ -1,2 +1,5 @@
 a. #comment
 x = 1
+b.
+x = 2
+c.

--- a/src/UnitTests/TestData/Grammar/IncompleteMemberExpr.py
+++ b/src/UnitTests/TestData/Grammar/IncompleteMemberExpr.py
@@ -1,0 +1,2 @@
+a. #comment
+x = 1


### PR DESCRIPTION
Fixes #345 

If next token is a new line after dot, squiggle the dot instead.