### PR TITLE
Log when interpreter is not found

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
         private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
                 _log?.Log(TraceEventType.Warning, "Interpreter does not exist:", Configuration.InterpreterPath);
-                _ui?.ShowMessageAsync($"Interpreter does not exist; analysis will not be available. See the output panel for more information.", TraceEventType.Error);
+                _ui?.ShowMessageAsync(Resources.InterpreterNotFound, TraceEventType.Error);
                 return Array.Empty<string>();
             }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
                 return paths.MaybeEnumerate().Select(p => p.Path).ToArray();
             } catch (InvalidOperationException ex) {
                 _log?.Log(TraceEventType.Warning, "Exception getting search paths", ex);
-                _ui?.ShowMessageAsync($"An exception occured while discovering search paths; analysis will not be available. See the output panel for more information.", TraceEventType.Error);
+                _ui?.ShowMessageAsync(Resources.ExceptionGettingSearchPaths, TraceEventType.Error);
                 return Array.Empty<string>();
             }
         }

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
         private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
                 _log?.Log(TraceEventType.Warning, "Interpreter does not exist:", Configuration.InterpreterPath);
-                _ui?.ShowMessageAsync($"Interpreter does not exist; analysis may not be available. See the output panel for more information.", TraceEventType.Warning);
+                _ui?.ShowMessageAsync($"Interpreter does not exist; analysis will not be available. See the output panel for more information.", TraceEventType.Error);
                 return Array.Empty<string>();
             }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
                 return paths.MaybeEnumerate().Select(p => p.Path).ToArray();
             } catch (InvalidOperationException ex) {
                 _log?.Log(TraceEventType.Warning, "Exception getting search paths", ex);
-                _ui?.ShowMessageAsync($"An exception occured while getting the search paths; analysis may not be available. See the output panel for more information.", TraceEventType.Warning);
+                _ui?.ShowMessageAsync($"An exception occured while discovering search paths; analysis will not be available. See the output panel for more information.", TraceEventType.Error);
                 return Array.Empty<string>();
             }
         }

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
         private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
-                _log?.Log(TraceEventType.Information, "Interpreter does not exist:", Configuration.InterpreterPath);
+                _log?.Log(TraceEventType.Error, "Interpreter does not exist:", Configuration.InterpreterPath);
                 return Array.Empty<string>();
             }
 

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
         private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
-                _log?.Log(TraceEventType.Error, "Interpreter does not exist:", Configuration.InterpreterPath);
+                _log?.Log(TraceEventType.Warning, "Interpreter does not exist:", Configuration.InterpreterPath);
                 return Array.Empty<string>();
             }
 
@@ -146,7 +146,8 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
                 var paths = await PythonLibraryPath.GetSearchPathsAsync(Configuration, fs, ps, cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
                 return paths.MaybeEnumerate().Select(p => p.Path).ToArray();
-            } catch (InvalidOperationException) {
+            } catch (InvalidOperationException ex) {
+                _log?.Log(TraceEventType.Warning, "Exception getting search paths", ex);
                 return Array.Empty<string>();
             }
         }

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
         private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
                 _log?.Log(TraceEventType.Warning, "Interpreter does not exist:", Configuration.InterpreterPath);
+                _ui?.ShowMessageAsync($"Interpreter does not exist; analysis may not be available. See the output panel for more information.", TraceEventType.Warning);
                 return Array.Empty<string>();
             }
 
@@ -148,6 +149,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
                 return paths.MaybeEnumerate().Select(p => p.Path).ToArray();
             } catch (InvalidOperationException ex) {
                 _log?.Log(TraceEventType.Warning, "Exception getting search paths", ex);
+                _ui?.ShowMessageAsync($"An exception occured while getting the search paths; analysis may not be available. See the output panel for more information.", TraceEventType.Warning);
                 return Array.Empty<string>();
             }
         }

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -135,6 +135,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
         private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
+                _log?.Log(TraceEventType.Information, "Interpreter does not exist:", Configuration.InterpreterPath);
                 return Array.Empty<string>();
             }
 

--- a/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
@@ -25,6 +25,7 @@ using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.IO;
 using Microsoft.Python.Core.Logging;
+using Microsoft.Python.Core.Services;
 
 namespace Microsoft.Python.Analysis.Modules.Resolution {
     internal abstract class ModuleResolutionBase {
@@ -32,6 +33,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
         protected readonly IPythonInterpreter _interpreter;
         protected readonly IFileSystem _fs;
         protected readonly ILogger _log;
+        protected readonly IUIService _ui;
         protected readonly bool _requireInitPy;
         protected string _root;
 
@@ -46,6 +48,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             _interpreter = services.GetService<IPythonInterpreter>();
             _fs = services.GetService<IFileSystem>();
             _log = services.GetService<ILogger>();
+            _ui = services.GetService<IUIService>();
 
             _requireInitPy = ModulePath.PythonVersionRequiresInitPyFiles(_interpreter.Configuration.Version);
         }

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -196,6 +196,24 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An exception occured while discovering search paths; analysis will not be available..
+        /// </summary>
+        internal static string ExceptionGettingSearchPaths {
+            get {
+                return ResourceManager.GetString("ExceptionGettingSearchPaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interpreter does not exist; analysis will not be available..
+        /// </summary>
+        internal static string InterpreterNotFound {
+            get {
+                return ResourceManager.GetString("InterpreterNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The number of empty lines to include between class or function declarations at the top level of a module..
         /// </summary>
         internal static string LinesBetweenLevelDeclarationsLong {

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -348,4 +348,10 @@
   <data name="UndefinedVariable" xml:space="preserve">
     <value>Undefined variable: '{0}'</value>
   </data>
+  <data name="ExceptionGettingSearchPaths" xml:space="preserve">
+    <value>An exception occured while discovering search paths; analysis will not be available.</value>
+  </data>
+  <data name="InterpreterNotFound" xml:space="preserve">
+    <value>Interpreter does not exist; analysis will not be available.</value>
+  </data>
 </root>


### PR DESCRIPTION
For #809.

If this happens we probably need some better handling, but we should at least print something.

I made it an error, which steals focus as in #810. I can change it to info or similar, but the LS will likely fail to initialize when there is no interpreter (at the moment).