### PR TITLE
Fix processing of inner functions + remove async from analysis

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IExpressionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IExpressionEvaluator.cs
@@ -15,8 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
@@ -57,7 +55,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         /// <summary>
         /// Evaluates expression in the currently open scope.
         /// </summary>
-        Task<IMember> GetValueFromExpressionAsync(Expression expr, CancellationToken cancellationToken = default);
+        IMember GetValueFromExpression(Expression expr);
 
         IMember LookupNameInScopes(string name, out IScope scope);
 

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -112,7 +112,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return await GetValueFromFunctionTypeAsync(call, pi, expr, cancellationToken);
             }
 
-            return null;
+            // Optimistically return the instance itself. This happens when the call is
+            // over 'function' that was actually replaced by a instance of a type.
+            return pi;
         }
 
         public async Task<IMember> GetValueFromFunctionTypeAsync(IPythonFunctionType fn, IPythonInstance instance, CallExpression expr, CancellationToken cancellationToken = default) {

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -16,8 +16,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Parsing.Ast;
@@ -26,15 +24,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
     internal sealed partial class ExpressionEval {
         private readonly Stack<FunctionDefinition> _callEvalStack = new Stack<FunctionDefinition>();
 
-        public async Task<IMember> GetValueFromCallableAsync(CallExpression expr, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
+        public IMember GetValueFromCallable(CallExpression expr) {
             if (expr?.Target == null) {
                 return null;
             }
 
-            var target = await GetValueFromExpressionAsync(expr.Target, cancellationToken);
+            var target = GetValueFromExpression(expr.Target);
             // Try generics
-            var result = await GetValueFromGenericAsync(target, expr, cancellationToken);
+            var result = GetValueFromGeneric(target, expr);
             if (result != null) {
                 return result;
             }
@@ -45,17 +42,17 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             IMember value = null;
             switch (target) {
                 case IPythonBoundType bt: // Bound property, method or an iterator.
-                    value = await GetValueFromBoundAsync(bt, expr, cancellationToken);
+                    value = GetValueFromBound(bt, expr);
                     break;
                 case IPythonInstance pi:
-                    value = await GetValueFromInstanceCall(pi, expr, cancellationToken);
+                    value = GetValueFromInstanceCall(pi, expr);
                     break;
                 case IPythonFunctionType ft: // Standalone function or a class method call.
                     var instance = ft.DeclaringType != null ? new PythonInstance(ft.DeclaringType) : null;
-                    value = await GetValueFromFunctionTypeAsync(ft, instance, expr, cancellationToken);
+                    value = GetValueFromFunctionType(ft, instance, expr);
                     break;
                 case IPythonClassType cls:
-                    value = await GetValueFromClassCtorAsync(cls, expr, cancellationToken);
+                    value = GetValueFromClassCtor(cls, expr);
                     break;
                 case IPythonType t:
                     // Target is type (info), the call creates instance.
@@ -71,8 +68,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return value;
         }
 
-        public async Task<IMember> GetValueFromClassCtorAsync(IPythonClassType cls, CallExpression expr, CancellationToken cancellationToken = default) {
-            await SymbolTable.EvaluateAsync(cls.ClassDefinition, cancellationToken);
+        public IMember GetValueFromClassCtor(IPythonClassType cls, CallExpression expr) {
+            SymbolTable.Evaluate(cls.ClassDefinition);
             // Determine argument types
             var args = ArgumentSet.Empty;
             var init = cls.GetMember<IPythonFunctionType>(@"__init__");
@@ -81,35 +78,35 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 if (a.Errors.Count > 0) {
                     // AddDiagnostics(Module.Uri, a.Errors);
                 }
-                args = await a.EvaluateAsync(cancellationToken);
+                args = a.Evaluate();
             }
             return cls.CreateInstance(cls.Name, GetLoc(expr), args);
         }
 
-        public async Task<IMember> GetValueFromBoundAsync(IPythonBoundType t, CallExpression expr, CancellationToken cancellationToken = default) {
+        public IMember GetValueFromBound(IPythonBoundType t, CallExpression expr) {
             switch (t.Type) {
                 case IPythonFunctionType fn:
-                    return await GetValueFromFunctionTypeAsync(fn, t.Self, expr, cancellationToken);
+                    return GetValueFromFunctionType(fn, t.Self, expr);
                 case IPythonPropertyType p:
-                    return await GetValueFromPropertyAsync(p, t.Self, cancellationToken);
+                    return GetValueFromProperty(p, t.Self);
                 case IPythonIteratorType it when t.Self is IPythonCollection seq:
                     return seq.GetIterator();
             }
             return UnknownType;
         }
 
-        public async Task<IMember> GetValueFromInstanceCall(IPythonInstance pi, CallExpression expr, CancellationToken cancellationToken = default) {
+        public IMember GetValueFromInstanceCall(IPythonInstance pi, CallExpression expr) {
             // Call on an instance such as 'a = 1; a()'
             // If instance is a function (such as an unbound method), then invoke it.
             var type = pi.GetPythonType();
             if (type is IPythonFunctionType pft) {
-                return await GetValueFromFunctionTypeAsync(pft, pi, expr, cancellationToken);
+                return GetValueFromFunctionType(pft, pi, expr);
             }
 
             // Try using __call__
             var call = type.GetMember("__call__").GetPythonType<IPythonFunctionType>();
             if (call != null) {
-                return await GetValueFromFunctionTypeAsync(call, pi, expr, cancellationToken);
+                return GetValueFromFunctionType(call, pi, expr);
             }
 
             // Optimistically return the instance itself. This happens when the call is
@@ -117,13 +114,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return pi;
         }
 
-        public async Task<IMember> GetValueFromFunctionTypeAsync(IPythonFunctionType fn, IPythonInstance instance, CallExpression expr, CancellationToken cancellationToken = default) {
+        public IMember GetValueFromFunctionType(IPythonFunctionType fn, IPythonInstance instance, CallExpression expr) {
             // If order to be able to find matching overload, we need to know
             // parameter types and count. This requires function to be analyzed.
             // Since we don't know which overload we will need, we have to 
             // process all known overloads for the function.
             foreach (var o in fn.Overloads) {
-                await SymbolTable.EvaluateAsync(o.FunctionDefinition, cancellationToken);
+                SymbolTable.Evaluate(o.FunctionDefinition);
             }
 
             // Pick the best overload.
@@ -132,9 +129,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             if (fn.Overloads.Count == 1) {
                 fd = fn.Overloads[0].FunctionDefinition;
                 args = new ArgumentSet(fn, 0, instance, expr, this);
-                args = await args.EvaluateAsync(cancellationToken);
+                args = args.Evaluate();
             } else {
-                args = await FindOverloadAsync(fn, instance, expr, cancellationToken);
+                args = FindOverload(fn, instance, expr);
                 if (args == null) {
                     return UnknownType;
                 }
@@ -163,7 +160,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
 
                 if (fn.IsSpecialized && fn is PythonFunctionType ft) {
                     foreach (var moduleName in ft.Dependencies) {
-                        cancellationToken.ThrowIfCancellationRequested();
                         Interpreter.ModuleResolution.GetOrLoadModule(moduleName);
                     }
                 }
@@ -175,16 +171,16 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
 
             // Try and evaluate with specific arguments but prevent recursion.
-            return await TryEvaluateWithArgumentsAsync(fn.DeclaringModule, fd, args, cancellationToken);
+            return TryEvaluateWithArguments(fn.DeclaringModule, fd, args);
         }
 
-        public async Task<IMember> GetValueFromPropertyAsync(IPythonPropertyType p, IPythonInstance instance, CancellationToken cancellationToken = default) {
+        public IMember GetValueFromProperty(IPythonPropertyType p, IPythonInstance instance) {
             // Function may not have been walked yet. Do it now.
-            await SymbolTable.EvaluateAsync(p.FunctionDefinition, cancellationToken);
+            SymbolTable.Evaluate(p.FunctionDefinition);
             return instance.Call(p.Name, ArgumentSet.Empty);
         }
 
-        private async Task<IMember> TryEvaluateWithArgumentsAsync(IPythonModule module, FunctionDefinition fd, IArgumentSet args, CancellationToken cancellationToken = default) {
+        private IMember TryEvaluateWithArguments(IPythonModule module, FunctionDefinition fd, IArgumentSet args) {
             // Attempt to evaluate with specific arguments but prevent recursion.
             IMember result = UnknownType;
             if (fd != null && !_callEvalStack.Contains(fd)) {
@@ -193,7 +189,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                     try {
                         // TODO: cache results per function + argument set?
                         var eval = new FunctionCallEvaluator(module, fd, this);
-                        result = await eval.EvaluateCallAsync(args, cancellationToken);
+                        result = eval.EvaluateCall(args);
                     } finally {
                         _callEvalStack.Pop();
                     }
@@ -202,16 +198,15 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return result;
         }
 
-        private async Task<ArgumentSet> FindOverloadAsync(IPythonFunctionType fn, IPythonInstance instance, CallExpression expr, CancellationToken cancellationToken = default) {
+        private ArgumentSet FindOverload(IPythonFunctionType fn, IPythonInstance instance, CallExpression expr) {
             if (fn.Overloads.Count == 1) {
                 return null;
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
             var sets = new List<ArgumentSet>();
             for (var i = 0; i < fn.Overloads.Count; i++) {
                 var a = new ArgumentSet(fn, i, instance, expr, this);
-                var args = await a.EvaluateAsync(cancellationToken);
+                var args = a.Evaluate();
                 sets.Add(args);
             }
 
@@ -256,7 +251,5 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
             return true;
         }
-
-
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -16,8 +16,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
@@ -88,26 +86,25 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return value;
         }
 
-        public async Task<IPythonType> GetTypeFromAnnotationAsync(Expression expr, CancellationToken cancellationToken = default, LookupOptions options = LookupOptions.Global | LookupOptions.Builtins) {
+        public IPythonType GetTypeFromAnnotation(Expression expr, LookupOptions options = LookupOptions.Global | LookupOptions.Builtins) {
             if (expr == null) {
                 return null;
             }
 
             if (expr is CallExpression callExpr) {
                 // x: NamedTuple(...)
-                return (await GetValueFromCallableAsync(callExpr, cancellationToken))?.GetPythonType() ?? UnknownType;
+                return GetValueFromCallable(callExpr)?.GetPythonType() ?? UnknownType;
             }
 
             if (expr is IndexExpression indexExpr) {
                 // Try generics
-                var target = await GetValueFromExpressionAsync(indexExpr.Target, cancellationToken);
-                var result = await GetValueFromGenericAsync(target, indexExpr, cancellationToken);
+                var target = GetValueFromExpression(indexExpr.Target);
+                var result = GetValueFromGeneric(target, indexExpr);
                 if(result != null) {
                     return result.GetPythonType();
                 }
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
             // Look at specialization and typing first
             var ann = new TypeAnnotation(Ast.LanguageVersion, expr);
             return ann.GetValue(new TypeAnnotationConverter(this, options));

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -128,6 +128,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             // When the analysis completed. Therefore if module is the one we are
             // analyzing, use scope from the evaluator rather than from the module.
             var gs = Module.Equals(module) || module == null ? GlobalScope : module.GlobalScope as Scope;
+            if (gs == null) {
+                return Disposable.Empty;
+            }
+
             if (node.Parent != null) {
                 fromScope = gs
                     .TraverseBreadthFirst(s => s.Children.OfType<Scope>())

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -16,8 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Analyzer.Symbols;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Modules;
@@ -71,8 +69,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public LocationInfo GetLocation(Node node) => node?.GetLocation(Module, Ast) ?? LocationInfo.Empty;
         public IEnumerable<DiagnosticsEntry> Diagnostics => _diagnostics;
 
-        public Task<IMember> GetValueFromExpressionAsync(Expression expr, CancellationToken cancellationToken = default)
-            => GetValueFromExpressionAsync(expr, DefaultLookupOptions, cancellationToken);
+        public IMember GetValueFromExpression(Expression expr)
+            => GetValueFromExpression(expr, DefaultLookupOptions);
 
         public IDisposable OpenScope(IScope scope) {
             if (!(scope is Scope s)) {
@@ -86,8 +84,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public IDisposable OpenScope(IPythonModule module, ScopeStatement scope) => OpenScope(module, scope, out _);
         #endregion
 
-        public async Task<IMember> GetValueFromExpressionAsync(Expression expr, LookupOptions options, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
+        public IMember GetValueFromExpression(Expression expr, LookupOptions options) {
             if (expr == null) {
                 return null;
             }
@@ -99,43 +96,43 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             IMember m;
             switch (expr) {
                 case NameExpression nex:
-                    m = await GetValueFromNameAsync(nex, options, cancellationToken);
+                    m = GetValueFromName(nex, options);
                     break;
                 case MemberExpression mex:
-                    m = await GetValueFromMemberAsync(mex, cancellationToken);
+                    m = GetValueFromMember(mex);
                     break;
                 case CallExpression cex:
-                    m = await GetValueFromCallableAsync(cex, cancellationToken);
+                    m = GetValueFromCallable(cex);
                     break;
                 case UnaryExpression uex:
-                    m = await GetValueFromUnaryOpAsync(uex, cancellationToken);
+                    m = GetValueFromUnaryOp(uex);
                     break;
                 case IndexExpression iex:
-                    m = await GetValueFromIndexAsync(iex, cancellationToken);
+                    m = GetValueFromIndex(iex);
                     break;
                 case ConditionalExpression coex:
-                    m = await GetValueFromConditionalAsync(coex, cancellationToken);
+                    m = GetValueFromConditional(coex);
                     break;
                 case ListExpression listex:
-                    m = await GetValueFromListAsync(listex, cancellationToken);
+                    m = GetValueFromList(listex);
                     break;
                 case DictionaryExpression dictex:
-                    m = await GetValueFromDictionaryAsync(dictex, cancellationToken);
+                    m = GetValueFromDictionary(dictex);
                     break;
                 case SetExpression setex:
-                    m = await GetValueFromSetAsync(setex, cancellationToken);
+                    m = GetValueFromSet(setex);
                     break;
                 case TupleExpression tex:
-                    m = await GetValueFromTupleAsync(tex, cancellationToken);
+                    m = GetValueFromTuple(tex);
                     break;
                 case YieldExpression yex:
-                    m = await GetValueFromExpressionAsync(yex.Expression, cancellationToken);
+                    m = GetValueFromExpression(yex.Expression);
                     break;
                 case GeneratorExpression genex:
-                    m = await GetValueFromGeneratorAsync(genex, cancellationToken);
+                    m = GetValueFromGenerator(genex);
                     break;
                 default:
-                    m = await GetValueFromBinaryOpAsync(expr, cancellationToken) ?? GetConstantFromLiteral(expr, options);
+                    m = GetValueFromBinaryOp(expr) ?? GetConstantFromLiteral(expr, options);
                     break;
             }
             if (m == null) {
@@ -144,7 +141,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return m;
         }
 
-        private async Task<IMember> GetValueFromNameAsync(NameExpression expr, LookupOptions options, CancellationToken cancellationToken = default) {
+        private IMember GetValueFromName(NameExpression expr, LookupOptions options) {
             if (expr == null || string.IsNullOrEmpty(expr.Name)) {
                 return null;
             }
@@ -153,18 +150,17 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return Module;
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
             var member = LookupNameInScopes(expr.Name, options);
             if (member != null) {
                 switch (member.GetPythonType()) {
                     case IPythonClassType cls:
-                        await SymbolTable.EvaluateAsync(cls.ClassDefinition, cancellationToken);
+                        SymbolTable.Evaluate(cls.ClassDefinition);
                         break;
                     case IPythonFunctionType fn:
-                        await SymbolTable.EvaluateAsync(fn.FunctionDefinition, cancellationToken);
+                        SymbolTable.Evaluate(fn.FunctionDefinition);
                         break;
                     case IPythonPropertyType prop:
-                        await SymbolTable.EvaluateAsync(prop.FunctionDefinition, cancellationToken);
+                        SymbolTable.Evaluate(prop.FunctionDefinition);
                         break;
                 }
                 return member;
@@ -174,13 +170,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return UnknownType;
         }
 
-        private async Task<IMember> GetValueFromMemberAsync(MemberExpression expr, CancellationToken cancellationToken = default) {
+        private IMember GetValueFromMember(MemberExpression expr) {
             if (expr?.Target == null || string.IsNullOrEmpty(expr.Name)) {
                 return null;
             }
 
             IPythonInstance instance = null;
-            var m = await GetValueFromExpressionAsync(expr.Target, cancellationToken);
+            var m = GetValueFromExpression(expr.Target);
             if (m is IPythonType typeInfo) {
                 var member = typeInfo.GetMember(expr.Name);
                 // If container is class/type info rather than the instance, then the method is an unbound function.
@@ -218,13 +214,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
         }
 
-        private async Task<IMember> GetValueFromConditionalAsync(ConditionalExpression expr, CancellationToken cancellationToken = default) {
+        private IMember GetValueFromConditional(ConditionalExpression expr) {
             if (expr == null) {
                 return null;
             }
 
-            var trueValue = await GetValueFromExpressionAsync(expr.TrueExpression, cancellationToken);
-            var falseValue = await GetValueFromExpressionAsync(expr.FalseExpression, cancellationToken);
+            var trueValue = GetValueFromExpression(expr.TrueExpression);
+            var falseValue = GetValueFromExpression(expr.FalseExpression);
 
             return trueValue ?? falseValue ?? UnknownType;
         }

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
@@ -15,8 +15,6 @@
 
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Core.DependencyResolution;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
@@ -26,8 +24,7 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed partial class ImportHandler {
-        public bool HandleFromImport(FromImportStatement node, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
+        public bool HandleFromImport(FromImportStatement node) {
             if (Module.ModuleType == ModuleType.Specialized) {
                 return false;
             }
@@ -122,10 +119,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             }
         }
 
-        private void HandleModuleImportStar(IPythonModule module, CancellationToken cancellationToken = default) {
+        private void HandleModuleImportStar(IPythonModule module) {
             foreach (var memberName in module.GetMemberNames()) {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 var member = module.GetMember(memberName);
                 if (member == null) {
                     Log?.Log(TraceEventType.Verbose, $"Undefined import: {module.Name}, {memberName}");

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using Microsoft.Python.Analysis.Core.DependencyResolution;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Modules;
@@ -30,16 +29,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed partial class ImportHandler : StatementHandler {
         public ImportHandler(AnalysisWalker walker) : base(walker) { }
 
-        public bool HandleImport(ImportStatement node, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
+        public bool HandleImport(ImportStatement node) {
             if (Module.ModuleType == ModuleType.Specialized) {
                 return false;
             }
 
             var len = Math.Min(node.Names.Count, node.AsNames.Count);
             for (var i = 0; i < len; i++) {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 var moduleImportExpression = node.Names[i];
                 var importNames = moduleImportExpression.Names.Select(n => n.Name).ToArray();
                 var asNameExpression = node.AsNames[i];

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/LoopHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/LoopHandler.cs
@@ -14,8 +14,6 @@
 // permissions and limitations under the License.
 
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Parsing.Ast;
 
@@ -23,10 +21,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed class LoopHandler : StatementHandler {
         public LoopHandler(AnalysisWalker walker) : base(walker) { }
 
-        public async Task HandleForAsync(ForStatement node, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var iterable = await Eval.GetValueFromExpressionAsync(node.List, cancellationToken);
+        public void HandleFor(ForStatement node) {
+            var iterable = Eval.GetValueFromExpression(node.List);
             var iterator = (iterable as IPythonIterable)?.GetIterator();
             if (iterator == null) {
                 // TODO: report that expression does not evaluate to iterable.
@@ -53,19 +49,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                     break;
             }
 
-            if (node.Body != null) {
-                await node.Body.WalkAsync(Walker, cancellationToken);
-            }
+            node.Body?.Walk(Walker);
         }
 
-        public async Task HandleWhileAsync(WhileStatement node, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (node.Body != null) {
-                await node.Body.WalkAsync(Walker, cancellationToken);
-            }
-            if (node.ElseStatement != null) {
-                await node.ElseStatement.WalkAsync(Walker, cancellationToken);
-            }
+        public void HandleWhile(WhileStatement node) {
+            node.Body?.Walk(Walker);
+            node.ElseStatement?.Walk(Walker);
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/NonLocalHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/NonLocalHandler.cs
@@ -13,26 +13,24 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed class NonLocalHandler : StatementHandler {
         public NonLocalHandler(AnalysisWalker walker) : base(walker) { }
 
-        public Task<bool> HandleNonLocalAsync(NonlocalStatement node, CancellationToken cancellationToken = default) {
+        public bool HandleNonLocal(NonlocalStatement node) {
             foreach (var nex in node.Names) {
                 Eval.CurrentScope.DeclareNonLocal(nex.Name, Eval.GetLoc(nex));
             }
-            return Task.FromResult(false);
+            return false;
         }
 
-        public Task<bool> HandleGlobalAsync(GlobalStatement node, CancellationToken cancellationToken = default) {
+        public bool HandleGlobal(GlobalStatement node) {
             foreach (var nex in node.Names) {
                 Eval.CurrentScope.DeclareGlobal(nex.Name, Eval.GetLoc(nex));
             }
-            return Task.FromResult(false);
+            return false;
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/TupleExpressionHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/TupleExpressionHandler.cs
@@ -15,8 +15,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Parsing.Ast;
@@ -25,15 +23,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed class TupleExpressionHandler : StatementHandler {
         public TupleExpressionHandler(AnalysisWalker walker) : base(walker) { }
 
-        public async Task HandleTupleAssignmentAsync(TupleExpression lhs, Expression rhs, IMember value, CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
+        public void HandleTupleAssignment(TupleExpression lhs, Expression rhs, IMember value) {
 
             if (rhs is TupleExpression tex) {
                 var returnedExpressions = tex.Items.ToArray();
                 var names = lhs.Items.OfType<NameExpression>().Select(x => x.Name).ToArray();
                 for (var i = 0; i < Math.Min(names.Length, returnedExpressions.Length); i++) {
                     if (returnedExpressions[i] != null && !string.IsNullOrEmpty(names[i])) {
-                        var v = await Eval.GetValueFromExpressionAsync(returnedExpressions[i], cancellationToken);
+                        var v = Eval.GetValueFromExpression(returnedExpressions[i]);
                         Eval.DeclareVariable(names[i], v ?? Eval.UnknownType, VariableSource.Declaration, returnedExpressions[i]);
                     }
                 }

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -14,8 +14,6 @@
 // permissions and limitations under the License.
 
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
@@ -34,33 +32,33 @@ namespace Microsoft.Python.Analysis.Analyzer {
             _stubAnalysis = Module.Stub is IDocument doc ? doc.GetAnyAnalysis() : null;
         }
 
-        public override async Task<bool> WalkAsync(PythonAst node, CancellationToken cancellationToken = default) {
+        public override bool Walk(PythonAst node) {
             Check.InvalidOperation(() => Ast == node, "walking wrong AST");
 
             // Collect basic information about classes and functions in order
             // to correctly process forward references. Does not determine
             // types yet since at this time imports or generic definitions
             // have not been processed.
-            await SymbolTable.BuildAsync(Eval, cancellationToken);
+            SymbolTable.Build(Eval);
             if (_stubAnalysis != null) {
                 Eval.Log?.Log(TraceEventType.Information, $"'{Module.Name}' evaluation skipped, stub is available.");
             }
-            return await base.WalkAsync(node, cancellationToken);
+            return base.Walk(node);
         }
 
         // Classes and functions are walked by their respective evaluators
-        public override async Task<bool> WalkAsync(ClassDefinition node, CancellationToken cancellationToken = default) {
-            await SymbolTable.EvaluateAsync(node, cancellationToken);
+        public override bool Walk(ClassDefinition node) {
+            SymbolTable.Evaluate(node);
             return false;
         }
 
-        public override async Task<bool> WalkAsync(FunctionDefinition node, CancellationToken cancellationToken = default) {
-            await SymbolTable.EvaluateAsync(node, cancellationToken);
+        public override bool Walk(FunctionDefinition node) {
+            SymbolTable.Evaluate(node);
             return false;
         }
 
-        public async Task CompleteAsync(CancellationToken cancellationToken = default) {
-            await SymbolTable.EvaluateAllAsync(cancellationToken);
+        public void Complete() {
+            SymbolTable.EvaluateAll();
             SymbolTable.ReplacedByStubs.Clear();
             MergeStub();
         }

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     }
                     
                     if (Interlocked.Increment(ref _runningTasks) >= _maxTaskRunning) {
-                        await AnalyzeAsync(node, walker.Version, stopWatch, analysisToken);
+                        Analyze(node, walker.Version, stopWatch, analysisToken);
                     } else {
                         StartAnalysis(node, walker.Version, stopWatch, analysisToken);
                     }
@@ -176,14 +176,14 @@ namespace Microsoft.Python.Analysis.Analyzer {
         }
 
         private void StartAnalysis(IDependencyChainNode<PythonAnalyzerEntry> node, int version, Stopwatch stopWatch, CancellationToken cancellationToken) 
-            => Task.Run(() => AnalyzeAsync(node, version, stopWatch, cancellationToken), cancellationToken).DoNotWait();
+            => Task.Run(() => Analyze(node, version, stopWatch, cancellationToken), cancellationToken);
 
         /// <summary>
         /// Performs analysis of the document. Returns document global scope
         /// with declared variables and inner scopes. Does not analyze chain
         /// of dependencies, it is intended for the single file analysis.
         /// </summary>
-        private async Task AnalyzeAsync(IDependencyChainNode<PythonAnalyzerEntry> node, int version, Stopwatch stopWatch, CancellationToken cancellationToken) {
+        private void Analyze(IDependencyChainNode<PythonAnalyzerEntry> node, int version, Stopwatch stopWatch, CancellationToken cancellationToken) {
             try {
                 var startTime = stopWatch.ElapsedMilliseconds;
                 var module = node.Value.Module;
@@ -192,12 +192,12 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 // Now run the analysis.
                 var walker = new ModuleWalker(_services, module, ast);
 
-                await ast.WalkAsync(walker, cancellationToken);
+                ast.Walk(walker);
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Note that we do not set the new analysis here and rather let
                 // Python analyzer to call NotifyAnalysisComplete.
-                await walker.CompleteAsync(cancellationToken);
+                walker.Complete();
                 cancellationToken.ThrowIfCancellationRequested();
                 var analysis = new DocumentAnalysis((IDocument)module, version, walker.GlobalScope, walker.Eval);
 

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -15,8 +15,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
@@ -32,12 +30,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             _classDef = classDef;
         }
 
-        public override Task EvaluateAsync(CancellationToken cancellationToken = default)
-            => EvaluateClassAsync(cancellationToken);
+        public override void Evaluate() {
+            EvaluateClass();
+            Result = _class;
+        }
 
-        public async Task EvaluateClassAsync(CancellationToken cancellationToken = default) {
-            cancellationToken.ThrowIfCancellationRequested();
-
+        public void EvaluateClass() {
             // Open class scope chain
             using (Eval.OpenScope(Module, _classDef, out var outerScope)) {
                 var instance = Eval.GetInScope(_classDef.Name, outerScope);
@@ -49,14 +47,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 }
 
                 // Evaluate inner classes, if any
-                await EvaluateInnerClassesAsync(_classDef, cancellationToken);
+                EvaluateInnerClasses(_classDef);
 
                 _class = classInfo;
                 // Set bases to the class.
                 var bases = new List<IPythonType>();
                 foreach (var a in _classDef.Bases.Where(a => string.IsNullOrEmpty(a.Name))) {
                     // We cheat slightly and treat base classes as annotations.
-                    var b = await Eval.GetTypeFromAnnotationAsync(a.Expression, cancellationToken);
+                    var b = Eval.GetTypeFromAnnotation(a.Expression);
                     if (b != null) {
                         bases.Add(b.GetPythonType());
                     }
@@ -66,11 +64,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 // Declare __class__ variable in the scope.
                 Eval.DeclareVariable("__class__", _class, VariableSource.Declaration, _classDef);
 
-                await ProcessClassBody(cancellationToken);
+                ProcessClassBody();
             }
         }
 
-        private async Task ProcessClassBody(CancellationToken cancellationToken = default) {
+        private void ProcessClassBody() {
             // Class is handled in a specific order rather than in the order of
             // the statement appearance. This is because we need all members
             // properly declared and added to the class type so when we process
@@ -79,39 +77,39 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
             // Process bases.
             foreach (var b in _class.Bases.Select(b => b.GetPythonType<IPythonClassType>()).ExcludeDefault()) {
-                await SymbolTable.EvaluateAsync(b.ClassDefinition, cancellationToken);
+                SymbolTable.Evaluate(b.ClassDefinition);
             }
 
             // Process imports
             foreach (var s in GetStatements<FromImportStatement>(_classDef)) {
-                ImportHandler.HandleFromImport(s, cancellationToken);
+                ImportHandler.HandleFromImport(s);
             }
 
             foreach (var s in GetStatements<ImportStatement>(_classDef)) {
-                ImportHandler.HandleImport(s, cancellationToken);
+                ImportHandler.HandleImport(s);
             }
 
             UpdateClassMembers();
 
             // Process assignments so we get class variables declared.
             foreach (var s in GetStatements<AssignmentStatement>(_classDef)) {
-                await AssignmentHandler.HandleAssignmentAsync(s, cancellationToken);
+                AssignmentHandler.HandleAssignment(s);
             }
             foreach (var s in GetStatements<ExpressionStatement>(_classDef)) {
-                await AssignmentHandler.HandleAnnotatedExpressionAsync(s.Expression as ExpressionWithAnnotation, null, cancellationToken);
+                AssignmentHandler.HandleAnnotatedExpression(s.Expression as ExpressionWithAnnotation, null);
             }
             UpdateClassMembers();
 
             // Ensure constructors are processed so class members are initialized.
-            await EvaluateConstructorsAsync(_classDef, cancellationToken);
+            EvaluateConstructors(_classDef);
             UpdateClassMembers();
 
             // Process remaining methods.
-            await SymbolTable.EvaluateScopeAsync(_classDef, cancellationToken);
+            SymbolTable.EvaluateScope(_classDef);
             UpdateClassMembers();
         }
 
-        private async Task EvaluateConstructorsAsync(ClassDefinition cd, CancellationToken cancellationToken = default) {
+        private void EvaluateConstructors(ClassDefinition cd) {
             // Do not use foreach since walker list is dynamically modified and walkers are removed
             // after processing. Handle __init__ and __new__ first so class variables are initialized.
             var constructors = SymbolTable.Evaluators
@@ -121,11 +119,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 .ToArray();
 
             foreach (var ctor in constructors) {
-                await SymbolTable.EvaluateAsync(ctor, cancellationToken);
+                SymbolTable.Evaluate(ctor);
             }
         }
 
-        private async Task EvaluateInnerClassesAsync(ClassDefinition cd, CancellationToken cancellationToken = default) {
+        private void EvaluateInnerClasses(ClassDefinition cd) {
             // Do not use foreach since walker list is dynamically modified and walkers are removed
             // after processing. Handle __init__ and __new__ first so class variables are initialized.
             var innerClasses = SymbolTable.Evaluators
@@ -135,7 +133,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 .ToArray();
 
             foreach (var c in innerClasses) {
-                await SymbolTable.EvaluateAsync(c, cancellationToken);
+                SymbolTable.Evaluate(c);
             }
         }
 
@@ -149,7 +147,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
         }
 
         // Classes and functions are walked by their respective evaluators
-        public override Task<bool> WalkAsync(ClassDefinition node, CancellationToken cancellationToken = default) => Task.FromResult(false);
-        public override Task<bool> WalkAsync(FunctionDefinition node, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public override bool Walk(ClassDefinition node) => false;
+        public override bool Walk(FunctionDefinition node) => false;
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -17,8 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Extensions;
 using Microsoft.Python.Analysis.Modules;
@@ -49,14 +47,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
         public FunctionDefinition FunctionDefinition { get; }
 
-        public override async Task EvaluateAsync(CancellationToken cancellationToken = default) {
+        public override void Evaluate() {
             if (SymbolTable.ReplacedByStubs.Contains(Target)) {
                 return;
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
             // Process annotations.
-            var annotationType = await Eval.GetTypeFromAnnotationAsync(FunctionDefinition.ReturnAnnotation, cancellationToken);
+            var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation);
             if (!annotationType.IsUnknown()) {
                 // Annotations are typically types while actually functions return
                 // instances unless specifically annotated to a type such as Type[T].
@@ -68,26 +65,27 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 var yieldExpr = suite?.Statements.OfType<ExpressionStatement>().Select(s => s.Expression as YieldExpression).ExcludeDefault().FirstOrDefault();
                 if (yieldExpr != null) {
                     // Function return is an iterator
-                    var yieldValue = await Eval.GetValueFromExpressionAsync(yieldExpr.Expression, cancellationToken) ?? Eval.UnknownType;
+                    var yieldValue = Eval.GetValueFromExpression(yieldExpr.Expression) ?? Eval.UnknownType;
                     var returnValue = new PythonGenerator(Eval.Interpreter, yieldValue);
                     _overload.SetReturnValue(returnValue, true);
                 }
             }
 
             using (Eval.OpenScope(_function.DeclaringModule, FunctionDefinition, out _)) {
-                await DeclareParametersAsync(cancellationToken);
+                DeclareParameters();
                 if (annotationType.IsUnknown() || Module.ModuleType == ModuleType.User) {
                     // Return type from the annotation is sufficient for libraries
                     // and stubs, no need to walk the body.
                     if (FunctionDefinition.Body != null && Module.ModuleType != ModuleType.Specialized) {
-                        await FunctionDefinition.Body.WalkAsync(this, cancellationToken);
+                        FunctionDefinition.Body.Walk(this);
                     }
                 }
             }
+            Result = _function;
         }
 
-        public override async Task<bool> WalkAsync(AssignmentStatement node, CancellationToken cancellationToken = default) {
-            var value = await Eval.GetValueFromExpressionAsync(node.Right, cancellationToken) ?? Eval.UnknownType;
+        public override bool Walk(AssignmentStatement node) {
+            var value = Eval.GetValueFromExpression(node.Right) ?? Eval.UnknownType;
 
             foreach (var lhs in node.Left) {
                 switch (lhs) {
@@ -101,11 +99,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                         return true; // Don't assign to 'self'
                 }
             }
-            return await base.WalkAsync(node, cancellationToken);
+            return base.Walk(node);
         }
 
-        public override async Task<bool> WalkAsync(ReturnStatement node, CancellationToken cancellationToken = default) {
-            var value = await Eval.GetValueFromExpressionAsync(node.Expression, cancellationToken);
+        public override bool Walk(ReturnStatement node) {
+            var value = Eval.GetValueFromExpression(node.Expression);
             if (value != null) {
                 _overload.AddReturnValue(value);
             }
@@ -113,13 +111,17 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
         }
 
         // Classes and functions are walked by their respective evaluators
-        public override Task<bool> WalkAsync(ClassDefinition node, CancellationToken cancellationToken = default) => Task.FromResult(false);
-        public override async Task<bool> WalkAsync(FunctionDefinition node, CancellationToken cancellationToken = default) {
-            await SymbolTable.EvaluateAsync(node, cancellationToken);
+        public override bool Walk(ClassDefinition node) => false;
+        public override bool Walk(FunctionDefinition node) {
+            // Inner function, declare as variable.
+            var m = SymbolTable.Evaluate(node);
+            if (m != null) {
+                Eval.DeclareVariable(node.NameExpression.Name, m, VariableSource.Declaration, Eval.GetLoc(node));
+            }
             return false;
         }
 
-        private async Task DeclareParametersAsync(CancellationToken cancellationToken = default) {
+        private void DeclareParameters() {
             // For class method no need to add extra parameters, but first parameter type should be the class.
             // For static and unbound methods do not add or set anything.
             // For regular bound methods add first parameter and set it to the class.
@@ -143,34 +145,32 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
             // Declare parameters in scope
             for (var i = skip; i < FunctionDefinition.Parameters.Length; i++) {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 var p = FunctionDefinition.Parameters[i];
                 if (!string.IsNullOrEmpty(p.Name)) {
                     // If parameter has default value, look for the annotation locally first
                     // since outer type may be getting redefined. Consider 's = None; def f(s: s = 123): ...
                     IPythonType paramType = null;
                     if (p.DefaultValue != null) {
-                        paramType = await Eval.GetTypeFromAnnotationAsync(p.Annotation, cancellationToken, LookupOptions.Local | LookupOptions.Builtins);
+                        paramType = Eval.GetTypeFromAnnotation(p.Annotation, LookupOptions.Local | LookupOptions.Builtins);
                         if (paramType == null) {
-                            var defaultValue = await Eval.GetValueFromExpressionAsync(p.DefaultValue, cancellationToken);
+                            var defaultValue = Eval.GetValueFromExpression(p.DefaultValue);
                             if (!defaultValue.IsUnknown()) {
                                 paramType = defaultValue.GetPythonType();
                             }
                         }
                     }
                     // If all else fails, look up globally.
-                    paramType = paramType ?? await Eval.GetTypeFromAnnotationAsync(p.Annotation, cancellationToken);
+                    paramType = paramType ?? Eval.GetTypeFromAnnotation(p.Annotation);
 
                     var pi = new ParameterInfo(Ast, p, paramType);
-                    await DeclareParameterAsync(p, i, pi, cancellationToken);
+                    DeclareParameter(p, i, pi);
                     parameters.Add(pi);
                 }
             }
             _overload.SetParameters(parameters);
         }
 
-        private async Task DeclareParameterAsync(Parameter p, int index, ParameterInfo pi, CancellationToken cancellationToken = default) {
+        private void DeclareParameter(Parameter p, int index, ParameterInfo pi) {
             IPythonType paramType;
 
             // If type is known from annotation, use it.
@@ -178,7 +178,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 // TODO: technically generics may have constraints. Should we consider them?
                 paramType = pi.Type;
             } else {
-                var defaultValue = await Eval.GetValueFromExpressionAsync(p.DefaultValue, cancellationToken) ?? Eval.UnknownType;
+                var defaultValue = Eval.GetValueFromExpression(p.DefaultValue) ?? Eval.UnknownType;
 
                 paramType = defaultValue?.GetPythonType();
                 if (!paramType.IsUnknown()) {
@@ -187,20 +187,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             }
 
             Eval.DeclareVariable(p.Name, new PythonInstance(paramType), VariableSource.Declaration, p.NameExpression);
-        }
-
-        private async Task EvaluateInnerFunctionsAsync(FunctionDefinition fd, CancellationToken cancellationToken = default) {
-            // Do not use foreach since walker list is dynamically modified and walkers are removed
-            // after processing. Handle __init__ and __new__ first so class variables are initialized.
-            var innerFunctions = SymbolTable.Evaluators
-                .Where(kvp => kvp.Key.Parent == fd && (kvp.Key is FunctionDefinition))
-                .Select(c => c.Value)
-                .ExcludeDefault()
-                .ToArray();
-
-            foreach (var c in innerFunctions) {
-                await SymbolTable.EvaluateAsync(c, cancellationToken);
-            }
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/MemberEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/MemberEvaluator.cs
@@ -15,9 +15,8 @@
 
 using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Analyzer.Evaluation;
+using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer.Symbols {
@@ -30,7 +29,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
         public ScopeStatement Target { get; }
         public bool IsClass => Target is ClassDefinition;
         public bool IsFunction => Target is FunctionDefinition;
-
-        public abstract Task EvaluateAsync(CancellationToken cancellationToken = default);
+        public IMember Result { get; protected set; }
+        public abstract void Evaluate();
     }
 }

--- a/src/Analysis/Ast/Impl/Types/ArgumentSet.cs
+++ b/src/Analysis/Ast/Impl/Types/ArgumentSet.cs
@@ -16,8 +16,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Diagnostics;
@@ -266,25 +264,25 @@ namespace Microsoft.Python.Analysis.Types {
             }
         }
 
-        public async Task<ArgumentSet> EvaluateAsync(CancellationToken cancellationToken = default) {
+        public ArgumentSet Evaluate() {
             if (_evaluated || Eval == null) {
                 return this;
             }
 
             foreach (var a in _arguments.Where(x => x.Value == null)) {
-                a.Value = await Eval.GetValueFromExpressionAsync(a.Expression, cancellationToken) ?? _eval.UnknownType;
+                a.Value = Eval.GetValueFromExpression(a.Expression) ?? _eval.UnknownType;
             }
 
             if (_listArgument != null) {
                 foreach (var e in _listArgument.Expressions) {
-                    var value = await Eval.GetValueFromExpressionAsync(e, cancellationToken) ?? _eval.UnknownType;
+                    var value = Eval.GetValueFromExpression(e) ?? _eval.UnknownType;
                     _listArgument._Values.Add(value);
                 }
             }
 
             if (_dictArgument != null) {
                 foreach (var e in _dictArgument.Expressions) {
-                    var value = await Eval.GetValueFromExpressionAsync(e.Value, cancellationToken) ?? _eval.UnknownType;
+                    var value = Eval.GetValueFromExpression(e.Value) ?? _eval.UnknownType;
                     _dictArgument._Args[e.Key] = value;
                 }
             }

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -528,5 +528,23 @@ d = f(D())";
             analysis.Should().HaveVariable("c").OfType(BuiltinTypeId.Int)
                 .And.HaveVariable("d").OfType(BuiltinTypeId.Float);
         }
+
+        [TestMethod, Priority(0)]
+        public async Task NestedFunction() {
+            const string code = @"
+def outer():
+    def inner():
+        x = 1
+        return x
+    return inner
+
+y = outer()
+z = y()
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            analysis.Should().HaveVariable("y").OfType(BuiltinTypeId.Function)
+                .And.HaveVariable("z").OfType(BuiltinTypeId.Int);
+        }
     }
 }

--- a/src/LanguageServer/Impl/Completion/ErrorExpressionCompletion.cs
+++ b/src/LanguageServer/Impl/Completion/ErrorExpressionCompletion.cs
@@ -14,12 +14,8 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core.Text;
@@ -29,7 +25,7 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Completion {
     internal static class ErrorExpressionCompletion {
-        public static async Task<CompletionResult> GetCompletionsAsync(ScopeStatement scope, Node statement, Node expression, CompletionContext context, CancellationToken cancellationToken = default) {
+        public static CompletionResult GetCompletions(ScopeStatement scope, Node statement, Node expression, CompletionContext context) {
             if (!(expression is ErrorExpression)) {
                 return CompletionResult.Empty;
             }
@@ -54,7 +50,7 @@ namespace Microsoft.Python.LanguageServer.Completion {
                     code = es.ReadExpression(tokens.Skip(1));
                     applicableSpan = new SourceSpan(context.Location, context.Location);
                     e = GetExpressionFromText(code, context, out var s1, out _);
-                    items = await ExpressionCompletion.GetCompletionsFromMembersAsync(e, s1, context, cancellationToken);
+                    items = ExpressionCompletion.GetCompletionsFromMembers(e, s1, context);
                     break;
 
                 case TokenKind.KeywordDef when lastToken.Key.End < context.Position && scope is FunctionDefinition fd: {
@@ -71,7 +67,7 @@ namespace Microsoft.Python.LanguageServer.Completion {
                     code = es.ReadExpression(tokens.Skip(2));
                     applicableSpan = new SourceSpan(context.TokenSource.GetTokenSpan(lastToken.Key).Start, context.Location);
                     e = GetExpressionFromText(code, context, out var s2, out _);
-                    items = await ExpressionCompletion.GetCompletionsFromMembersAsync(e, s2, context, cancellationToken);
+                    items = ExpressionCompletion.GetCompletionsFromMembers(e, s2, context);
                     break;
 
                 case TokenKind.Name when nextLast == TokenKind.KeywordDef && scope is FunctionDefinition fd: {

--- a/src/LanguageServer/Impl/Completion/ExpressionCompletion.cs
+++ b/src/LanguageServer/Impl/Completion/ExpressionCompletion.cs
@@ -15,31 +15,27 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
-using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
-using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Protocol;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Completion {
     internal static  class ExpressionCompletion {
-        public static Task<IEnumerable<CompletionItem>> GetCompletionsFromMembersAsync(Expression e, IScope scope, CompletionContext context, CancellationToken cancellationToken = default) {
+        public static IEnumerable<CompletionItem> GetCompletionsFromMembers(Expression e, IScope scope, CompletionContext context) {
             using (context.Analysis.ExpressionEvaluator.OpenScope(scope)) {
-                return GetItemsFromExpressionAsync(e, context, cancellationToken);
+                return GetItemsFromExpression(e, context);
             }
         }
 
-        public static Task<IEnumerable<CompletionItem>> GetCompletionsFromMembersAsync(Expression e, ScopeStatement scope, CompletionContext context, CancellationToken cancellationToken = default) {
+        public static IEnumerable<CompletionItem> GetCompletionsFromMembers(Expression e, ScopeStatement scope, CompletionContext context) {
             using (context.Analysis.ExpressionEvaluator.OpenScope(context.Analysis.Document, scope)) {
-                return GetItemsFromExpressionAsync(e, context, cancellationToken);
+                return GetItemsFromExpression(e, context);
             }
         }
 
-        private static async Task<IEnumerable<CompletionItem>> GetItemsFromExpressionAsync(Expression e, CompletionContext context, CancellationToken cancellationToken = default) {
-            var value = await context.Analysis.ExpressionEvaluator.GetValueFromExpressionAsync(e, cancellationToken);
+        private static IEnumerable<CompletionItem> GetItemsFromExpression(Expression e, CompletionContext context) {
+            var value = context.Analysis.ExpressionEvaluator.GetValueFromExpression(e);
             if (!value.IsUnknown()) {
                 var items = new List<CompletionItem>();
                 var type = value.GetPythonType();

--- a/src/LanguageServer/Impl/Completion/TopLevelCompletion.cs
+++ b/src/LanguageServer/Impl/Completion/TopLevelCompletion.cs
@@ -16,12 +16,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Analyzer.Expressions;
 using Microsoft.Python.Analysis.Types;
-using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Protocol;
@@ -29,7 +26,7 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Completion {
     internal static class TopLevelCompletion {
-        public static async Task<CompletionResult> GetCompletionsAsync(Node statement, ScopeStatement scopeStatement, CompletionContext context, CancellationToken cancellationToken = default) {
+        public static CompletionResult GetCompletions(Node statement, ScopeStatement scopeStatement, CompletionContext context) {
             SourceSpan? applicableSpan = null;
             var eval = context.Analysis.ExpressionEvaluator;
 
@@ -61,7 +58,7 @@ namespace Microsoft.Python.LanguageServer.Completion {
             // Add possible function arguments.
             var finder = new ExpressionFinder(context.Ast, new FindExpressionOptions { Calls = true });
             if (finder.GetExpression(context.Position) is CallExpression callExpr && callExpr.GetArgumentAtIndex(context.Ast, context.Position, out _)) {
-                var value = await eval.GetValueFromExpressionAsync(callExpr.Target, cancellationToken);
+                var value = eval.GetValueFromExpression(callExpr.Target);
                 if (value?.GetPythonType() is IPythonFunctionType ft) {
                     var arguments = ft.Overloads.SelectMany(o => o.Parameters).Select(p => p?.Name)
                         .Where(n => !string.IsNullOrEmpty(n))

--- a/src/LanguageServer/Impl/Implementation/Server.Editor.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Editor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             var res = new CompletionList();
             var analysis = await GetAnalysisAsync(uri, cancellationToken);
             if(analysis != null) { 
-                var result = await _completionSource.GetCompletionsAsync(analysis, @params.position, cancellationToken);
+                var result = _completionSource.GetCompletions(analysis, @params.position);
                 res.items = result.Completions.ToArray();
             }
 
@@ -50,7 +50,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             var analysis = await GetAnalysisAsync(uri, cancellationToken);
             if (analysis != null) {
-                return await _hoverSource.GetHoverAsync(analysis, @params.position, cancellationToken);
+                return _hoverSource.GetHover(analysis, @params.position);
             }
             return null;
         }
@@ -61,7 +61,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             var analysis = await GetAnalysisAsync(uri, cancellationToken);
             if (analysis != null) {
-                return await _signatureSource.GetSignatureAsync(analysis, @params.position, cancellationToken);
+                return _signatureSource.GetSignature(analysis, @params.position);
             }
             return null;
         }
@@ -72,7 +72,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             var analysis = await GetAnalysisAsync(uri, cancellationToken);
             var ds = new DefinitionSource();
-            var reference = await ds.FindDefinitionAsync(analysis, @params.position, cancellationToken);
+            var reference = ds.FindDefinition(analysis, @params.position);
             return reference != null ? new[] { reference } : Array.Empty<Reference>();
         }
     }

--- a/src/LanguageServer/Impl/Sources/HoverSource.cs
+++ b/src/LanguageServer/Impl/Sources/HoverSource.cs
@@ -13,15 +13,10 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Analyzer.Expressions;
 using Microsoft.Python.Analysis.Types;
-using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Core.Text;
@@ -37,7 +32,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             _docSource = docSource;
         }
 
-        public async Task<Hover> GetHoverAsync(IDocumentAnalysis analysis, SourceLocation location, CancellationToken cancellationToken = default) {
+        public Hover GetHover(IDocumentAnalysis analysis, SourceLocation location) {
             if (analysis is EmptyAnalysis) {
                 return new Hover { contents = Resources.AnalysisIsInProgressHover };
             }
@@ -83,7 +78,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             IMember value;
             IPythonType type;
             using (eval.OpenScope(analysis.Document, scope)) {
-                value = await analysis.ExpressionEvaluator.GetValueFromExpressionAsync(expr, cancellationToken);
+                value = analysis.ExpressionEvaluator.GetValueFromExpression(expr);
                 type = value?.GetPythonType();
                 if (type == null) {
                     return null;
@@ -103,7 +98,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
                 // In case of a member expression get the target since if we end up with method
                 // of a generic class, the function will need specific type to determine its return
                 // value correctly. I.e. in x.func() we need to determine type of x (self for func).
-                var v = await analysis.ExpressionEvaluator.GetValueFromExpressionAsync(mex.Target, cancellationToken);
+                var v = analysis.ExpressionEvaluator.GetValueFromExpression(mex.Target);
                 self = v?.GetPythonType();
             }
 

--- a/src/LanguageServer/Impl/Sources/SignatureSource.cs
+++ b/src/LanguageServer/Impl/Sources/SignatureSource.cs
@@ -15,8 +15,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Analyzer.Expressions;
@@ -34,7 +32,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             _docSource = docSource;
         }
 
-        public async Task<SignatureHelp> GetSignatureAsync(IDocumentAnalysis analysis, SourceLocation location, CancellationToken cancellationToken = default) {
+        public SignatureHelp GetSignature(IDocumentAnalysis analysis, SourceLocation location) {
             if (analysis is EmptyAnalysis) {
                 return null;
             }
@@ -48,10 +46,10 @@ namespace Microsoft.Python.LanguageServer.Sources {
             if (call != null) {
                 using (analysis.ExpressionEvaluator.OpenScope(analysis.Document, scope)) {
                     if (call.Target is MemberExpression mex) {
-                        var v = await analysis.ExpressionEvaluator.GetValueFromExpressionAsync(mex.Target, cancellationToken);
+                        var v = analysis.ExpressionEvaluator.GetValueFromExpression(mex.Target);
                         selfType = v?.GetPythonType();
                     }
-                    value = await analysis.ExpressionEvaluator.GetValueFromExpressionAsync(call.Target, cancellationToken);
+                    value = analysis.ExpressionEvaluator.GetValueFromExpression(call.Target);
                 }
             }
 

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -27,7 +27,6 @@ using Microsoft.Python.LanguageServer.Tests.FluentAssertions;
 using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute;
 using TestUtilities;
 
 namespace Microsoft.Python.LanguageServer.Tests {
@@ -55,7 +54,7 @@ class C:
 ";
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(8, 1));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(8, 1));
             comps.Should().HaveLabels("C", "x", "y", "while", "for");
         }
 
@@ -67,7 +66,7 @@ x.
 ";
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 3));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(3, 3));
             comps.Should().HaveLabels(@"isupper", @"capitalize", @"split");
         }
 
@@ -79,7 +78,7 @@ datetime.datetime.
 ";
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 19));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(3, 19));
             comps.Should().HaveLabels("now", @"tzinfo", @"ctime");
         }
 
@@ -94,10 +93,10 @@ ABCDE.me
 ";
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 4));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(5, 4));
             comps.Should().HaveLabels(@"ABCDE");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(6, 9));
+            comps = cs.GetCompletions(analysis, new SourceLocation(6, 9));
             comps.Should().HaveLabels("method1");
         }
 
@@ -112,7 +111,7 @@ class oar(list):
 ";
             var analysis = await GetAnalysisAsync(code, version);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 9));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 9));
 
             result.Should().HaveItem("append")
                 .Which.Should().HaveInsertText($"append(self, {parameterName}):{Environment.NewLine}    return super().append({parameterName})")
@@ -136,7 +135,7 @@ x.oar(100)
 
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(4, 8));
+            var result = cs.GetCompletions(analysis, new SourceLocation(4, 8));
             result.Should().HaveItem("a");
         }
 
@@ -153,7 +152,7 @@ x.oar(100)
 
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(4, 8));
+            var result = cs.GetCompletions(analysis, new SourceLocation(4, 8));
             result.Should().HaveItem("a");
         }
 
@@ -175,7 +174,7 @@ c.
 
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(11, 3));
+            var result = cs.GetCompletions(analysis, new SourceLocation(11, 3));
             result.Should().NotContainLabels("fob");
             result.Should().HaveLabels("oar");
         }
@@ -195,7 +194,7 @@ class B(A):
             var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(7, 10));
+            var result = cs.GetCompletions(analysis, new SourceLocation(7, 10));
             result.Should()
                 .HaveInsertTexts($"foo(self, a, b=None, *args, **kwargs):{Environment.NewLine}    return super({superArgs}).foo(a, b=b, *args, **kwargs)")
                 .And.NotContainInsertTexts($"foo(self, a, b = None, *args, **kwargs):{Environment.NewLine}    return super({superArgs}).foo(a, b = b, *args, **kwargs)");
@@ -209,24 +208,24 @@ class B(A):
 
             var analysis = await GetAnalysisAsync("raise ", version);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 7));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 7));
             result.Should().HaveInsertTexts("Exception", "ValueError").And.NotContainInsertTexts("def", "abs");
 
             if (is3X) {
                 analysis = await GetAnalysisAsync("raise Exception from ", PythonVersions.LatestAvailable3X);
                 cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-                result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 7));
+                result = cs.GetCompletions(analysis, new SourceLocation(1, 7));
                 result.Should().HaveInsertTexts("Exception", "ValueError").And.NotContainInsertTexts("def", "abs");
 
-                result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 17));
+                result = cs.GetCompletions(analysis, new SourceLocation(1, 17));
                 result.Should().HaveInsertTexts("from").And.NotContainInsertTexts("Exception", "def", "abs");
 
-                result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 22));
+                result = cs.GetCompletions(analysis, new SourceLocation(1, 22));
                 result.Should().HaveAnyCompletions();
 
                 analysis = await GetAnalysisAsync("raise Exception fr ", PythonVersions.LatestAvailable3X);
-                result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 19));
+                result = cs.GetCompletions(analysis, new SourceLocation(1, 19));
                 result.Should().HaveInsertTexts("from")
                     .And.NotContainInsertTexts("Exception", "def", "abs")
                     .And.Subject.ApplicableSpan.Should().Be(1, 17, 1, 19);
@@ -234,10 +233,10 @@ class B(A):
 
             analysis = await GetAnalysisAsync("raise Exception, x, y", version);
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 17));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 17));
             result.Should().HaveAnyCompletions();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 20));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 20));
             result.Should().HaveAnyCompletions();
         }
 
@@ -246,29 +245,29 @@ class B(A):
             var analysis = await GetAnalysisAsync("try:\n    pass\nexcept ");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 8));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 8));
             result.Should().HaveInsertTexts("Exception", "ValueError").And.NotContainInsertTexts("def", "abs");
 
             analysis = await GetAnalysisAsync("try:\n    pass\nexcept (");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 9));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 9));
             result.Should().HaveInsertTexts("Exception", "ValueError").And.NotContainInsertTexts("def", "abs");
 
             analysis = await GetAnalysisAsync("try:\n    pass\nexcept Exception  as ");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 8));
             result.Should().HaveInsertTexts("Exception", "ValueError").And.NotContainInsertTexts("def", "abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 18));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 18));
             result.Should().HaveInsertTexts("as").And.NotContainInsertTexts("def", "abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 22));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 22));
             result.Should().HaveNoCompletion();
 
             analysis = await GetAnalysisAsync("try:\n    pass\nexc");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 18));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 18));
             result.Should().HaveInsertTexts("except", "def", "abs");
 
             analysis = await GetAnalysisAsync("try:\n    pass\nexcept Exception a");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 19));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 19));
             result.Should().HaveInsertTexts("as")
                 .And.NotContainInsertTexts("Exception", "def", "abs")
                 .And.Subject.ApplicableSpan.Should().Be(3, 18, 3, 19);
@@ -287,25 +286,25 @@ x
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 3));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 3));
             result.Should().HaveLabels("real", @"imag").And.NotContainLabels("abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 4));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 4));
             result.Should().HaveLabels("real", @"imag").And.NotContainLabels("abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 5));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 5));
             result.Should().HaveLabels("real", @"imag").And.NotContainLabels("abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(4, 3));
+            result = cs.GetCompletions(analysis, new SourceLocation(4, 3));
             result.Should().HaveLabels("real", @"imag").And.NotContainLabels("abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 5));
+            result = cs.GetCompletions(analysis, new SourceLocation(5, 5));
             result.Should().HaveLabels("real", @"imag").And.NotContainLabels("abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(6, 4));
+            result = cs.GetCompletions(analysis, new SourceLocation(6, 4));
             result.Should().HaveLabels("real", @"imag").And.NotContainLabels("abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(7, 2));
+            result = cs.GetCompletions(analysis, new SourceLocation(7, 2));
             result.Should().HaveLabels("abs").And.NotContainLabels("real", @"imag");
         }
 
@@ -314,10 +313,10 @@ x
             var analysis = await GetAnalysisAsync("x = x\ny = ");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 4));
+            var result = cs.GetCompletions(analysis, new SourceLocation(2, 4));
             result.Should().HaveLabels("x", "abs");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 5));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 5));
             result.Should().HaveLabels("x", "abs");
         }
 
@@ -332,7 +331,7 @@ class Simple(unittest.TestCase):
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable2X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 38));
+            var result = cs.GetCompletions(analysis, new SourceLocation(5, 38));
             result.Should().HaveInsertTexts("exception");
         }
 
@@ -347,7 +346,7 @@ class Simple(unittest.TestCase):
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 38));
+            var result = cs.GetCompletions(analysis, new SourceLocation(5, 38));
             result.Should().HaveInsertTexts("exception");
         }
 
@@ -359,7 +358,7 @@ sys  .  version
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 7));
+            var result = cs.GetCompletions(analysis, new SourceLocation(2, 7));
             result.Should().HaveLabels("argv");
         }
 
@@ -368,7 +367,7 @@ sys  .  version
             var analysis = await GetAnalysisAsync("import sys\nsys.\n");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 5));
+            var result = cs.GetCompletions(analysis, new SourceLocation(2, 5));
             result.Completions?.Select(i => i.documentation.kind)
                 .Should().NotBeEmpty().And.BeSubsetOf(new[] { MarkupKind.PlainText, MarkupKind.Markdown });
         }
@@ -385,7 +384,7 @@ foo.
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(6, 5));
+            var result = cs.GetCompletions(analysis, new SourceLocation(6, 5));
             result.Should().HaveLabels("clear", "copy", "items", "keys", "update", "values");
         }
 
