### PR TITLE
Basic analysis progress reporting

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IProgressReporter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IProgressReporter.cs
@@ -15,6 +15,6 @@
 
 namespace Microsoft.Python.Analysis.Analyzer {
     internal interface IProgressReporter {
-        void ReportRemaining(int count);
+        void ReportRemaining(int count = -1);
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IProgressReporter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IProgressReporter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.Python.Analysis.Analyzer {
+    internal interface IProgressReporter {
+        void ReportRemaining(int count);
+    }
+}

--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
@@ -15,7 +15,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Parsing.Ast;

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/ConditionalHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/ConditionalHandler.cs
@@ -66,24 +66,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                     someRecognized = true;
                 }
             }
-
-            // Handle basic check such as
-            // if isinstance(value, type):
-            //    return value
-            // by assigning type to the value unless clause is raising exception.
-            var ce = node.Tests.FirstOrDefault()?.Test as CallExpression;
-            if (ce?.Target is NameExpression ne && ne.Name == @"isinstance" && ce.Args.Count == 2) {
-                var nex = ce.Args[0].Expression as NameExpression;
-                var name = nex?.Name;
-                var typeName = (ce.Args[1].Expression as NameExpression)?.Name;
-                if (name != null && typeName != null) {
-                    var typeId = typeName.GetTypeId();
-                    if (typeId != BuiltinTypeId.Unknown) {
-                        var t = new PythonType(typeName, Module, string.Empty, LocationInfo.Empty, typeId);
-                        Eval.DeclareVariable(name, t, VariableSource.Declaration, nex);
-                    }
-                }
-            }
             return !someRecognized;
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/ProgressReporter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ProgressReporter.cs
@@ -1,0 +1,89 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Threading;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.Services;
+
+namespace Microsoft.Python.Analysis.Analyzer {
+    internal sealed class ProgressReporter : IProgressReporter, IDisposable {
+        private const int _initialDelay = 100;
+        private const int _reportingInterval = 300;
+        private const int _disposeInterval = 1500;
+
+        private readonly IProgressService _progressService;
+        private readonly object _lock = new object();
+        private int _lastReportedCount;
+        private int _lastReportedToClient;
+        private IProgress _progress;
+        private Timer _reportTimer;
+        private Timer _disposeTimer;
+        private bool _running;
+
+        public ProgressReporter(IProgressService progressService) {
+            _progressService = progressService;
+        }
+
+        public void Dispose() {
+            lock (_lock) {
+                _running = false;
+                _reportTimer.Dispose();
+                _disposeTimer.Dispose();
+                _progress?.Dispose();
+            }
+        }
+
+        public void ReportRemaining(int count) {
+            lock (_lock) {
+                if (!_running) {
+                    // Delay reporting a bit in case the analysis is short in order to reduce UI flicker.
+                    _running = true;
+                    _reportTimer?.Dispose();
+                    _reportTimer = new Timer(OnReportTimer, null, _initialDelay, _reportingInterval);
+                }
+
+                _disposeTimer?.Dispose();
+                _disposeTimer = new Timer(OnDisposeTimer, null, _disposeInterval, Timeout.Infinite);
+                _lastReportedCount = count;
+            }
+        }
+
+        private void OnReportTimer(object o) {
+            lock (_lock) {
+                if (_running && _lastReportedToClient != _lastReportedCount) {
+                    _lastReportedToClient = _lastReportedCount;
+                    _progress = _progress ?? _progressService.BeginProgress();
+                    if (_lastReportedCount > 0) {
+                        _progress?.Report(Resources.AnalysisProgress.FormatUI(_lastReportedCount)).DoNotWait();
+                    }
+                }
+            }
+        }
+
+        private void OnDisposeTimer(object o) {
+            lock (_lock) {
+                if (_running) {
+                    _running = false;
+                    _progress?.Dispose();
+                    _progress = null;
+
+                    _reportTimer.Dispose();
+                    _disposeTimer.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Core.DependencyResolution;
@@ -40,6 +39,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private readonly object _syncObj = new object();
         private readonly AsyncManualResetEvent _analysisCompleteEvent = new AsyncManualResetEvent();
         private readonly AsyncAutoResetEvent _analysisRunningEvent = new AsyncAutoResetEvent();
+        private readonly ProgressReporter _progress;
         private readonly ILogger _log;
         private readonly int _maxTaskRunning = 8;
         private int _runningTasks;
@@ -48,12 +48,16 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public PythonAnalyzer(IServiceManager services) {
             _services = services;
             _log = services.GetService<ILogger>();
+            _progress = new ProgressReporter(services.GetService<IProgressService>());
             _dependencyResolver = new DependencyResolver<ModuleKey, PythonAnalyzerEntry>(new ModuleDependencyFinder());
             _analysisCompleteEvent.Set();
             _analysisRunningEvent.Set();
         }
 
-        public void Dispose() => _disposeToken.TryMarkDisposed();
+        public void Dispose() {
+            _progress.Dispose();
+            _disposeToken.TryMarkDisposed();
+        }
 
         public Task WaitForCompleteAnalysisAsync(CancellationToken cancellationToken = default)
             => _analysisCompleteEvent.WaitAsync(cancellationToken);
@@ -72,8 +76,8 @@ namespace Microsoft.Python.Analysis.Analyzer {
             if (waitTime < 0 || Debugger.IsAttached) {
                 return await GetAnalysisAsync(entry, default, cancellationToken);
             }
-            
-            using (var timeoutCts = new CancellationTokenSource(waitTime)) 
+
+            using (var timeoutCts = new CancellationTokenSource(waitTime))
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken)) {
                 cts.CancelAfter(waitTime);
                 var timeoutToken = timeoutCts.Token;
@@ -118,17 +122,17 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 if (significantDependencies.Count == 0) {
                     return;
                 }
-                
+
                 entry.Invalidate(_version + 1);
                 entry.AddAnalysisDependencies(significantDependencies);
             }
 
             AnalyzeDocumentAsync(key, entry, default).DoNotWait();
 
-            bool IsSignificant(IPythonModule m) 
+            bool IsSignificant(IPythonModule m)
                 => m != entry.Module && ((m.ModuleType == ModuleType.User && m.Analysis.Version < entry.AnalysisVersion) || m.Analysis is EmptyAnalysis);
         }
-        
+
         public void EnqueueDocumentForAnalysis(IPythonModule module, PythonAst ast, int bufferVersion, CancellationToken cancellationToken) {
             var key = new ModuleKey(module);
             PythonAnalyzerEntry entry;
@@ -137,7 +141,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     if (entry.BufferVersion >= bufferVersion) {
                         return;
                     }
-                    
+
                     entry.Invalidate(ast, bufferVersion, _version + 1);
                 } else {
                     entry = new PythonAnalyzerEntry(module, ast, new EmptyAnalysis(_services, (IDocument)module), bufferVersion, _version + 1);
@@ -154,8 +158,8 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(_disposeToken.CancellationToken, cancellationToken)) {
                 var analysisToken = cts.Token;
- 
-                var walker = await _dependencyResolver.AddChangesAsync(key, entry, cts.Token);
+
+                var walker = await _dependencyResolver.AddChangesAsync(key, entry, cts.Token, _progress);
                 var stopOnVersionChange = true;
                 lock (_syncObj) {
                     if (_version > walker.Version) {
@@ -187,10 +191,13 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     }
 
                     _log?.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {walker.AffectedValues.Count} entries has started.");
+                    _progress.ReportRemaining(walker.Remaining);
                     await AnalyzeAffectedEntriesAsync(walker, stopOnVersionChange, stopWatch, analysisToken);
                 } finally {
                     _analysisRunningEvent.Set();
                     stopWatch.Stop();
+                    _progress.ReportRemaining(walker.Remaining);
+
                     if (_log != null) {
                         if (walker.Remaining == 0) {
                             _log?.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} has been completed in {stopWatch.Elapsed.TotalMilliseconds} ms.");
@@ -227,7 +234,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     StartAnalysis(node, walker.Version, stopWatch, cancellationToken);
                 }
             }
-            
+
             if (walker.MissingKeys.Where(k => !k.IsTypeshed).Count == 0) {
                 Interlocked.Exchange(ref _runningTasks, 0);
                 _analysisCompleteEvent.Set();
@@ -241,7 +248,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        private void StartAnalysis(IDependencyChainNode<PythonAnalyzerEntry> node, int version, Stopwatch stopWatch, CancellationToken cancellationToken) 
+        private void StartAnalysis(IDependencyChainNode<PythonAnalyzerEntry> node, int version, Stopwatch stopWatch, CancellationToken cancellationToken)
             => Task.Run(() => Analyze(node, version, stopWatch, cancellationToken), cancellationToken);
 
         /// <summary>
@@ -299,7 +306,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 IsTypeshed = isTypeshed;
             }
 
-            public bool Equals(ModuleKey other) 
+            public bool Equals(ModuleKey other)
                 => Name.EqualsOrdinal(other.Name) && FilePath.PathEquals(other.FilePath) && IsTypeshed == other.IsTypeshed;
 
             public override bool Equals(object obj) => obj is ModuleKey other && Equals(other);
@@ -378,7 +385,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 }
             }
 
-            private static bool Ignore(IModuleManagement moduleResolution, string name) 
+            private static bool Ignore(IModuleManagement moduleResolution, string name)
                 => moduleResolution.BuiltinModuleName.EqualsOrdinal(name) || moduleResolution.GetSpecializedModule(name) != null;
         }
     }

