### PR TITLE
Simpler creation of FileSystemProxy in EnumerateFileSystemInfos

### DIFF
--- a/src/Core/Impl/IO/DirectoryInfoProxy.cs
+++ b/src/Core/Impl/IO/DirectoryInfoProxy.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Python.Core.IO {
             var matcher = GetMatcher(includePatterns, excludePatterns);
             PatternMatchingResult matchResult = SafeExecuteMatcher(matcher);
             return matchResult.Files.Select((filePatternMatch) => {
-                return CreateFileSystemInfoProxy(new FileInfo(filePatternMatch.Path));
+                var path = PathUtils.NormalizePath(filePatternMatch.Path);
+                return CreateFileSystemInfoProxy(new FileInfo(path));
             });
         }
 

--- a/src/Core/Impl/IO/DirectoryInfoProxy.cs
+++ b/src/Core/Impl/IO/DirectoryInfoProxy.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Python.Core.IO {
             var matcher = GetMatcher(includePatterns, excludePatterns);
             PatternMatchingResult matchResult = SafeExecuteMatcher(matcher);
             return matchResult.Files.Select((filePatternMatch) => {
-                var fileSystemInfo = _directoryInfo.GetFileSystemInfos(filePatternMatch.Stem).First();
-                return CreateFileSystemInfoProxy(fileSystemInfo);
+                return CreateFileSystemInfoProxy(new FileInfo(filePatternMatch.Path));
             });
         }
 


### PR DESCRIPTION
Fixes #791 .
Creates a FileInfo directly from a file path instead of relying on GetFileSystemInfos.