@@ -402,10 +401,10 @@ def func(a: List[str]):
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 7));
+            var result = cs.GetCompletions(analysis, new SourceLocation(5, 7));
             result.Should().HaveLabels("clear", "copy", "count", "index", "remove", "reverse");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(6, 10));
+            result = cs.GetCompletions(analysis, new SourceLocation(6, 10));
             result.Should().HaveLabels("capitalize");
         }
 
@@ -422,10 +421,10 @@ def func(a: Dict[int, str]):
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 7));
+            var result = cs.GetCompletions(analysis, new SourceLocation(5, 7));
             result.Should().HaveLabels("keys", "values");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(6, 10));
+            result = cs.GetCompletions(analysis, new SourceLocation(6, 10));
             result.Should().HaveLabels("capitalize");
         }
 
@@ -452,11 +451,11 @@ y = boxedstr.
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(14, 14));
+            var result = cs.GetCompletions(analysis, new SourceLocation(14, 14));
             result.Should().HaveItem("get").Which.Should().HaveDocumentation("Box.get() -> int");
             result.Should().NotContainLabels("bit_length");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(17, 14));
+            result = cs.GetCompletions(analysis, new SourceLocation(17, 14));
             result.Should().HaveItem("get").Which.Should().HaveDocumentation("Box.get() -> str");
             result.Should().NotContainLabels("capitalize");
         }
