### PR TITLE
Fix goto definition in stubbed modules

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -78,8 +78,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             scope = scopes.FirstOrDefault(s => s.Variables.Contains(name));
             var value = scope?.Variables[name].Value;
             if (value == null) {
-                if (Module != Interpreter.ModuleResolution.BuiltinsModule && options.HasFlag(LookupOptions.Builtins)) {
-                    value = Interpreter.ModuleResolution.BuiltinsModule.GetMember(name);
+                var builtins = Interpreter.ModuleResolution.BuiltinsModule;
+                value = Interpreter.ModuleResolution.BuiltinsModule.GetMember(name);
+                if (Module != builtins && options.HasFlag(LookupOptions.Builtins)) {
+                    value = builtins.GetMember(name);
+                    scope = builtins.GlobalScope;
                 }
             }
 
@@ -100,7 +103,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 // Try generics
                 var target = GetValueFromExpression(indexExpr.Target);
                 var result = GetValueFromGeneric(target, indexExpr);
-                if(result != null) {
+                if (result != null) {
                     return result.GetPythonType();
                 }
             }

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
                         // Get documentation from the current type, if any, since stubs
                         // typically do not contain documentation while scraped code does.
-                        member?.GetPythonType()?.TransferDocumentation(stubMember.GetPythonType());
+                        member?.GetPythonType()?.TransferDocumentationAndLocation(stubMember.GetPythonType());
                         cls.AddMember(name, stubMember, overwrite: true);
                     }
                 } else {
@@ -116,7 +116,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     // Modules members that are modules should remain as they are, i.e. os.path
                     // should remain library with its own stub attached.
                     if (!stubType.IsUnknown() && !(stubType is IPythonModule)) {
-                        sourceType.TransferDocumentation(stubType);
+                        sourceType.TransferDocumentationAndLocation(stubType);
                         // TODO: choose best type between the scrape and the stub. Stub probably should always win.
                         var source = Eval.CurrentScope.Variables[v.Name]?.Source ?? VariableSource.Declaration;
                         Eval.DeclareVariable(v.Name, v.Value, source, LocationInfo.Empty, overwrite: true);

--- a/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
@@ -21,19 +21,22 @@ namespace Microsoft.Python.Analysis {
         public static bool IsUnknown(this IPythonType value) =>
             value == null || (value.TypeId == BuiltinTypeId.Unknown && value.MemberType == PythonMemberType.Unknown && value.Name.Equals("Unknown"));
 
-        public static bool IsGenericParameter(this IPythonType value) 
+        public static bool IsGenericParameter(this IPythonType value)
             => value is IGenericTypeParameter;
 
         public static bool IsGeneric(this IPythonType value)
             => value is IGenericTypeParameter || value is IGenericType || (value is IPythonClassType c && c.IsGeneric());
 
-        public static void TransferDocumentation(this IPythonType src, IPythonType dst) {
+        public static void TransferDocumentationAndLocation(this IPythonType src, IPythonType dst) {
             if (src != null && dst is PythonType pt) {
                 pt.TrySetTypeId(dst.TypeId);
                 var documentation = src.Documentation;
                 if (string.IsNullOrEmpty(pt.Documentation) && !string.IsNullOrEmpty(documentation)) {
-                    pt.SetDocumentationProvider(_ => documentation);
+                    if (!string.IsNullOrEmpty(documentation)) {
+                        pt.SetDocumentationProvider(_ => documentation);
+                    }
                 }
+                //d.SetLocation(s.Location);
             }
         }
     }

--- a/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
@@ -31,12 +31,14 @@ namespace Microsoft.Python.Analysis {
             if (src != null && dst is PythonType pt) {
                 pt.TrySetTypeId(dst.TypeId);
                 var documentation = src.Documentation;
-                if (string.IsNullOrEmpty(pt.Documentation) && !string.IsNullOrEmpty(documentation)) {
+                if (!string.IsNullOrEmpty(documentation)) {
                     if (!string.IsNullOrEmpty(documentation)) {
-                        pt.SetDocumentationProvider(_ => documentation);
+                        pt.SetDocumentation(documentation);
                     }
                 }
-                //d.SetLocation(s.Location);
+                if (src is ILocatedMember lm) {
+                    pt.SetLocation(lm.Location);
+                }
             }
         }
     }

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -103,6 +103,9 @@ namespace Microsoft.Python.Analysis.Modules {
             Uri = uri;
             FilePath = creationOptions.FilePath ?? uri?.LocalPath;
             Stub = creationOptions.Stub;
+            if (Stub is PythonModule stub && ModuleType != ModuleType.Stub) {
+                stub.PrimaryModule = this;
+            }
 
             if (ModuleType == ModuleType.Specialized || ModuleType == ModuleType.Unresolved) {
                 ContentState = State.Analyzed;
@@ -198,6 +201,13 @@ namespace Microsoft.Python.Analysis.Modules {
             await GetAstAsync(cancellationToken);
             await Services.GetService<IPythonAnalyzer>().GetAnalysisAsync(this, -1, cancellationToken);
         }
+
+        /// <summary>
+        /// If module is a stub points to the primary module.
+        /// Typically used in code navigation scenarios when user
+        /// wants to see library code and not a stub.
+        /// </summary>
+        public IPythonModule PrimaryModule { get; internal set; }
 
         protected virtual string LoadContent() {
             if (ContentState < State.Loading) {

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassMember.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassMember.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Python.Analysis.Types {
     /// <summary>
     /// Represents member of a class.
     /// </summary>
-    public interface IPythonClassMember : IPythonType {
+    public interface IPythonClassMember : IPythonType, ILocatedMember {
         IPythonType DeclaringType { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Python.Analysis.Types {
     /// <summary>
     /// Represents Python class type definition.
     /// </summary>
-    public interface IPythonClassType : IPythonType {
+    public interface IPythonClassType : IPythonType, ILocatedMember {
         /// <summary>
         /// Class definition node in the AST.
         /// </summary>

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonModule.cs
@@ -55,5 +55,12 @@ namespace Microsoft.Python.Analysis.Types {
         /// analysis until later time, when module members are actually needed.
         /// </summary>
         Task LoadAndAnalyzeAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// If module is a stub points to the primary module.
+        /// Typically used in code navigation scenarios when user
+        /// wants to see library code and not a stub.
+        /// </summary>
+        IPythonModule PrimaryModule { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Python.Analysis.Types {
         #region IPythonFunction
         public FunctionDefinition FunctionDefinition { get; }
         public IPythonType DeclaringType { get; }
-        public override string Documentation => _doc ?? _overloads.FirstOrDefault()?.Documentation;
+        public override string Documentation => _doc ?? base.Documentation ?? _overloads.FirstOrDefault()?.Documentation;
         public virtual bool IsClassMethod { get; private set; }
         public virtual bool IsStatic { get; private set; }
         public override bool IsAbstract => _isAbstract;

--- a/src/LanguageServer/Impl/Sources/DefinitionSource.cs
+++ b/src/LanguageServer/Impl/Sources/DefinitionSource.cs
@@ -14,7 +14,6 @@
 // permissions and limitations under the License.
 
 using Microsoft.Python.Analysis;
-using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Analyzer.Expressions;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Modules;
@@ -46,7 +45,9 @@ namespace Microsoft.Python.LanguageServer.Sources {
                     !(statement is ImportStatement) && !(statement is FromImportStatement)) {
                     var m = eval.LookupNameInScopes(nex.Name, out var scope);
                     if (m != null && scope.Variables[nex.Name] is IVariable v) {
-                        return new Reference { range = v.Location.Span, uri = v.Location.DocumentUri };
+                        if (CanNavigateToModule(v.Value.GetPythonType()?.DeclaringModule, analysis)) {
+                            return new Reference { range = v.Location.Span, uri = v.Location.DocumentUri };
+                        }
                     }
                 }
 
@@ -84,29 +85,27 @@ namespace Microsoft.Python.LanguageServer.Sources {
                     module = ft.DeclaringModule;
                     location = ft.Location;
                     break;
-                case IPythonInstance instance when instance.Type is IPythonFunctionType ft: {
-                        node = ft.FunctionDefinition;
-                        module = ft.DeclaringModule;
-                        break;
-                    }
-                case IPythonInstance _ when expr is NameExpression nex: {
-                        var member = eval.LookupNameInScopes(nex.Name, out var scope);
-                        if (member != null && scope != null) {
-                            var v = scope.Variables[nex.Name];
-                            if (v != null) {
-                                return new Reference { range = v.Location.Span, uri = v.Location.DocumentUri };
-                            }
+                case IPythonInstance instance when instance.Type is IPythonFunctionType ft:
+                    node = ft.FunctionDefinition;
+                    module = ft.DeclaringModule;
+                    break;
+                case IPythonInstance _ when expr is NameExpression nex:
+                    var m1 = eval.LookupNameInScopes(nex.Name, out var scope);
+                    if (m1 != null && scope != null) {
+                        var v = scope.Variables[nex.Name];
+                        if (v != null) {
+                            return new Reference { range = v.Location.Span, uri = v.Location.DocumentUri };
                         }
-                        break;
                     }
+                    break;
                 case IPythonInstance _ when expr is MemberExpression mex: {
                         var target = eval.GetValueFromExpression(mex.Target);
                         var type = target?.GetPythonType();
-                        var member = type?.GetMember(mex.Name);
-                        if (member is IPythonInstance v) {
+                        var m2 = type?.GetMember(mex.Name);
+                        if (m2 is IPythonInstance v) {
                             return new Reference { range = v.Location.Span, uri = v.Location.DocumentUri };
                         }
-                        return FromMember(member, null, statement, analysis);
+                        return FromMember(m2, null, statement, analysis);
                     }
             }
 
@@ -131,6 +130,9 @@ namespace Microsoft.Python.LanguageServer.Sources {
         }
 
         private static bool CanNavigateToModule(IPythonModule m, IDocumentAnalysis analysis) {
+            if (m == null) {
+                return false;
+            }
             var canNavigate = m.ModuleType == ModuleType.User || m.ModuleType == ModuleType.Package || m.ModuleType == ModuleType.Library;
 #if DEBUG
             // Allow navigation anywhere in debug.

--- a/src/LanguageServer/Test/GoToDefinitionTests.cs
+++ b/src/LanguageServer/Test/GoToDefinitionTests.cs
@@ -142,7 +142,7 @@ class A(object):
             var ds = new DefinitionSource();
 
             var reference = ds.FindDefinition(analysis, new SourceLocation(2, 12));
-            reference.uri.AbsolutePath.Should().Contain("python.pyi");
+            reference.Should().BeNull();
         }
     }
 }

--- a/src/LanguageServer/Test/GoToDefinitionTests.cs
+++ b/src/LanguageServer/Test/GoToDefinitionTests.cs
@@ -18,6 +18,7 @@ using FluentAssertions;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Sources;
 using Microsoft.Python.LanguageServer.Tests.FluentAssertions;
+using Microsoft.Python.Parsing.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 
@@ -81,10 +82,67 @@ c.method(1, 2)
             reference.range.Should().Be(17, 0, 17, 1); // TODO: store all locations
 
             reference = ds.FindDefinition(analysis, new SourceLocation(19, 5));
-            reference.range.Should().Be(5, 0, 9, 18);
+            reference.range.Should().Be(5, 6, 9, 18);
 
             reference = ds.FindDefinition(analysis, new SourceLocation(20, 5));
             reference.range.Should().Be(7, 4, 9, 18);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task GotoModuleSource() {
+            const string code = @"
+import sys
+import logging
+
+logging.info('')
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var ds = new DefinitionSource();
+
+            var reference = ds.FindDefinition(analysis, new SourceLocation(2, 9));
+            reference.Should().BeNull();
+
+            reference = ds.FindDefinition(analysis, new SourceLocation(5, 3));
+            reference.range.Should().Be(2, 7, 2, 14);
+
+            reference = ds.FindDefinition(analysis, new SourceLocation(3, 10));
+            reference.range.Should().Be(0, 0, 0, 0);
+            reference.uri.AbsolutePath.Should().Contain("logging");
+            reference.uri.AbsolutePath.Should().NotContain("pyi");
+
+            reference = ds.FindDefinition(analysis, new SourceLocation(5, 11));
+            reference.uri.AbsolutePath.Should().Contain("logging");
+            reference.uri.AbsolutePath.Should().NotContain("pyi");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task GotoModuleSourceImportAs() {
+            const string code = @"
+import logging as log
+log
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var ds = new DefinitionSource();
+
+            var reference = ds.FindDefinition(analysis, new SourceLocation(3, 2));
+            reference.range.Should().Be(1, 18, 1, 21);
+
+            reference = ds.FindDefinition(analysis, new SourceLocation(2, 20));
+            reference.uri.AbsolutePath.Should().Contain("logging");
+            reference.uri.AbsolutePath.Should().NotContain("pyi");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task GotoBuiltinObject() {
+            const string code = @"
+class A(object):
+    pass
+";
+            var analysis = await GetAnalysisAsync(code);
+            var ds = new DefinitionSource();
+
+            var reference = ds.FindDefinition(analysis, new SourceLocation(2, 12));
+            reference.uri.AbsolutePath.Should().Contain("python.pyi");
         }
     }
 }


### PR DESCRIPTION
Fixes #618

* If goto def happens in import statement, open module source
* Resolve location to original module if it is a stub
* Transfer location for stubbed types so we can navigate to them in the real module
* Fix incorrect fetching of docs in function when override did not take doc from the base