### PR TITLE
Unfilter __all__

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -149,20 +149,11 @@ namespace Microsoft.Python.Analysis.Modules {
         #region IMemberContainer
         public virtual IMember GetMember(string name) => Analysis.GlobalScope.Variables[name]?.Value;
         public virtual IEnumerable<string> GetMemberNames() {
-            // Try __all__ since it contains exported members
-            var all = Analysis.GlobalScope.Variables["__all__"];
-            if (all?.Value is IPythonCollection collection) {
-                return collection.Contents
-                    .OfType<IPythonConstant>()
-                    .Select(c => c.GetString())
-                    .Where(s => !string.IsNullOrEmpty(s));
-            }
+            // TODO: Filter __all__. See: https://github.com/Microsoft/python-language-server/issues/620
 
-            // __all__ is not declared. Try filtering by origin:
-            // drop imported modules and generics.
+            // drop imported modules and typing.
             return Analysis.GlobalScope.Variables
-                .Where(v => v.Value?.MemberType != PythonMemberType.Generic
-                            && !(v.Value?.GetPythonType() is PythonModule)
+                .Where(v => !(v.Value?.GetPythonType() is PythonModule)
                             && !(v.Value?.GetPythonType().DeclaringModule is TypingModule && !(this is TypingModule)))
                 .Select(v => v.Name);
         }


### PR DESCRIPTION
Fixes #642.
Reopens #619.
Related #620.

This unfilters `__all__` except for things which are directly from `typing` or are imported modules, though even that may be too strong. The old LS didn't look at `__all__` whatsoever, so maybe all of these should be allowed to come through; you tell me.

Numpy:

![image](https://user-images.githubusercontent.com/5341706/53849114-a8f21a00-3f6b-11e9-876b-547fe34a596e.png)