@@ -484,11 +483,11 @@ y = boxedstr.
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(14, 14));
+            var result = cs.GetCompletions(analysis, new SourceLocation(14, 14));
             result.Should().HaveLabels("append", "index");
             result.Should().NotContainLabels("bit_length");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(17, 14));
+            result = cs.GetCompletions(analysis, new SourceLocation(17, 14));
             result.Should().HaveLabels("append", "index");
             result.Should().NotContainLabels("capitalize");
         }
@@ -513,9 +512,9 @@ class C(object):
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var completionInD = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 5));
-            var completionInOar = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 9));
-            var completionForAbc = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 13));
+            var completionInD = cs.GetCompletions(analysis, new SourceLocation(3, 5));
+            var completionInOar = cs.GetCompletions(analysis, new SourceLocation(5, 9));
+            var completionForAbc = cs.GetCompletions(analysis, new SourceLocation(5, 13));
 
             completionInD.Should().HaveLabels("C", "D", "oar")
                 .And.NotContainLabels("a", "abc", "self", "x", "fob", "baz");
@@ -540,8 +539,8 @@ x.abc()
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
             var objectMemberNames = analysis.Document.Interpreter.GetBuiltinType(BuiltinTypeId.Object).GetMemberNames();
 
-            var completion = await cs.GetCompletionsAsync(analysis, new SourceLocation(7, 1));
-            var completionX = await cs.GetCompletionsAsync(analysis, new SourceLocation(7, 3));
+            var completion = cs.GetCompletions(analysis, new SourceLocation(7, 1));
+            var completionX = cs.GetCompletions(analysis, new SourceLocation(7, 3));
 
             completion.Should().HaveLabels("a", "x").And.NotContainLabels("abc", "self");
             completionX.Should().HaveLabels(objectMemberNames).And.HaveLabels("abc");
