### PR TITLE
Fix EndIndex in parser

### DIFF
--- a/src/Analysis/Engine/Impl/Parsing/Parser.cs
+++ b/src/Analysis/Engine/Impl/Parsing/Parser.cs
@@ -2340,7 +2340,7 @@ namespace Microsoft.PythonTools.Parsing {
                 AddSecondPreceedingWhiteSpace(ret, isAsync ? withWhiteSpace : null);
                 AddListWhiteSpace(ret, itemWhiteSpace.ToArray());
             }
-            ret.SetLoc(start, GetEndForStatement());
+            ret.SetLoc(start, body.EndIndex);
             ret.SetKeywordEndIndex(keywordEnd);
             return ret;
         }
@@ -2526,7 +2526,7 @@ namespace Microsoft.PythonTools.Parsing {
             var header = GetEnd();
             Statement suite = ParseSuite();
             IfStatementTest ret = new IfStatementTest(expr, suite);
-            ret.SetLoc(start, GetEndForStatement());
+            ret.SetLoc(start, suite.EndIndex);
             ret.HeaderIndex = header;
             return ret;
         }
@@ -2556,12 +2556,14 @@ namespace Microsoft.PythonTools.Parsing {
             Statement finallySuite = null;
             Statement elseSuite = null;
             TryStatement ret;
+            int end = body.EndIndex;
 
             string finallyWhiteSpace = null, elseWhiteSpace = null;
             if (MaybeEat(TokenKind.KeywordFinally)) {
                 finallyWhiteSpace = _tokenWhiteSpace;
                 finallyIndex = _lookahead.Span.End;
                 finallySuite = ParseFinallySuite(finallySuite);
+                end = finallySuite.EndIndex;
                 ret = new TryStatement(body, null, elseSuite, finallySuite);
                 ret.HeaderIndex = mid;
             } else {
@@ -2572,6 +2574,7 @@ namespace Microsoft.PythonTools.Parsing {
                         break;
                     }
                     TryStatementHandler handler = ParseTryStmtHandler();
+                    end = handler.EndIndex;
 
                     handlers.Add(handler);
 
@@ -2587,6 +2590,7 @@ namespace Microsoft.PythonTools.Parsing {
                     elseWhiteSpace = _tokenWhiteSpace;
                     elseIndex = _lookahead.Span.End;
                     elseSuite = ParseSuite();
+                    end = elseSuite.EndIndex;
                 }
 
                 if (MaybeEat(TokenKind.KeywordFinally)) {
@@ -2594,6 +2598,7 @@ namespace Microsoft.PythonTools.Parsing {
                     finallyWhiteSpace = _tokenWhiteSpace;
                     finallyIndex = _lookahead.Span.End;
                     finallySuite = ParseFinallySuite(finallySuite);
+                    end = finallySuite.EndIndex;
                 }
 
                 ret = new TryStatement(body, handlers.ToArray(), elseSuite, finallySuite);
@@ -2610,7 +2615,7 @@ namespace Microsoft.PythonTools.Parsing {
                     AddThirdPreceedingWhiteSpace(ret, finallyWhiteSpace);
                 }
             }
-            ret.SetLoc(start, GetEndForStatement());
+            ret.SetLoc(start, end);
 
             return ret;
         }

--- a/src/Analysis/Engine/Test/ParserTests.cs
+++ b/src/Analysis/Engine/Test/ParserTests.cs
@@ -3025,6 +3025,34 @@ pass
             );
         }
 
+        [TestMethod, Priority(0)]
+        public void FunctionLocations() {
+            var ast = ParseFileNoErrors("FunctionLocations.py", PythonLanguageVersion.V36);
+
+            Action<Statement, string, int, int> checkFunctionLocation = (Statement stmt, string name, int startIndex, int endIndex) => {
+                Assert.AreEqual(typeof(FunctionDefinition), stmt.GetType());
+                var funcDef = (FunctionDefinition)stmt;
+                Assert.AreEqual(name, funcDef.Name);
+                Assert.AreEqual(startIndex, funcDef.StartIndex);
+                Assert.AreEqual(endIndex, funcDef.EndIndex);
+            };
+
+            CheckAst(
+                ast,
+                CheckSuite(
+                    (stmt) => checkFunctionLocation(stmt, "if_statement", 0, 48),
+                    (stmt) => checkFunctionLocation(stmt, "if_else_statement", 50, 129),
+                    (stmt) => checkFunctionLocation(stmt, "with_statement", 131, 183),
+                    (stmt) => checkFunctionLocation(stmt, "try_statement", 185, 230),
+                    (stmt) => checkFunctionLocation(stmt, "try_except_statement", 232, 312),
+                    (stmt) => checkFunctionLocation(stmt, "try_else_statement", 314, 418),
+                    (stmt) => checkFunctionLocation(stmt, "for_statement", 420, 483),
+                    (stmt) => checkFunctionLocation(stmt, "assign_statements", 485, 542),
+                    (stmt) => checkFunctionLocation(stmt, "assign_statement", 544, 578)
+                )
+            );
+        }
+
         #endregion
 
         #region Checker Factories / Helpers

