### PR TITLE
Split searchPaths by semicolon to work around extension before config cleanup

### DIFF
--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             // TODO: multi-root workspaces.
             var rootDir = @params.rootUri != null ? @params.rootUri.ToAbsolutePath() : PathUtils.NormalizePath(@params.rootPath);
             var configuration = InterpreterConfiguration.FromDictionary(@params.initializationOptions.interpreter.properties);
-            configuration.SearchPaths = @params.initializationOptions.searchPaths;
+            configuration.SearchPaths = @params.initializationOptions.searchPaths.Select(p => p.Split(';')).SelectMany().Where(p => !string.IsNullOrEmpty(p)).ToList();
             configuration.TypeshedPath = @params.initializationOptions.typeStubSearchPaths.FirstOrDefault();
 
             _interpreter = await PythonInterpreter.CreateAsync(configuration, rootDir, _services, cancellationToken);

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             // TODO: multi-root workspaces.
             var rootDir = @params.rootUri != null ? @params.rootUri.ToAbsolutePath() : PathUtils.NormalizePath(@params.rootPath);
             var configuration = InterpreterConfiguration.FromDictionary(@params.initializationOptions.interpreter.properties);
-            configuration.SearchPaths = @params.initializationOptions.searchPaths.Select(p => p.Split(';')).SelectMany().Where(p => !string.IsNullOrEmpty(p)).ToList();
+            configuration.SearchPaths = @params.initializationOptions.searchPaths.Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany().ToList();
             configuration.TypeshedPath = @params.initializationOptions.typeStubSearchPaths.FirstOrDefault();
 
             _interpreter = await PythonInterpreter.CreateAsync(configuration, rootDir, _services, cancellationToken);


### PR DESCRIPTION
Temporary fix until these configurations and the extension are cleaned up together.