@@ -556,32 +555,32 @@ x.abc()
             var analysis = await GetAnalysisAsync("def f(a, b:int, c=2, d:float=None): pass", version);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 5));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 5));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 7));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 7));
             result.Should().HaveNoCompletion();
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 8));
             result.Should().HaveNoCompletion();
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 10));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 10));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 14));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 14));
             result.Should().HaveLabels("int");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 17));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 17));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 29));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 29));
             result.Should().HaveLabels("float");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 34));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 34));
             result.Should().HaveLabels("NotImplemented");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 35));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 35));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 36));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 36));
             result.Should().HaveLabels("any");
         }
 
@@ -590,22 +589,22 @@ x.abc()
             var analysis = await GetAnalysisAsync("@dec" + Environment.NewLine + "def  f(): pass", PythonVersions.LatestAvailable2X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 1));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 1));
             result.Should().HaveLabels("any");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 2));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 2));
             result.Should().HaveLabels("abs").And.NotContainLabels("def");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 1));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 1));
             result.Should().HaveLabels("def");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 2));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 2));
             result.Should().HaveLabels("def");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 5));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 5));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 6));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 6));
             result.Should().HaveNoCompletion();
         }
 
@@ -614,22 +613,22 @@ x.abc()
             var analysis = await GetAnalysisAsync("@dec" + Environment.NewLine + "async   def  f(): pass", PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 1));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 1));
             result.Should().HaveLabels("any");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 2));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 2));
             result.Should().HaveLabels("abs").And.NotContainLabels("def");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 1));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 1));
             result.Should().HaveLabels("def");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 12));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 12));
             result.Should().HaveLabels("def");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 13));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 13));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 14));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 14));
             result.Should().HaveNoCompletion();
         }
 