--- a/src/Analysis/Engine/Test/ParserTests.cs
+++ b/src/Analysis/Engine/Test/ParserTests.cs
@@ -3027,30 +3027,32 @@ pass
 
         [TestMethod, Priority(0)]
         public void FunctionLocations() {
-            var ast = ParseFileNoErrors("FunctionLocations.py", PythonLanguageVersion.V36);
+            foreach (var version in V3Versions) {
+                var ast = ParseFileNoErrors("FunctionLocations.py", version);
 
-            Action<Statement, string, int, int> checkFunctionLocation = (Statement stmt, string name, int startIndex, int endIndex) => {
-                Assert.AreEqual(typeof(FunctionDefinition), stmt.GetType());
-                var funcDef = (FunctionDefinition)stmt;
-                Assert.AreEqual(name, funcDef.Name);
-                Assert.AreEqual(startIndex, funcDef.StartIndex);
-                Assert.AreEqual(endIndex, funcDef.EndIndex);
-            };
+                Action<Statement, string, int, int> checkFunctionLocation = (Statement stmt, string name, int startIndex, int endIndex) => {
+                    Assert.AreEqual(typeof(FunctionDefinition), stmt.GetType());
+                    var funcDef = (FunctionDefinition)stmt;
+                    Assert.AreEqual(name, funcDef.Name);
+                    Assert.AreEqual(startIndex, funcDef.StartIndex);
+                    Assert.AreEqual(endIndex, funcDef.EndIndex);
+                };
 
-            CheckAst(
-                ast,
-                CheckSuite(
-                    (stmt) => checkFunctionLocation(stmt, "if_statement", 0, 48),
-                    (stmt) => checkFunctionLocation(stmt, "if_else_statement", 50, 129),
-                    (stmt) => checkFunctionLocation(stmt, "with_statement", 131, 183),
-                    (stmt) => checkFunctionLocation(stmt, "try_statement", 185, 230),
-                    (stmt) => checkFunctionLocation(stmt, "try_except_statement", 232, 312),
-                    (stmt) => checkFunctionLocation(stmt, "try_else_statement", 314, 418),
-                    (stmt) => checkFunctionLocation(stmt, "for_statement", 420, 483),
-                    (stmt) => checkFunctionLocation(stmt, "assign_statements", 485, 542),
-                    (stmt) => checkFunctionLocation(stmt, "assign_statement", 544, 578)
-                )
-            );
+                CheckAst(
+                    ast,
+                    CheckSuite(
+                        (stmt) => checkFunctionLocation(stmt, "if_statement", 0, 48),
+                        (stmt) => checkFunctionLocation(stmt, "if_else_statement", 50, 129),
+                        (stmt) => checkFunctionLocation(stmt, "with_statement", 131, 183),
+                        (stmt) => checkFunctionLocation(stmt, "try_statement", 185, 230),
+                        (stmt) => checkFunctionLocation(stmt, "try_except_statement", 232, 312),
+                        (stmt) => checkFunctionLocation(stmt, "try_else_statement", 314, 418),
+                        (stmt) => checkFunctionLocation(stmt, "for_statement", 420, 483),
+                        (stmt) => checkFunctionLocation(stmt, "assign_statements", 485, 542),
+                        (stmt) => checkFunctionLocation(stmt, "assign_statement", 544, 578)
+                    )
+                );
+            }
         }
 
         #endregion

--- a/src/UnitTests/TestData/Grammar/FunctionLocations.py
+++ b/src/UnitTests/TestData/Grammar/FunctionLocations.py
@@ -1,0 +1,35 @@
+def if_statement():
+    if True:
+        x = 1
+def if_else_statement():
+    if True:
+        x = 1
+    else:
+        x = 1
+def with_statement():
+    with None:
+        x = 1
+def try_statement():
+    try:
+        x = 1
+def try_except_statement():
+    try:
+        x = 1
+    except:
+        x = 1
+def try_else_statement():
+    try:
+        x = 1
+    except:
+        x = 1
+    else:
+        x = 1
+def for_statement():
+    for i in range(0, 10):
+        x = 1
+def assign_statements():
+    x = 1
+    x = 2
+    x = 3
+def assign_statement():
+    x = 1


### PR DESCRIPTION
Makes the EndIndex of a suite statement use the EndIndex of the last statement, rather than use the current token location, which may have advanced further, past some new line chars.

Example: In some scenarios, the EndIndex of a function ended up the same as the StartIndex of the next function.

That was a regression introduced in https://github.com/Microsoft/PTVS/commit/33bf79ebb758f4592f683b44587bd3e096cabae2#diff-90ae8164360db2dc89b75eeace0edd36L3868

This fixes outlining https://github.com/Microsoft/PTVS/issues/4703 and test discovery https://github.com/Microsoft/PTVS/issues/4908