--- a/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Python.Analysis.Dependencies {
     /// </summary>
     internal interface IDependencyResolver<TKey, TValue> {
         ImmutableArray<TKey> MissingKeys { get; }
-        Task<IDependencyChainWalker<TKey, TValue>> AddChangesAsync(TKey key, TValue value, CancellationToken cancellationToken, IProgressReporter progress = null);
+        Task<IDependencyChainWalker<TKey, TValue>> AddChangesAsync(TKey key, TValue value, CancellationToken cancellationToken);
     }
 }

--- a/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
@@ -15,7 +15,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Python.Analysis.Documents;
+using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Core.Collections;
 
 namespace Microsoft.Python.Analysis.Dependencies {
@@ -27,6 +27,6 @@ namespace Microsoft.Python.Analysis.Dependencies {
     /// </summary>
     internal interface IDependencyResolver<TKey, TValue> {
         ImmutableArray<TKey> MissingKeys { get; }
-        Task<IDependencyChainWalker<TKey, TValue>> AddChangesAsync(TKey key, TValue value, CancellationToken cancellationToken);
+        Task<IDependencyChainWalker<TKey, TValue>> AddChangesAsync(TKey key, TValue value, CancellationToken cancellationToken, IProgressReporter progress = null);
     }
 }

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Analyzing in background, {0} items left....
+        /// </summary>
+        internal static string AnalysisProgress {
+            get {
+                return ResourceManager.GetString("AnalysisProgress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If checked, statements separated by semicolons are moved onto individual lines. If unchecked, lines with multiple statements are not modified..
         /// </summary>
         internal static string BreakMultipleStatementsPerLineLong {

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -339,4 +339,7 @@
   <data name="Analysis_UnknownParameterName" xml:space="preserve">
     <value>Unknown parameter name.</value>
   </data>
+  <data name="AnalysisProgress" xml:space="preserve">
+    <value>Analyzing in background, {0} items left...</value>
+  </data>
 </root>

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -328,9 +328,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         #endregion
 
         #region Extensions
+
         [JsonRpcMethod("python/loadExtension")]
-        public Task LoadExtension(JToken token, CancellationToken cancellationToken)
-            => _server.LoadExtensionAsync(ToObject<PythonAnalysisExtensionParams>(token), _services, cancellationToken);
+        public Task LoadExtension(JToken token, CancellationToken cancellationToken) => Task.CompletedTask;
+            //=> _server.LoadExtensionAsync(ToObject<PythonAnalysisExtensionParams>(token), _services, cancellationToken);
 
         [JsonRpcMethod("python/extensionCommand")]
         public Task ExtensionCommand(JToken token, CancellationToken cancellationToken)

--- a/src/LanguageServer/Impl/Services/ClientApplication.cs
+++ b/src/LanguageServer/Impl/Services/ClientApplication.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Python.LanguageServer.Services {
         }
 
         public Task NotifyAsync(string targetName, params object[] arguments)
-            => _rpc.NotifyAsync(targetName, arguments);
+            => arguments != null && arguments.Length > 0 
+                ?  _rpc.NotifyAsync(targetName, arguments)
+                :  _rpc.NotifyAsync(targetName);
 
         public Task NotifyWithParameterObjectAsync(string targetName, object argument = null)
             => _rpc.NotifyWithParameterObjectAsync(targetName, argument);


### PR DESCRIPTION
Fixes #688

- Numbers can go up/down. We can nix numbers and just leave the spinner if that is weird.
- Special class that reduces frequency of reporting traffic and auto-disposes the message when there is no activity.