@@ -642,40 +641,40 @@ x.abc()
             var analysis = await GetAnalysisAsync("class C(object, parameter=MC): pass", version);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 8));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 8));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 9));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 9));
             if (is3x) {
                 result.Should().HaveLabels(@"metaclass=", "object");
             } else {
                 result.Should().HaveLabels("object").And.NotContainLabels(@"metaclass=");
             }
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 15));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 15));
             result.Should().HaveLabels("any");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 17));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 17));
             result.Should().HaveLabels("any");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 29));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 29));
             result.Should().HaveLabels("object");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 30));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 30));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 31));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 31));
             result.Should().HaveLabels("any");
 
             analysis = await GetAnalysisAsync("class D(o", version);
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 8));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 9));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 9));
             result.Should().HaveLabels("any");
 
             analysis = await GetAnalysisAsync(@"class E(metaclass=MC,o): pass", version);
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 22));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 22));
             result.Should().HaveLabels("object").And.NotContainLabels(@"metaclass=");
         }
 
@@ -684,37 +683,37 @@ x.abc()
             var analysis = await GetAnalysisAsync("with x as y, z as w: pass");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 6));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 6));
             result.Should().HaveAnyCompletions();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 8));
             result.Should().HaveInsertTexts("as").And.NotContainInsertTexts("abs", "dir");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 11));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 11));
             result.Should().HaveNoCompletion();
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 14));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 14));
             result.Should().HaveAnyCompletions();
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 17));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 17));
             result.Should().HaveInsertTexts("as").And.NotContainInsertTexts("abs", "dir");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 21));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 21));
             result.Should().HaveAnyCompletions();
 
 
             analysis = await GetAnalysisAsync("with ");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 6));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 6));
             result.Should().HaveAnyCompletions();
 
             analysis = await GetAnalysisAsync("with x ");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 6));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 6));
             result.Should().HaveAnyCompletions();
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 8));
             result.Should().HaveInsertTexts("as").And.NotContainInsertTexts("abs", "dir");
 
             analysis = await GetAnalysisAsync("with x as ");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 6));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 6));
             result.Should().HaveAnyCompletions();
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 8));
             result.Should().HaveInsertTexts("as").And.NotContainInsertTexts("abs", "dir");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 11));
