### PR TITLE
Work around KeyNotFound exception

### DIFF
--- a/src/LanguageServer/Impl/Indexing/SymbolIndex.cs
+++ b/src/LanguageServer/Impl/Indexing/SymbolIndex.cs
@@ -84,7 +84,9 @@ namespace Microsoft.Python.LanguageServer.Indexing {
         }
 
         public void MarkAsPending(string path) {
-            _index[path].MarkAsPending();
+            if (_index.TryGetValue(path, out var mostRecentDocSymbols)) {
+                mostRecentDocSymbols.MarkAsPending();
+            }
         }
 
         private IEnumerable<FlatSymbol> WorkspaceSymbolsQuery(string path, string query,


### PR DESCRIPTION
Fixes #852.

Not sure why this would be called before an `Add` or similar were to add the doc, but this will at least stop the exceptions from happening.