### PR TITLE
Changing Expression's nodenames

### DIFF
--- a/src/Parsing/Impl/Ast/BackQuoteExpression.cs
+++ b/src/Parsing/Impl/Ast/BackQuoteExpression.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public Expression Expression { get; }
 
+        public override string NodeName => "string conversion";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Expression != null) yield return Expression;
         }

--- a/src/Parsing/Impl/Ast/CallExpression.cs
+++ b/src/Parsing/Impl/Ast/CallExpression.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         internal override string CheckDelete() => "can't delete function call";
 
+        public override string NodeName => "function call";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Target != null) yield return Target;
             foreach (var arg in Args) {

--- a/src/Parsing/Impl/Ast/ErrorExpression.cs
+++ b/src/Parsing/Impl/Ast/ErrorExpression.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public ErrorExpression(string verbatimImage, Expression preceding) : this(verbatimImage, preceding, null) { }
 
+        public override string NodeName => "error expression";
+
         public ErrorExpression AddPrefix(string verbatimImage, Expression preceding) => new ErrorExpression(verbatimImage, preceding, this);
 
         public string VerbatimImage => _verbatimImage;

--- a/src/Parsing/Impl/Ast/FString.cs
+++ b/src/Parsing/Impl/Ast/FString.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public readonly string Unparsed;
 
+        public override string NodeName => "f-string expression";
+
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
                 foreach (var child in _children) {

--- a/src/Parsing/Impl/Ast/FormatSpecifier.cs
+++ b/src/Parsing/Impl/Ast/FormatSpecifier.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public readonly string Unparsed;
 
+        public override string NodeName => "format specifier";
+
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
                 foreach (var child in _children) {

--- a/src/Parsing/Impl/Ast/IndexExpression.cs
+++ b/src/Parsing/Impl/Ast/IndexExpression.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         internal override string CheckDelete() => null;
 
+        public override string NodeName => "subscript";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Target != null) yield return Target;
             if (Index != null) yield return Index;

--- a/src/Parsing/Impl/Ast/LambdaExpression.cs
+++ b/src/Parsing/Impl/Ast/LambdaExpression.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public FunctionDefinition Function { get; }
 
+        public override string NodeName => "lambda";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Function != null) yield return Function;
         }

--- a/src/Parsing/Impl/Ast/MemberExpression.cs
+++ b/src/Parsing/Impl/Ast/MemberExpression.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         internal override string CheckDelete() => null;
 
+        public override string NodeName => "attribute";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Target != null) yield return Target;
         }

--- a/src/Parsing/Impl/Ast/NameExpression.cs
+++ b/src/Parsing/Impl/Ast/NameExpression.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Python.Parsing.Ast {
         public override string ToString() => base.ToString() + ":" + Name;
         internal override string CheckAssign() => null;
         internal override string CheckDelete() => null;
+        public override string NodeName => "name";
 
         public override IEnumerable<Node> GetChildNodes() => Enumerable.Empty<Node>();
 

--- a/src/Parsing/Impl/Ast/ParenthesisExpression.cs
+++ b/src/Parsing/Impl/Ast/ParenthesisExpression.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         internal override string CheckDelete() => Expression.CheckDelete();
 
+        public override string NodeName => "parenthesized expression";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Expression != null) yield return Expression;
         }

--- a/src/Parsing/Impl/Ast/SequenceExpression.cs
+++ b/src/Parsing/Impl/Ast/SequenceExpression.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         internal override string CheckAugmentedAssign() => "illegal expression for augmented assignment";
 
+        public override string NodeName => "sequence";
+
         private static bool IsComplexAssignment(Expression expr) => !(expr is NameExpression);
     }
 }

--- a/src/Parsing/Impl/Ast/SliceExpression.cs
+++ b/src/Parsing/Impl/Ast/SliceExpression.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Python.Parsing.Ast {
         /// </summary>
         public bool StepProvided { get; }
 
+        public override string NodeName => "slice";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (SliceStart != null) yield return SliceStart;
             if (SliceStop != null) yield return SliceStop;

--- a/src/Parsing/Impl/Ast/StarredExpression.cs
+++ b/src/Parsing/Impl/Ast/StarredExpression.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public int StarCount { get; }
 
+        public override string NodeName => "starred";
+
         public override IEnumerable<Node> GetChildNodes() {
             yield return Expression;
         }

--- a/src/Parsing/Impl/Ast/YieldFromExpression.cs
+++ b/src/Parsing/Impl/Ast/YieldFromExpression.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public Expression Expression { get; }
 
+        public override string NodeName => "yield from expression";
+
         public override IEnumerable<Node> GetChildNodes() {
             if (Expression != null) yield return Expression;
         }

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -1256,7 +1256,7 @@ namespace Microsoft.Python.Parsing.Tests {
                     new ErrorInfo("invalid syntax", 7, 1, 8, 8, 1, 9),
                     new ErrorInfo("unexpected token '<newline>'", 8, 1, 9, 10, 2, 1),
                     new ErrorInfo("unexpected token 'as'", 10, 2, 1, 12, 2, 3),
-                    new ErrorInfo("can't assign to ErrorExpression", 10, 2, 1, 12, 2, 3)
+                    new ErrorInfo("can't assign to error expression", 10, 2, 1, 12, 2, 3)
                 );
             }
         }


### PR DESCRIPTION
All nodes have a default NodeName implementation, which is just the type's name.
Nodenames can be used to report syntax errors. (See for example ExpressionWithAnnotation.cs) 
I will use them to report syntax errors related to named expressions.

This PR implements missing nodenames so that errors match what CPython prints.
