### PR TITLE
Various import completion fixes

### DIFF
--- a/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.Node.cs
+++ b/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.Node.cs
@@ -119,7 +119,9 @@ namespace Microsoft.Python.Analysis.Core.DependencyResolution {
                 foreach (var edge in _edges) {
                     var children = edge.End.Children;
                     foreach (var child in children) {
-                        results = results.Add(child.Name);
+                        if (IsNotInitPy(child)) {
+                            results = results.Add(child.Name);
+                        }
                     }
                 }
 


### PR DESCRIPTION
- Import search now is always happening through PathResolver
- Filtering empty name at the end of module path
- Fixes #716: Language Server 0.2.16 crashes (Request textDocument/completion failed.)
- Fixes #594: Completion support in 'from . import'