+            result = cs.GetCompletions(analysis, new SourceLocation(1, 11));
             result.Should().HaveNoCompletion();
         }
 
@@ -728,50 +727,50 @@ from unittest.case import TestCase as TC, TestCase
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 7));
+            var result = cs.GetCompletions(analysis, new SourceLocation(2, 7));
             result.Should().HaveLabels("from", "import", "abs", "dir").And.NotContainLabels("abc");
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 8));
             result.Should().HaveLabels("abc", @"unittest").And.NotContainLabels("abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 17));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 17));
             result.Should().HaveLabels("case").And.NotContainLabels("abc", @"unittest", "abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 23));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 23));
             result.Should().HaveLabels("as").And.NotContainLabels("abc", @"unittest", "abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 25));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 25));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 28));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 28));
             result.Should().HaveLabels("abc", @"unittest").And.NotContainLabels("abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 5));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 5));
             result.Should().HaveLabels("from", "import", "abs", "dir").And.NotContainLabels("abc");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 6));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 6));
             result.Should().HaveLabels("abc", @"unittest").And.NotContainLabels("abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 15));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 15));
             result.Should().HaveLabels("case").And.NotContainLabels("abc", @"unittest", "abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 20));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 20));
             result.Should().HaveLabels("import").And.NotContainLabels("abc", @"unittest", "abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 22));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 22));
             result.Should().HaveLabels("import")
                 .And.NotContainLabels("abc", @"unittest", "abs", "dir")
                 .And.Subject.ApplicableSpan.Should().Be(3, 20, 3, 26);
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 27));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 27));
             result.Should().HaveLabels("TestCase").And.NotContainLabels("abs", "dir", "case");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 36));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 36));
             result.Should().HaveLabels("as").And.NotContainLabels("abc", @"unittest", "abs", "dir");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 39));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 39));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 44));
