### PR TITLE
Create stub resolver before builtins

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
             _moduleResolution = new MainModuleResolution(root, sm);
             await _moduleResolution.InitializeAsync(cancellationToken);
 
+            _stubResolution = new TypeshedResolution(sm);
+            await _stubResolution.InitializeAsync(cancellationToken);
+
             var builtinModule = _moduleResolution.BuiltinsModule;
             lock (_lock) {
                 _builtinTypes[BuiltinTypeId.NoneType]
@@ -57,9 +60,6 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     = UnknownType = new PythonType("Unknown", builtinModule, string.Empty, LocationInfo.Empty);
             }
             await _moduleResolution.LoadBuiltinTypesAsync(cancellationToken);
-
-            _stubResolution = new TypeshedResolution(sm);
-            await _stubResolution.InitializeAsync(cancellationToken);
         }
 
         public static async Task<IPythonInterpreter> CreateAsync(InterpreterConfiguration configuration, string root, IServiceManager sm, CancellationToken cancellationToken = default) {


### PR DESCRIPTION
Fixes #719.

Looking at the stack trace on that issue, `Initialize` occurs, which eventually gets an AST, which then spawns a task which eventually calls `CreateModule`, which refers back to `PythonInterpreter`, whose stub resolver has not yet been instantiated. I don't believe instantiating it earlier has any effect other than that it's there earlier so won't be `null`, as `InitializeAsync` only sets up an internal path resolver.

I'm not really sure if this is the "true" fix, since it seems weird for there to be this sort of cycle, but I'm not the most familiar with this specific bit.