### PR TITLE
Compile docstring converter regexes

### DIFF
--- a/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
+++ b/src/LanguageServer/Impl/Documentation/DocstringConverter.cs
@@ -237,9 +237,9 @@ namespace Microsoft.Python.LanguageServer.Documentation {
                 // Applying this only when i == 0 or i == parts.Length-1 may work.
 
                 // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references
-                // part = Regex.Replace(part, @"^_+", "", RegexOptions.Singleline | RegexOptions.Compiled);
+                // part = Regex.Replace(part, @"^_+", "");
                 // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-internal-targets
-                // part = Regex.Replace(part, @"_+$", "", RegexOptions.Singleline | RegexOptions.Compiled);
+                // part = Regex.Replace(part, @"_+$", "");
 
                 // TODO: Strip footnote/citation references.
 


### PR DESCRIPTION
Fixes #705.

This isn't the end of the completion speedups, see #704. The regexes should be removed in favor of a real parser, eventually.

Also, I preallocate the builder based on the size of the input, rather than letting it resize needlessly.

I put the regexes as close to their uses as possible, rather than shoving them all at the top or bottom.