### PR TITLE
Adding support for setting initial source location in parser

### DIFF
--- a/src/Parsing/Impl/ErrorSink.cs
+++ b/src/Parsing/Impl/ErrorSink.cs
@@ -22,7 +22,15 @@ namespace Microsoft.Python.Parsing {
 
         internal void Add(string message, NewLineLocation[] lineLocations, int startIndex, int endIndex, int errorCode, Severity severity) => Add(
                 message,
-                new SourceSpan(NewLineLocation.IndexToLocation(lineLocations, startIndex), NewLineLocation.IndexToLocation(lineLocations, endIndex)),
+                NewLineLocation.IndexToLocation(lineLocations, startIndex),
+                NewLineLocation.IndexToLocation(lineLocations, endIndex),
+                errorCode,
+                severity
+            );
+
+        internal void Add(string message, SourceLocation startSourceLoc, SourceLocation endSourceLoc, int errorCode, Severity severity) => Add(
+                message,
+                new SourceSpan(startSourceLoc, endSourceLoc),
                 errorCode,
                 severity
             );

--- a/src/Parsing/Impl/LiteralParser.cs
+++ b/src/Parsing/Impl/LiteralParser.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Python.Parsing {
     /// Summary description for ConstantValue.
     /// </summary>
     internal static class LiteralParser {
-        public static string ParseString(string text, bool isRaw, bool isUni, bool isFormatted) => ParseString(text.ToCharArray(), 0, text.Length, isRaw, isUni, isFormatted, false);
+        public static string ParseString(string text, bool isRaw, bool isUni) => ParseString(text.ToCharArray(), 0, text.Length, isRaw, isUni, false);
 
-        public static string ParseString(char[] text, int start, int length, bool isRaw, bool isUni, bool isFormatted, bool normalizeLineEndings) {
+        public static string ParseString(char[] text, int start, int length, bool isRaw, bool isUni, bool normalizeLineEndings) {
             if (text == null) {
                 throw new ArgumentNullException("text");
             }
@@ -43,7 +43,7 @@ namespace Microsoft.Python.Parsing {
             while (i < l) {
                 var ch = text[i++];
                 // We treat formatted strings differently here so that we can detect '\\' inside fstrings
-                if ((!isRaw || isUni) && !isFormatted && ch == '\\') {
+                if ((!isRaw || isUni) && ch == '\\') {
                     if (buf == null) {
                         buf = new StringBuilder(length);
                         buf.Append(text, start, i - start - 1);

--- a/src/Parsing/Impl/LiteralParser.cs
+++ b/src/Parsing/Impl/LiteralParser.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Python.Parsing {
     /// Summary description for ConstantValue.
     /// </summary>
     internal static class LiteralParser {
-        public static string ParseString(string text, bool isRaw, bool isUni) => ParseString(text.ToCharArray(), 0, text.Length, isRaw, isUni, false);
+        public static string ParseString(string text, bool isRaw, bool isUni, bool isFormatted) => ParseString(text.ToCharArray(), 0, text.Length, isRaw, isUni, isFormatted, false);
 
-        public static string ParseString(char[] text, int start, int length, bool isRaw, bool isUni, bool normalizeLineEndings) {
+        public static string ParseString(char[] text, int start, int length, bool isRaw, bool isUni, bool isFormatted, bool normalizeLineEndings) {
             if (text == null) {
                 throw new ArgumentNullException("text");
             }
@@ -42,7 +42,8 @@ namespace Microsoft.Python.Parsing {
             var l = start + length;
             while (i < l) {
                 var ch = text[i++];
-                if ((!isRaw || isUni) && ch == '\\') {
+                // We treat formatted strings differently here so that we can detect '\\' inside fstrings
+                if ((!isRaw || isUni) && !isFormatted && ch == '\\') {
                     if (buf == null) {
                         buf = new StringBuilder(length);
                         buf.Append(text, start, i - start - 1);

--- a/src/Parsing/Impl/LiteralParser.cs
+++ b/src/Parsing/Impl/LiteralParser.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Python.Parsing {
             var l = start + length;
             while (i < l) {
                 var ch = text[i++];
-                // We treat formatted strings differently here so that we can detect '\\' inside fstrings
                 if ((!isRaw || isUni) && ch == '\\') {
                     if (buf == null) {
                         buf = new StringBuilder(length);

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -299,7 +299,8 @@ namespace Microsoft.Python.Parsing {
             if (_errorCode == 0) {
                 _errorCode = errorCode;
             }
-            _errors.Add(message,
+            _errors.Add(
+                message,
                 new SourceSpan(_tokenizer.IndexToLocation(start), _tokenizer.IndexToLocation(end)),
                 errorCode,
                 Severity.Error

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Python.Parsing {
                     TokenizerOptions.GroupingRecovery |
                     (options.StubFile ? TokenizerOptions.StubFile : 0),
                 (span, text) => options.RaiseProcessComment(parser, new CommentEventArgs(span, text)));
-            tokenizer.Initialize(null, reader, SourceLocation.MinValue);
+            tokenizer.Initialize(null, reader, options.InitialSourceLocation ?? SourceLocation.MinValue);
             tokenizer.IndentationInconsistencySeverity = options.IndentationInconsistencySeverity;
 
             parser = new Parser(
@@ -299,12 +299,11 @@ namespace Microsoft.Python.Parsing {
             if (_errorCode == 0) {
                 _errorCode = errorCode;
             }
-            _errors.Add(
-                message,
-                _tokenizer.GetLineLocations(),
-                start, end,
+            _errors.Add(message,
+                new SourceSpan(_tokenizer.IndexToLocation(start), _tokenizer.IndexToLocation(end)),
                 errorCode,
-                Severity.Error);
+                Severity.Error
+            );
         }
 
         #endregion

--- a/src/Parsing/Impl/ParserOptions.cs
+++ b/src/Parsing/Impl/ParserOptions.cs
@@ -22,11 +22,14 @@ namespace Microsoft.Python.Parsing {
         public static ParserOptions Default = new ParserOptions();
         public ParserOptions() {
             ErrorSink = ErrorSink.Null;
+            InitialSourceLocation = SourceLocation.MinValue;
         }
 
         public ParserOptions Clone() => (ParserOptions)MemberwiseClone();
 
         public ErrorSink ErrorSink { get; set; }
+
+        public SourceLocation? InitialSourceLocation { get; set; }
 
         public Severity IndentationInconsistencySeverity { set; get; }
 

--- a/src/Parsing/Impl/Tokenizer.cs
+++ b/src/Parsing/Impl/Tokenizer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Python.Parsing {
                 match = ~match - 1;
             }
 
-            return new SourceLocation(index + _initialLocation.Index, match + 2 + _initialLocation.Line - 1, index - _newLineLocations[match].EndIndex + _initialLocation.Column);
+            return new SourceLocation(index + _initialLocation.Index, match + 2 + _initialLocation.Line - 1, index - _newLineLocations[match].EndIndex + 1);
         }
 
         internal ErrorSink ErrorSink {
@@ -991,10 +991,10 @@ namespace Microsoft.Python.Parsing {
 
             MarkTokenEnd();
 
-            return MakeStringToken(quote, isRaw, isUnicode, isBytes, isTriple, _start + startAdd, TokenLength - startAdd - end_add);
+            return MakeStringToken(quote, isRaw, isUnicode, isBytes, isTriple, isFormatted, _start + startAdd, TokenLength - startAdd - end_add);
         }
 
-        private Token MakeStringToken(char quote, bool isRaw, bool isUnicode, bool isBytes, bool isTriple, int start, int length) {
+        private Token MakeStringToken(char quote, bool isRaw, bool isUnicode, bool isBytes, bool isTriple, bool isFormatted, int start, int length) {
             bool makeUnicode;
             if (isUnicode) {
                 makeUnicode = true;
@@ -1007,7 +1007,7 @@ namespace Microsoft.Python.Parsing {
             if (makeUnicode) {
                 string contents;
                 try {
-                    contents = LiteralParser.ParseString(_buffer, start, length, isRaw, true, !_disableLineFeedLineSeparator);
+                    contents = LiteralParser.ParseString(_buffer, start, length, isRaw, true, isFormatted, !_disableLineFeedLineSeparator);
                 } catch (DecoderFallbackException e) {
                     _errors.Add(e.Message, _newLineLocations.ToArray(), _tokenStartIndex, _tokenEndIndex, ErrorCodes.SyntaxError, Severity.Error);
                     contents = "";

--- a/src/Parsing/Impl/Tokenizer.cs
+++ b/src/Parsing/Impl/Tokenizer.cs
@@ -2188,7 +2188,7 @@ namespace Microsoft.Python.Parsing {
         }
 
         private void ReportSyntaxError(IndexSpan span, string message, int errorCode)
-            => _errors.Add(message, _newLineLocations.ToArray(), span.Start, span.End, errorCode, Severity.Error);
+            => _errors.Add(message, IndexToLocation(span.Start), IndexToLocation(span.End), errorCode, Severity.Error);
 
         [Conditional("DUMP_TOKENS")]
         private static void DumpToken(Token token)

--- a/src/Parsing/Impl/Tokenizer.cs
+++ b/src/Parsing/Impl/Tokenizer.cs
@@ -991,10 +991,10 @@ namespace Microsoft.Python.Parsing {
 
             MarkTokenEnd();
 
-            return MakeStringToken(quote, isRaw, isUnicode, isBytes, isTriple, isFormatted, _start + startAdd, TokenLength - startAdd - end_add);
+            return MakeStringToken(quote, isRaw, isUnicode, isBytes, isTriple, _start + startAdd, TokenLength - startAdd - end_add);
         }
 
-        private Token MakeStringToken(char quote, bool isRaw, bool isUnicode, bool isBytes, bool isTriple, bool isFormatted, int start, int length) {
+        private Token MakeStringToken(char quote, bool isRaw, bool isUnicode, bool isBytes, bool isTriple, int start, int length) {
             bool makeUnicode;
             if (isUnicode) {
                 makeUnicode = true;
@@ -1007,7 +1007,7 @@ namespace Microsoft.Python.Parsing {
             if (makeUnicode) {
                 string contents;
                 try {
-                    contents = LiteralParser.ParseString(_buffer, start, length, isRaw, true, isFormatted, !_disableLineFeedLineSeparator);
+                    contents = LiteralParser.ParseString(_buffer, start, length, isRaw, true, !_disableLineFeedLineSeparator);
                 } catch (DecoderFallbackException e) {
                     _errors.Add(e.Message, _newLineLocations.ToArray(), _tokenStartIndex, _tokenEndIndex, ErrorCodes.SyntaxError, Severity.Error);
                     contents = "";

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -2870,6 +2870,25 @@ namespace Microsoft.Python.Parsing.Tests {
         //    Assert.IsFalse(anyErrors, "Errors occurred. See output trace for details.");
         //}
 
+        [TestMethod, Priority(0)]
+        public void ReportsErrorsUsingLocationOffset() {
+            const PythonLanguageVersion version = PythonLanguageVersion.V35;
+            var errorSink = new CollectingErrorSink();
+            var code = @"x! + 1
+x! + 1";
+            using (var reader = new StringReader(code)) {
+                var parser = Parser.CreateParser(reader, version, new ParserOptions() {
+                    ErrorSink = errorSink,
+                    InitialSourceLocation = new SourceLocation(0, 10, 10)
+                });
+                parser.ParseFile();
+            }
+            errorSink.Errors.Should().BeEquivalentTo(new[] {
+                new ErrorResult("unexpected token '!'", new SourceSpan(10, 11, 10, 12)),
+                new ErrorResult("unexpected token '!'", new SourceSpan(11, 2, 11, 3))
+            });
+        }
+
         private static string StdLibWorker(InterpreterConfiguration configuration) {
             var files = new List<string>();
             var version = configuration.Version.ToLanguageVersion();

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -2872,21 +2872,23 @@ namespace Microsoft.Python.Parsing.Tests {
 
         [TestMethod, Priority(0)]
         public void ReportsErrorsUsingLocationOffset() {
-            const PythonLanguageVersion version = PythonLanguageVersion.V35;
-            var errorSink = new CollectingErrorSink();
-            var code = @"f = pass
+            foreach (var version in AllVersions) {
+
+                var errorSink = new CollectingErrorSink();
+                var code = @"f = pass
 f = pass";
-            using (var reader = new StringReader(code)) {
-                var parser = Parser.CreateParser(reader, version, new ParserOptions() {
-                    ErrorSink = errorSink,
-                    InitialSourceLocation = new SourceLocation(0, 10, 10)
-                });
-                parser.ParseFile();
-            }
-            errorSink.Errors.Should().BeEquivalentTo(new[] {
+                using (var reader = new StringReader(code)) {
+                    var parser = Parser.CreateParser(reader, version, new ParserOptions() {
+                        ErrorSink = errorSink,
+                        InitialSourceLocation = new SourceLocation(0, 10, 10)
+                    });
+                    parser.ParseFile();
+                }
+                errorSink.Errors.Should().BeEquivalentTo(new[] {
                 new ErrorResult("unexpected token 'pass'", new SourceSpan(10, 14, 10, 18)),
                 new ErrorResult("unexpected token 'pass'", new SourceSpan(11, 5, 11, 9))
             });
+            }
         }
 
         private static string StdLibWorker(InterpreterConfiguration configuration) {

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -2873,7 +2873,6 @@ namespace Microsoft.Python.Parsing.Tests {
         [TestMethod, Priority(0)]
         public void ReportsErrorsUsingLocationOffset() {
             foreach (var version in AllVersions) {
-
                 var errorSink = new CollectingErrorSink();
                 var code = @"f = pass
 f = pass";
@@ -2885,9 +2884,9 @@ f = pass";
                     parser.ParseFile();
                 }
                 errorSink.Errors.Should().BeEquivalentTo(new[] {
-                new ErrorResult("unexpected token 'pass'", new SourceSpan(10, 14, 10, 18)),
-                new ErrorResult("unexpected token 'pass'", new SourceSpan(11, 5, 11, 9))
-            });
+                    new ErrorResult("unexpected token 'pass'", new SourceSpan(10, 14, 10, 18)),
+                    new ErrorResult("unexpected token 'pass'", new SourceSpan(11, 5, 11, 9))
+                });
             }
         }
 

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -2874,8 +2874,8 @@ namespace Microsoft.Python.Parsing.Tests {
         public void ReportsErrorsUsingLocationOffset() {
             const PythonLanguageVersion version = PythonLanguageVersion.V35;
             var errorSink = new CollectingErrorSink();
-            var code = @"x! + 1
-x! + 1";
+            var code = @"f = pass
+f = pass";
             using (var reader = new StringReader(code)) {
                 var parser = Parser.CreateParser(reader, version, new ParserOptions() {
                     ErrorSink = errorSink,
@@ -2884,8 +2884,8 @@ x! + 1";
                 parser.ParseFile();
             }
             errorSink.Errors.Should().BeEquivalentTo(new[] {
-                new ErrorResult("unexpected token '!'", new SourceSpan(10, 11, 10, 12)),
-                new ErrorResult("unexpected token '!'", new SourceSpan(11, 2, 11, 3))
+                new ErrorResult("unexpected token 'pass'", new SourceSpan(10, 14, 10, 18)),
+                new ErrorResult("unexpected token 'pass'", new SourceSpan(11, 5, 11, 9))
             });
         }
 


### PR DESCRIPTION
We make sure that error reports have correct line numbers and columns, considering the initial location.
This will be useful when we create parsers for f-strings sub expressions