### PR TITLE
Fix nullref during testing

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/ProgressReporter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ProgressReporter.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             lock (_lock) {
                 if (_running && _lastReportedToClient != _lastReportedCount) {
                     _lastReportedToClient = _lastReportedCount;
-                    _progress = _progress ?? _progressService.BeginProgress();
+                    _progress = _progress ?? _progressService?.BeginProgress();
                     if (_lastReportedCount > 0) {
                         _progress?.Report(Resources.AnalysisProgress.FormatUI(_lastReportedCount)).DoNotWait();
                     }


### PR DESCRIPTION
Running analysis tests after #687 fails because there is no progress reporting service.