### PR TITLE
Reduce amount of async code in PythonAnalyzer

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -286,17 +286,17 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 entry.TrySetAnalysis(analysis, version);
                 node.Commit();
 
-                _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) is completed in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms.");
+                _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) completed in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms.");
             } catch (OperationCanceledException oce) {
                 node.Value.TryCancel(oce, version);
                 node.Skip();
                 var module = node.Value.Module;
-                _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) is canceled.");
+                _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) canceled.");
             } catch (Exception exception) {
                 var module = node.Value.Module;
                 node.Value.TrySetException(exception, version);
                 node.Commit();
-                _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) has failed.");
+                _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) failed.");
             } finally {
                 Interlocked.Decrement(ref _runningTasks);
             }

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerEntry.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerEntry.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             lock (_syncObj) {
                 module = _module;
                 ast = _ast;
-                return _analysisVersion <= version;
+                return _previousAnalysis is EmptyAnalysis || _analysisVersion <= version;
             }
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerEntry.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerEntry.cs
@@ -23,94 +23,151 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     internal sealed class PythonAnalyzerEntry {
+        private readonly object _syncObj = new object();
         private TaskCompletionSource<IDocumentAnalysis> _analysisTcs;
+        private IPythonModule _module;
+        private PythonAst _ast;
+        private IDocumentAnalysis _previousAnalysis;
+        private ImmutableArray<IPythonModule> _analysisDependencies;
+        private int _bufferVersion;
+        private int _analysisVersion;
 
-        public IPythonModule Module { get; }
-        public PythonAst Ast { get; private set; }
-        public IDocumentAnalysis PreviousAnalysis { get; private set; }
-        public ImmutableArray<IPythonModule> AnalysisDependencies { get; private set; }
-        public int BufferVersion { get; private set; }
-        public int AnalysisVersion { get; private set; }
+        public IPythonModule Module {
+            get {
+                lock (_syncObj) {
+                    return _module;
+                }
+            }
+        }
+
+        public PythonAst Ast {
+            get {
+                lock (_syncObj) {
+                    return _ast;
+                }
+            }
+        }
+
+        public IDocumentAnalysis PreviousAnalysis {
+            get {
+                lock (_syncObj) {
+                    return _previousAnalysis;
+                }
+            }
+        }
+
+        public ImmutableArray<IPythonModule> AnalysisDependencies {
+            get {
+                lock (_syncObj) {
+                    return _analysisDependencies;
+                }
+            }
+        }
+
+        public int BufferVersion {
+            get {
+                lock (_syncObj) {
+                    return _bufferVersion;
+                }
+            }
+        }
+
+        public int AnalysisVersion {
+            get {
+                lock (_syncObj) {
+                    return _analysisVersion;
+                }
+            }
+        }
+
         public bool NotAnalyzed => PreviousAnalysis is EmptyAnalysis;
 
         public PythonAnalyzerEntry(IPythonModule module, PythonAst ast, IDocumentAnalysis previousAnalysis, int bufferVersion, int analysisVersion) {
-            Module = module;
-            Ast = ast;
-            PreviousAnalysis = previousAnalysis;
-            AnalysisDependencies = ImmutableArray<IPythonModule>.Empty;
+            _module = module;
+            _ast = ast;
+            _previousAnalysis = previousAnalysis;
+            _analysisDependencies = ImmutableArray<IPythonModule>.Empty;
 
-            BufferVersion = bufferVersion;
-            AnalysisVersion = analysisVersion;
+            _bufferVersion = bufferVersion;
+            _analysisVersion = analysisVersion;
             _analysisTcs = new TaskCompletionSource<IDocumentAnalysis>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         public Task<IDocumentAnalysis> GetAnalysisAsync(CancellationToken cancellationToken) 
             => _analysisTcs.Task.ContinueWith(t => t.GetAwaiter().GetResult(), cancellationToken);
 
-        public void TrySetAnalysis(IDocumentAnalysis analysis, int version, object syncObj) {
-            lock (syncObj) {
-                if (NotAnalyzed) {
-                    PreviousAnalysis = analysis;
+        public void TrySetAnalysis(IDocumentAnalysis analysis, int version) {
+            lock (_syncObj) {
+                if (_previousAnalysis is EmptyAnalysis) {
+                    _previousAnalysis = analysis;
                 }
 
-                if (AnalysisVersion > version) {
+                if (_analysisVersion > version) {
                     return;
                 }
 
-                AnalysisDependencies = ImmutableArray<IPythonModule>.Empty;
+                _analysisDependencies = ImmutableArray<IPythonModule>.Empty;
                 UpdateAnalysisTcs(version);
             }
 
             _analysisTcs.TrySetResult(analysis);
         }
 
-        public void TrySetException(Exception ex, int version, object syncObj) {
-            lock (syncObj) {
-                if (AnalysisVersion > version) {
+        public void TrySetException(Exception ex, int version) {
+            lock (_syncObj) {
+                if (_analysisVersion > version) {
                     return;
                 }
 
-                AnalysisVersion = version;
+                _analysisVersion = version;
             }
 
             _analysisTcs.TrySetException(ex);
         }
 
-        public void TryCancel(OperationCanceledException oce, int version, object syncObj) {
-            lock (syncObj) {
-                if (AnalysisVersion > version) {
+        public void TryCancel(OperationCanceledException oce, int version) {
+            lock (_syncObj) {
+                if (_analysisVersion > version) {
                     return;
                 }
 
-                AnalysisVersion = version;
+                _analysisVersion = version;
             }
             
             _analysisTcs.TrySetCanceled(oce.CancellationToken);
         }
 
-        public void Invalidate(int analysisVersion)
-            => Invalidate(Ast, BufferVersion, analysisVersion);
+        public void Invalidate(int analysisVersion) => Invalidate(_ast, _bufferVersion, analysisVersion);
 
-        public void AddAnalysisDependencies(ImmutableArray<IPythonModule> dependencies) {
-            AnalysisDependencies = AnalysisDependencies.AddRange(dependencies);
+        public void Invalidate(ImmutableArray<IPythonModule> dependencies, int analysisVersion) {
+            lock (_syncObj) {
+                if (_analysisVersion >= analysisVersion) {
+                    return;
+                }
+
+                UpdateAnalysisTcs(analysisVersion);
+                _analysisDependencies = _analysisDependencies.AddRange(dependencies);
+            }
         }
 
         public void Invalidate(PythonAst ast, int bufferVersion, int analysisVersion) {
-            if (AnalysisVersion >= analysisVersion && BufferVersion >= bufferVersion) {
-                return;
-            }
+            lock (_syncObj) {
+                if (_analysisVersion >= analysisVersion && _bufferVersion >= bufferVersion) {
+                    return;
+                }
 
-            Ast = ast;
-            BufferVersion = bufferVersion;
-            
-            UpdateAnalysisTcs(analysisVersion);
+                _ast = ast;
+                _bufferVersion = bufferVersion;
+
+                UpdateAnalysisTcs(analysisVersion);
+            }
         }
 
         private void UpdateAnalysisTcs(int analysisVersion) {
-            AnalysisVersion = analysisVersion;
+            _analysisVersion = analysisVersion;
             if (_analysisTcs.Task.Status == TaskStatus.RanToCompletion) {
-                PreviousAnalysis = _analysisTcs.Task.Result;
-                AnalysisDependencies = ImmutableArray<IPythonModule>.Empty;
+                _previousAnalysis = _analysisTcs.Task.Result;
+                _analysisDependencies = ImmutableArray<IPythonModule>.Empty;
             }
 
             if (_analysisTcs.Task.IsCompleted) {

--- a/src/Analysis/Ast/Impl/Dependencies/IDependencyChainWalker.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/IDependencyChainWalker.cs
@@ -24,6 +24,5 @@ namespace Microsoft.Python.Analysis.Dependencies {
         ImmutableArray<TValue> AffectedValues { get; }
         int Version { get; }
         int Remaining { get; }
-        bool IsCompleted { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Python.Analysis.Dependencies {
     /// concurrently.
     /// </summary>
     internal interface IDependencyResolver<TKey, TValue> {
-        ImmutableArray<TKey> MissingKeys { get; }
-        Task<IDependencyChainWalker<TKey, TValue>> AddChangesAsync(TKey key, TValue value, CancellationToken cancellationToken);
+        IDependencyChainWalker<TKey, TValue> NotifyChanges(TKey key, TValue value, ImmutableArray<TKey> incomingKeys);
     }
 }

--- a/src/Core/Impl/Extensions/TaskExtensions.cs
+++ b/src/Core/Impl/Extensions/TaskExtensions.cs
@@ -98,5 +98,8 @@ namespace Microsoft.Python.Core {
         /// <see cref="AggregateException"/>.
         /// </summary>
         public static T WaitAndUnwrapExceptions<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+
+        public static Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken) 
+            => task.ContinueWith(t => t.GetAwaiter().GetResult(), cancellationToken, TaskContinuationOptions.None, TaskScheduler.Default);
     }
 }


### PR DESCRIPTION
Stabilization fixes:
- IoC is replaced with direct list of dependencies
- All operations in `ProjectAnalyzerEntry` now happen under individual lock
- Cancellation of analysis can't abort graph change in the middle of the process
- Allow access to AST instance only with corresponding module instance
- Update IPythonModule instance when entry is invalidated