+            result = cs.GetCompletions(analysis, new SourceLocation(3, 44));
             result.Should().HaveLabels("TestCase").And.NotContainLabels("abs", "dir", "case");
 
             code = @"
@@ -780,7 +779,7 @@ pass
 ";
             analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 22));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 22));
             result.Should().HaveLabels("import")
                 .And.NotContainLabels("abc", @"unittest", "abs", "dir")
                 .And.Subject.ApplicableSpan.Should().Be(2, 20, 2, 23);
@@ -789,7 +788,7 @@ pass
 import unittest.case a
 pass";
             analysis = await GetAnalysisAsync(code);
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 23));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 23));
             result.Should().HaveLabels("as")
                 .And.NotContainLabels("abc", @"unittest", "abs", "dir")
                 .And.Subject.ApplicableSpan.Should().Be(2, 22, 2, 23);
@@ -798,7 +797,7 @@ pass";
 from unittest.case import TestCase a
 pass";
             analysis = await GetAnalysisAsync(code);
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 37));
+            result = cs.GetCompletions(analysis, new SourceLocation(2, 37));
             result.Should().HaveLabels("as")
                 .And.NotContainLabels("abc", @"unittest", "abs", "dir")
                 .And.Subject.ApplicableSpan.Should().Be(2, 36, 2, 37);
@@ -814,13 +813,13 @@ pass";
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 9));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 9));
             result.Should().HaveNoCompletion();
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(4, 8));
+            result = cs.GetCompletions(analysis, new SourceLocation(4, 8));
             result.Should().HaveInsertTexts("def").And.NotContainInsertTexts("__init__");
 
-            result = await cs.GetCompletionsAsync(analysis, new SourceLocation(4, 9));
+            result = cs.GetCompletions(analysis, new SourceLocation(4, 9));
             result.Should().HaveLabels("__init__").And.NotContainLabels("def");
         }
 
@@ -829,7 +828,7 @@ pass";
 
             var analysis = await GetAnalysisAsync("\"str.\"");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 6));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 6));
             result.Should().HaveNoCompletion();
         }
 
@@ -838,7 +837,7 @@ pass";
 
             var analysis = await GetAnalysisAsync("x = 1 #str. more text");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 12));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 12));
             result.Should().HaveNoCompletion();
         }
 
@@ -853,7 +852,7 @@ os.
             var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 4));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 4));
             result.Should().HaveLabels("path", @"devnull", "SEEK_SET", @"curdir");
         }
 
@@ -868,7 +867,7 @@ os.path.
             var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 9));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 9));
             result.Should().HaveLabels("split", @"getsize", @"islink", @"abspath");
         }
 
@@ -883,7 +882,7 @@ E
             var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 2));
