### PR TITLE
Silence scraper stderr

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/CompiledPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/CompiledPythonModule.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Python.Analysis.Modules {
                 CreateNoWindow = true,
                 StandardOutputEncoding = Encoding.UTF8,
                 RedirectStandardInput = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             };
             var ps = Services.GetService<IProcessServices>();
 

--- a/src/Core/Impl/OS/PlatformProcess.cs
+++ b/src/Core/Impl/OS/PlatformProcess.cs
@@ -19,29 +19,30 @@ using System.IO;
 
 namespace Microsoft.Python.Core.OS {
     public sealed class PlatformProcess : IProcess {
-        private readonly Process _process;
+        public Process Process { get; private set; }
+
         private readonly IProcessServices _ps;
         public PlatformProcess(IProcessServices ps, Process process) {
             _ps = ps;
-            _process = process;
+            Process = process;
         }
 
-        public int Id => _process.Id;
-        public StreamWriter StandardInput => _process.StandardInput;
-        public StreamReader StandardOutput => _process.StandardOutput;
-        public StreamReader StandardError => _process.StandardError;
-        public bool HasExited => _process.HasExited;
-        public int ExitCode => _process.ExitCode;
+        public int Id => Process.Id;
+        public StreamWriter StandardInput => Process.StandardInput;
+        public StreamReader StandardOutput => Process.StandardOutput;
+        public StreamReader StandardError => Process.StandardError;
+        public bool HasExited => Process.HasExited;
+        public int ExitCode => Process.ExitCode;
 
         public event EventHandler Exited {
             add {
-                _process.EnableRaisingEvents = true;
-                _process.Exited += value;
+                Process.EnableRaisingEvents = true;
+                Process.Exited += value;
             }
-            remove => _process.Exited -= value;
+            remove => Process.Exited -= value;
         }
 
-        public bool WaitForExit(int milliseconds) => _process.WaitForExit(milliseconds);
-        public void Dispose() => _process.Dispose();
+        public bool WaitForExit(int milliseconds) => Process.WaitForExit(milliseconds);
+        public void Dispose() => Process.Dispose();
     }
 }

--- a/src/Core/Impl/OS/ProcessServices.cs
+++ b/src/Core/Impl/OS/ProcessServices.cs
@@ -40,6 +40,12 @@ namespace Microsoft.Python.Core.OS {
         public async Task<string> ExecuteAndCaptureOutputAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken = default) {
             var output = string.Empty;
             var process = Start(startInfo);
+
+            if (startInfo.RedirectStandardError && process is PlatformProcess p) {
+                p.Process.ErrorDataReceived += new DataReceivedEventHandler((s, e) => { });
+                p.Process.BeginErrorReadLine();
+            }
+
             try {
                 output = await process.StandardOutput.ReadToEndAsync();
                 await process.WaitForExitAsync(30000, cancellationToken);


### PR DESCRIPTION
Fixes #817.

This was more complicated than just asking to redirect stderr, as it needs to be read asynchronously to prevent a deadlock while reading both stderr and stdout.