### PR TITLE
Couple of test related fixes

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -107,8 +107,12 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
         public void InvalidateAnalysis(IPythonModule module) {
             lock (_syncObj) {
-                if (_analysisEntries.TryGetValue(new AnalysisModuleKey(module), out var entry)) {
+                var key = new AnalysisModuleKey(module);
+                if (_analysisEntries.TryGetValue(key, out var entry)) {
                     entry.Invalidate(_version + 1);
+                } else {
+                    _analysisEntries[key] = new PythonAnalyzerEntry(new EmptyAnalysis(_services, (IDocument)module));
+                    _analysisCompleteEvent.Reset();
                 }
             }
         }
@@ -147,9 +151,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
                         return;
                     }
                 } else {
-                    _analysisCompleteEvent.Reset();
                     entry = new PythonAnalyzerEntry(new EmptyAnalysis(_services, (IDocument)module));
                     _analysisEntries[key] = entry;
+                    _analysisCompleteEvent.Reset();
                 }
             }
 

--- a/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
@@ -35,18 +35,21 @@ namespace Microsoft.Python.Analysis.Documents {
         private readonly Dictionary<string, DocumentEntry> _documentsByName = new Dictionary<string, DocumentEntry>();
         private readonly IServiceContainer _services;
         private readonly object _lock = new object();
-        private readonly string _workspaceRoot;
 
         private IModuleManagement _moduleManagement;
         private IModuleManagement ModuleManagement => _moduleManagement ?? (_moduleManagement = _services.GetService<IPythonInterpreter>().ModuleResolution);
 
         private class DocumentEntry {
-            public IDocument Document;
+            public readonly IDocument Document;
             public int LockCount;
+
+            public DocumentEntry(IDocument document) {
+                Document = document;
+                LockCount = 0;
+            }
         }
 
-        public RunningDocumentTable(string workspaceRoot, IServiceContainer services) {
-            _workspaceRoot = workspaceRoot;
+        public RunningDocumentTable(IServiceContainer services) {
             _services = services;
         }
 
@@ -205,7 +208,7 @@ namespace Microsoft.Python.Analysis.Documents {
                     throw new InvalidOperationException($"CreateDocument does not support module type {mco.ModuleType}");
             }
 
-            var entry = new DocumentEntry { Document = document, LockCount = 0 };
+            var entry = new DocumentEntry(document);
             _documentsByUri[document.Uri] = entry;
             _documentsByName[mco.ModuleName] = entry;
             return entry;

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -213,13 +213,18 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         private void InitializeContent(string content) {
+            bool startParse;
             lock (AnalysisLock) {
                 LoadContent(content);
 
-                var startParse = ContentState < State.Parsing && _parsingTask == null;
+                startParse = ContentState < State.Parsing && _parsingTask == null;
                 if (startParse) {
                     Parse();
                 }
+            }
+
+            if (startParse) {
+                Services.GetService<IPythonAnalyzer>().InvalidateAnalysis(this);
             }
         }
 

--- a/src/Analysis/Ast/Test/AnalysisTestBase.cs
+++ b/src/Analysis/Ast/Test/AnalysisTestBase.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Python.Analysis.Tests {
             sm.AddService(interpreter);
 
             TestLogger.Log(TraceEventType.Information, "Create RunningDocumentTable");
-            var documentTable = new RunningDocumentTable(root, sm);
+            var documentTable = new RunningDocumentTable(sm);
             sm.AddService(documentTable);
 
             return sm;

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             var analyzer = new PythonAnalyzer(_services);
             _services.AddService(analyzer);
 
-            _services.AddService(new RunningDocumentTable(@params.rootPath, _services));
+            _services.AddService(new RunningDocumentTable(_services));
             _rdt = _services.GetService<IRunningDocumentTable>();
 
             // TODO: multi-root workspaces.

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Analysis;
+using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
@@ -949,12 +950,14 @@ os.path.
             var root = TestData.GetTestSpecificRootUri().AbsolutePath;
             await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
+            var analyzer = Services.GetService<IPythonAnalyzer>();
 
             rdt.OpenDocument(initPyPath, "answer = 42");
             var module = rdt.OpenDocument(module1Path, "from .");
             rdt.OpenDocument(module2Path, string.Empty);
             rdt.OpenDocument(module3Path, string.Empty);
 
+            await analyzer.WaitForCompleteAnalysisAsync();
             var analysis = await module.GetAnalysisAsync(-1);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 

--- a/src/LanguageServer/Test/ImportsTests.cs
+++ b/src/LanguageServer/Test/ImportsTests.cs
@@ -147,11 +147,12 @@ VALUE = 42";
             var root = TestData.GetTestSpecificRootUri().AbsolutePath;
             await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
+            var analyzer = Services.GetService<IPythonAnalyzer>();
 
             var doc1 = rdt.OpenDocument(uri1, content1);
             rdt.OpenDocument(uri2, content2);
             rdt.OpenDocument(uri3, content3);
-
+            await analyzer.WaitForCompleteAnalysisAsync();
             var analysis = await doc1.GetAnalysisAsync(-1);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
@@ -252,6 +253,7 @@ mod2.B.";
             await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
 
             var rdt = Services.GetService<IRunningDocumentTable>();
+            var analyzer = Services.GetService<IPythonAnalyzer>();
             var interpreter = Services.GetService<IPythonInterpreter>();
             interpreter.ModuleResolution.SetUserSearchPaths(new[] { folder1, folder2 });
 
@@ -260,6 +262,7 @@ mod2.B.";
 
             var mainPath = Path.Combine(root, "main.py");
             var doc = rdt.OpenDocument(new Uri(mainPath), mainContent);
+            await analyzer.WaitForCompleteAnalysisAsync();
             var analysis = await doc.GetAnalysisAsync(-1);
 
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);

--- a/src/LanguageServer/Test/RdtTests.cs
+++ b/src/LanguageServer/Test/RdtTests.cs
@@ -78,8 +78,6 @@ namespace Microsoft.Python.LanguageServer.Tests {
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             rdt.OpenDocument(uri1, "from LockCount1 import *");
-            var doc = rdt.GetDocument(uri1);
-            await doc.GetAstAsync(CancellationToken.None);
             await Services.GetService<IPythonAnalyzer>().WaitForCompleteAnalysisAsync();
 
             var docLc1 = rdt.First(d => d.Name.Contains("LockCount1"));
@@ -110,8 +108,6 @@ namespace Microsoft.Python.LanguageServer.Tests {
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             rdt.OpenDocument(uri, "from LockCount1 import *");
-            var doc = rdt.GetDocument(uri);
-            await doc.GetAstAsync(CancellationToken.None);
             await Services.GetService<IPythonAnalyzer>().WaitForCompleteAnalysisAsync();
 
             var docLc1 = rdt.First(d => d.Name.Contains("LockCount1"));


### PR DESCRIPTION
- IPythonAnalyzer.InvalidateAnalysis is now called when first parse happens
- Fixes for tests that require final analysis while user module (created by RDT.OpenDocument) can have intermediate analysis