### PR TITLE
Remove colon split

### DIFF
--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             ) {
                 // TODO: Remove this split once the extension is updated and no longer passes the interpreter search paths directly.
                 // This is generally harmless to keep around.
-                SearchPaths = @params.initializationOptions.searchPaths.Select(p => p.Split(new[] { ';', ':' }, StringSplitOptions.RemoveEmptyEntries)).SelectMany().ToList(),
+                SearchPaths = @params.initializationOptions.searchPaths.Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany().ToList(),
                 TypeshedPath = @params.initializationOptions.typeStubSearchPaths.FirstOrDefault()
             };
 


### PR DESCRIPTION
I forgot that `:` appears in `C:\`. I'm going to merge this immediately so we can get a build out with a fix.

Fixes #801.