+            var result = cs.GetCompletions(analysis, new SourceLocation(3, 2));
             result.Should().HaveLabels("EX");
 
             var doc = is3x ? "exists(path: str) -> bool*" : "exists(path: unicode) -> bool*";
@@ -896,7 +895,7 @@ E
             var analysis = await GetAnalysisAsync(code);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var result = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 10));
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 10));
             result.Completions.Count(c => c.label.EqualsOrdinal(@"sys")).Should().Be(1);
             result.Completions.Count(c => c.label.EqualsOrdinal(@"sysconfig")).Should().Be(1);
         }

--- a/src/LanguageServer/Test/GoToDefinitionTests.cs
+++ b/src/LanguageServer/Test/GoToDefinitionTests.cs
@@ -17,9 +17,9 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Sources;
+using Microsoft.Python.LanguageServer.Tests.FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
-using Microsoft.Python.LanguageServer.Tests.FluentAssertions;
 
 namespace Microsoft.Python.LanguageServer.Tests {
     [TestClass]
@@ -59,31 +59,31 @@ c.method(1, 2)
             var analysis = await GetAnalysisAsync(code);
             var ds = new DefinitionSource();
 
-            var reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(4, 5));
+            var reference = ds.FindDefinition(analysis, new SourceLocation(4, 5));
             reference.range.Should().Be(1, 7, 1, 9);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(9, 9));
+            reference = ds.FindDefinition(analysis, new SourceLocation(9, 9));
             reference.range.Should().Be(7, 15, 7, 19);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(9, 14));
+            reference = ds.FindDefinition(analysis, new SourceLocation(9, 14));
             reference.range.Should().Be(6, 4, 6, 5);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(13, 5));
+            reference = ds.FindDefinition(analysis, new SourceLocation(13, 5));
             reference.range.Should().Be(11, 9, 11, 10);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(14, 9));
+            reference = ds.FindDefinition(analysis, new SourceLocation(14, 9));
             reference.range.Should().Be(11, 9, 11, 10);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(17, 5));
+            reference = ds.FindDefinition(analysis, new SourceLocation(17, 5));
             reference.range.Should().Be(11, 0, 14, 12);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(18, 1));
+            reference = ds.FindDefinition(analysis, new SourceLocation(18, 1));
             reference.range.Should().Be(17, 0, 17, 1); // TODO: store all locations
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(19, 5));
+            reference = ds.FindDefinition(analysis, new SourceLocation(19, 5));
             reference.range.Should().Be(5, 0, 9, 18);
 
-            reference = await ds.FindDefinitionAsync(analysis, new SourceLocation(20, 5));
+            reference = ds.FindDefinition(analysis, new SourceLocation(20, 5));
             reference.range.Should().Be(7, 4, 9, 18);
         }
     }

--- a/src/LanguageServer/Test/HoverTests.cs
+++ b/src/LanguageServer/Test/HoverTests.cs
@@ -56,28 +56,28 @@ string = str
             var analysis = await GetAnalysisAsync(code);
             var hs = new HoverSource(new PlainTextDocumentationSource());
 
-            var hover = await hs.GetHoverAsync(analysis, new SourceLocation(2, 2));
+            var hover = hs.GetHover(analysis, new SourceLocation(2, 2));
             hover.contents.value.Should().Be("x: str");
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(2, 7));
+            hover = hs.GetHover(analysis, new SourceLocation(2, 7));
             hover.Should().BeNull();
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(4, 7));
+            hover = hs.GetHover(analysis, new SourceLocation(4, 7));
             hover.contents.value.Should().Be("class C\n\nClass C is awesome");
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(6, 9));
+            hover = hs.GetHover(analysis, new SourceLocation(6, 9));
             hover.contents.value.Should().Be("C.method(a: int, b) -> float\n\nReturns a float!!!");
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(6, 22));
+            hover = hs.GetHover(analysis, new SourceLocation(6, 22));
             hover.contents.value.Should().Be("a: int");
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(10, 7));
+            hover = hs.GetHover(analysis, new SourceLocation(10, 7));
             hover.contents.value.Should().Be("func(a, b)\n\nDoes nothing useful");
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(14, 2));
+            hover = hs.GetHover(analysis, new SourceLocation(14, 2));
             hover.contents.value.Should().Be("y: int");
 
-            hover = await hs.GetHoverAsync(analysis, new SourceLocation(15, 2));
+            hover = hs.GetHover(analysis, new SourceLocation(15, 2));
             hover.contents.value.Should().StartWith("class str\n\nstr(object='') -> str");
         }
 
@@ -207,7 +207,7 @@ import os.path as PATH
         }
 
         private static async Task AssertHover(HoverSource hs, IDocumentAnalysis analysis, SourceLocation position, string hoverText, SourceSpan? span = null) {
-            var hover = await hs.GetHoverAsync(analysis, position);
+            var hover = hs.GetHover(analysis, position);
 
             if (hoverText.EndsWith("*")) {
                 // Check prefix first, but then show usual message for mismatched value

--- a/src/LanguageServer/Test/ImportsTests.cs
+++ b/src/LanguageServer/Test/ImportsTests.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Analysis;
@@ -70,7 +69,7 @@ projectA.";
             var analysis = await doc.GetAnalysisAsync(0);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(7, 10));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(7, 10));
             comps.Should().HaveLabels("foo");
         }
 
@@ -98,7 +97,7 @@ VALUE = 42";
             var analysis = await doc1.GetAnalysisAsync(0);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 5));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(2, 5));
             comps.Should().HaveLabels("VALUE");
         }
 
@@ -121,7 +120,7 @@ VALUE = 42");
             var analysis = await doc.GetAnalysisAsync(0);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 5));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(2, 5));
             comps.Should().HaveLabels("VALUE");
         }
 
@@ -150,7 +149,7 @@ module2.";
 
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 21));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(1, 21));
             comps.Should().HaveLabels("module1", "module2");
 
             doc.Update(new[] {
@@ -163,10 +162,10 @@ module2.";
             await doc.GetAstAsync();
             analysis = await doc.GetAnalysisAsync(0);
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 9));
+            comps = cs.GetCompletions(analysis, new SourceLocation(2, 9));
             comps.Should().HaveLabels("X").And.NotContainLabels("Y");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 9));
+            comps = cs.GetCompletions(analysis, new SourceLocation(3, 9));
             comps.Should().HaveLabels("Y").And.NotContainLabels("X");
         }
 
@@ -206,16 +205,16 @@ mod2.B.";
             var analysis = await doc.GetAnalysisAsync(0);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 6));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(2, 6));
             comps.Should().HaveLabels("A").And.NotContainLabels("B");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(3, 6));
+            comps = cs.GetCompletions(analysis, new SourceLocation(3, 6));
             comps.Should().HaveLabels("B").And.NotContainLabels("A");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(4, 8));
+            comps = cs.GetCompletions(analysis, new SourceLocation(4, 8));
             comps.Should().HaveLabels("method1");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 8));
+            comps = cs.GetCompletions(analysis, new SourceLocation(5, 8));
             comps.Should().HaveLabels("method2");
         }
 
@@ -245,16 +244,16 @@ package.sub_package.module2.";
             var analysis = await doc.GetAnalysisAsync(0);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(5, 9));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(5, 9));
             comps.Should().OnlyHaveLabels("sub_package");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(6, 21));
+            comps = cs.GetCompletions(analysis, new SourceLocation(6, 21));
             comps.Should().OnlyHaveLabels("module1", "module2");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(7, 29));
+            comps = cs.GetCompletions(analysis, new SourceLocation(7, 29));
             comps.Should().HaveLabels("X").And.NotContainLabels("Y");
 
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(8, 29));
+            comps = cs.GetCompletions(analysis, new SourceLocation(8, 29));
             comps.Should().HaveLabels("Y").And.NotContainLabels("X");
         }
 
@@ -262,7 +261,7 @@ package.sub_package.module2.";
         public async Task TypingModule() {
             var analysis = await GetAnalysisAsync(@"from typing import ");
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(1, 20));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(1, 20));
             comps.Should().HaveLabels("TypeVar", "List", "Dict", "Union");
         }
 
@@ -288,7 +287,7 @@ package.sub_package.module2.";
             var analysis = await doc.GetAnalysisAsync(0);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 13));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(2, 13));
             comps.Should().OnlyHaveLabels("module");
 
             doc.Update(new[] {
@@ -299,7 +298,7 @@ package.sub_package.module2.";
             });
 
             analysis = await doc.GetAnalysisAsync(0);
-            comps = await cs.GetCompletionsAsync(analysis, new SourceLocation(2, 21));
+            comps = cs.GetCompletions(analysis, new SourceLocation(2, 21));
             comps.Should().HaveLabels("X");
         }
     }

--- a/src/LanguageServer/Test/SignatureTests.cs
+++ b/src/LanguageServer/Test/SignatureTests.cs
@@ -46,7 +46,7 @@ C().method()
             var analysis = await GetAnalysisAsync(code);
             var src = new SignatureSource(new PlainTextDocumentationSource());
 
-            var sig = await src.GetSignatureAsync(analysis, new SourceLocation(6, 12));
+            var sig = src.GetSignature(analysis, new SourceLocation(6, 12));
             sig.activeSignature.Should().Be(0);
             sig.activeParameter.Should().Be(0);
             sig.signatures.Length.Should().Be(1);
@@ -73,12 +73,12 @@ y = boxedstr.get()
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var src = new SignatureSource(new PlainTextDocumentationSource());
 
-            var sig = await src.GetSignatureAsync(analysis, new SourceLocation(11, 18));
+            var sig = src.GetSignature(analysis, new SourceLocation(11, 18));
             sig.signatures.Should().NotBeNull();
             sig.signatures.Length.Should().Be(1);
             sig.signatures[0].label.Should().Be("get() -> int");
 
-            sig = await src.GetSignatureAsync(analysis, new SourceLocation(14, 18));
+            sig = src.GetSignature(analysis, new SourceLocation(14, 18));
             sig.signatures.Should().NotBeNull();
             sig.signatures.Length.Should().Be(1);
             sig.signatures[0].label.Should().Be("get() -> str");


### PR DESCRIPTION
Fixes #358 

Fix itself is basically 2 liner - declare inner function as variable after processing. However, async processing made results somewhat unstable, depending on order of processing. Since analysis runs as a task anyway and importing is no longer async, I removed async methods.