### PR TITLE
Fix #719: Scraper produces incorrect output for the Anaconda 2X builtin

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
@@ -86,6 +86,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                     return TryGetModulePossibleImport(possibleModuleImport, parent, location, out variableModule);
                 case ImplicitPackageImport packageImport:
                     return TryGetPackageFromImport(packageImport, parent, out variableModule);
+                case RelativeImportBeyondTopLevel importBeyondTopLevel:
+                    var message = Resources.ErrorRelativeImportBeyondTopLevel.FormatInvariant(importBeyondTopLevel.RelativeImportName);
+                    Eval.ReportDiagnostics(Eval.Module.Uri, new DiagnosticsEntry(message, location.Span, ErrorCodes.UnresolvedImport, Severity.Warning));
+                    variableModule = default;
+                    return false;
                 case ImportNotFound importNotFound:
                     var memberName = asNameExpression?.Name ?? importNotFound.FullName;
                     MakeUnresolvedImport(memberName, importNotFound.FullName, location);

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private readonly AsyncAutoResetEvent _analysisRunningEvent = new AsyncAutoResetEvent();
         private readonly ProgressReporter _progress;
         private readonly ILogger _log;
-        private readonly int _maxTaskRunning = 8;
+        private readonly int _maxTaskRunning = Environment.ProcessorCount * 3;
         private int _runningTasks;
         private int _version;
 

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Relative import &apos;{0}&apos; beyond top-level package.
+        /// </summary>
+        internal static string ErrorRelativeImportBeyondTopLevel {
+            get {
+                return ResourceManager.GetString("ErrorRelativeImportBeyondTopLevel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to unresolved import &apos;{0}&apos;.
         /// </summary>
         internal static string ErrorUnresolvedImport {

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -312,6 +312,9 @@
   <data name="ErrorUnresolvedImport" xml:space="preserve">
     <value>unresolved import '{0}'</value>
   </data>
+  <data name="ErrorRelativeImportBeyondTopLevel" xml:space="preserve">
+    <value>Relative import '{0}' beyond top-level package</value>
+  </data>
   <data name="ErrorUseBeforeDef" xml:space="preserve">
     <value>'{0}' used before definition</value>
   </data>

--- a/src/Analysis/Ast/Impl/scrape_module.py
+++ b/src/Analysis/Ast/Impl/scrape_module.py
@@ -28,9 +28,12 @@ import sys
 import tokenize
 import warnings
 
-try:
-    import builtins
-except ImportError:
+if sys.version_info >= (3, 0):
+    try:
+        import builtins
+    except ImportError:
+        import __builtin__ as builtins
+else:
     import __builtin__ as builtins
 
 try:

--- a/src/Analysis/Ast/Test/BasicTests.cs
+++ b/src/Analysis/Ast/Test/BasicTests.cs
@@ -19,6 +19,8 @@ using FluentAssertions;
 using Microsoft.Python.Analysis.Tests.FluentAssertions;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
+using Microsoft.Python.Parsing;
+using Microsoft.Python.Parsing.Tests;
 using Microsoft.Python.Tests.Utilities.FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
@@ -83,12 +85,19 @@ x = sys.path
                 .And.HaveVariable("x").OfType(BuiltinTypeId.List);
         }
 
-        [TestMethod, Priority(0)]
-        public async Task BuiltinsTest() {
+        [DataRow(true, true)]
+        [DataRow(false, true)]
+        [DataRow(true, false)]
+        [DataRow(false, false)]
+        [DataTestMethod, Priority(0)]
+        public async Task BuiltinsTest(bool isPython3X, bool isAnaconda) {
             const string code = @"
 x = 1
 ";
-            var analysis = await GetAnalysisAsync(code);
+            var configuration = isPython3X 
+                ? isAnaconda ? PythonVersions.LatestAnaconda3X : PythonVersions.LatestAvailable3X 
+                : isAnaconda ? PythonVersions.LatestAnaconda2X : PythonVersions.LatestAvailable2X;
+            var analysis = await GetAnalysisAsync(code, configuration);
 
             var v = analysis.Should().HaveVariable("x").Which;
             var t = v.Value.GetPythonType();

--- a/src/Analysis/Ast/Test/ImportTests.cs
+++ b/src/Analysis/Ast/Test/ImportTests.cs
@@ -212,7 +212,7 @@ x = f()
             var d = analysis.Diagnostics.First();
             d.ErrorCode.Should().Be(ErrorCodes.UnresolvedImport);
             d.SourceSpan.Should().Be(1, 6, 1, 19);
-            d.Message.Should().Be(Resources.ErrorUnresolvedImport.FormatInvariant("nonexistent"));
+            d.Message.Should().Be(Resources.ErrorRelativeImportBeyondTopLevel.FormatInvariant("nonexistent"));
         }
     }
 }

--- a/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.cs
+++ b/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.cs
@@ -190,9 +190,9 @@ namespace Microsoft.Python.Analysis.Core.DependencyResolution {
                 return default;
             }
 
-            if (parentCount > lastEdge.PathLength) {
+            if (parentCount >= lastEdge.PathLength) {
                 // Can't get outside of the root
-                return default;
+                return new RelativeImportBeyondTopLevel(string.Join(".", relativePath));
             }
 
             var fullNameList = relativePath.TakeWhile(n => !string.IsNullOrEmpty(n)).ToList();
@@ -208,7 +208,7 @@ namespace Microsoft.Python.Analysis.Core.DependencyResolution {
 
                 return new ImportNotFound(new StringBuilder(lastEdge.Start.Name)
                     .Append(".")
-                    .Append(fullNameList)
+                    .Append(".", fullNameList)
                     .ToString());
             }
 

--- a/src/Analysis/Core/Impl/DependencyResolution/RelativeImportBeyondTopLevel.cs
+++ b/src/Analysis/Core/Impl/DependencyResolution/RelativeImportBeyondTopLevel.cs
@@ -1,0 +1,23 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.Python.Analysis.Core.DependencyResolution {
+    public class RelativeImportBeyondTopLevel : IImportSearchResult {
+        public string RelativeImportName { get; }
+        public RelativeImportBeyondTopLevel(string relativeImportName) {
+            RelativeImportName = relativeImportName;
+        }
+    }
+}

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -904,6 +904,26 @@ os.path.
         }
 
         [TestMethod, Priority(0)]
+        public async Task FromDotInRootWithInitPy() {
+            var initPyPath = TestData.GetTestSpecificUri("__init__.py");
+            var module1Path = TestData.GetTestSpecificUri("module1.py");
+
+            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
+            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            var rdt = Services.GetService<IRunningDocumentTable>();
+
+            rdt.OpenDocument(initPyPath, string.Empty);
+            var module1 = rdt.OpenDocument(module1Path, "from .");
+            module1.Interpreter.ModuleResolution.GetOrLoadModule("__init__");
+
+            var analysis = await module1.GetAnalysisAsync(-1);
+
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 7));
+            result.Should().HaveNoCompletion();
+        }
+
+        [TestMethod, Priority(0)]
         public async Task FromDotInExplicitPackage() {
             var initPyPath = TestData.GetTestSpecificUri("package", "__init__.py");
             var module1Path = TestData.GetTestSpecificUri("package", "module1.py");

--- a/src/Parsing/Test/PythonVersions.cs
+++ b/src/Parsing/Test/PythonVersions.cs
@@ -36,12 +36,16 @@ namespace Microsoft.Python.Parsing.Tests {
         public static readonly InterpreterConfiguration Anaconda27_x64 = GetAnacondaVersion(PythonLanguageVersion.V27, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration Anaconda36 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x86);
         public static readonly InterpreterConfiguration Anaconda36_x64 = GetAnacondaVersion(PythonLanguageVersion.V36, InterpreterArchitecture.x64);
+        public static readonly InterpreterConfiguration Anaconda37 = GetAnacondaVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x86);
+        public static readonly InterpreterConfiguration Anaconda37_x64 = GetAnacondaVersion(PythonLanguageVersion.V37, InterpreterArchitecture.x64);
         public static readonly InterpreterConfiguration IronPython27_x64 = GetIronPythonVersion(true);
         public static readonly InterpreterConfiguration Jython27 = GetJythonVersion(PythonLanguageVersion.V27);
 
         public static IEnumerable<InterpreterConfiguration> AnacondaVersions => GetVersions(
             Anaconda36,
             Anaconda36_x64,
+            Anaconda37,
+            Anaconda37_x64,
             Anaconda27,
             Anaconda27_x64);
 
@@ -82,6 +86,8 @@ namespace Microsoft.Python.Parsing.Tests {
             Python27_x64).FirstOrDefault() ?? NotInstalled("v2");
 
         public static InterpreterConfiguration LatestAnaconda3X => GetVersions(
+            Anaconda37,
+            Anaconda37_x64,
             Anaconda36,
             Anaconda36_x64).FirstOrDefault() ?? NotInstalled("Anaconda v3");
 

--- a/src/Parsing/Test/PythonVersions.cs
+++ b/src/Parsing/Test/PythonVersions.cs
@@ -81,6 +81,14 @@ namespace Microsoft.Python.Parsing.Tests {
             Python27,
             Python27_x64).FirstOrDefault() ?? NotInstalled("v2");
 
+        public static InterpreterConfiguration LatestAnaconda3X => GetVersions(
+            Anaconda36,
+            Anaconda36_x64).FirstOrDefault() ?? NotInstalled("Anaconda v3");
+
+        public static InterpreterConfiguration LatestAnaconda2X => GetVersions(
+            Anaconda27,
+            Anaconda27_x64).FirstOrDefault() ?? NotInstalled("Anaconda v2");
+
         public static InterpreterConfiguration EarliestAvailable => EarliestAvailable2X ?? EarliestAvailable3X;
 
         public static InterpreterConfiguration EarliestAvailable3X => GetVersions(


### PR DESCRIPTION
Also:
- fixed messaging for relative imports that go beyond top-level 
- made amount of tasks in `PythonAnalyzer` dependent on the number of CPU cores