### PR TITLE
Handle complex left side of assignment in SymbolIndexWalker

### DIFF
--- a/src/LanguageServer/Impl/Indexing/SymbolIndexWalker.cs
+++ b/src/LanguageServer/Impl/Indexing/SymbolIndexWalker.cs
@@ -125,14 +125,7 @@ namespace Microsoft.Python.LanguageServer.Indexing {
         public override bool Walk(AssignmentStatement node) {
             node.Right?.Walk(this);
             foreach (var exp in node.Left) {
-                switch (exp) {
-                    case ExpressionWithAnnotation ewa when ewa.Expression is NameExpression ne:
-                        AddVarSymbol(ne);
-                        break;
-                    case NameExpression ne:
-                        AddVarSymbol(ne);
-                        break;
-                }
+                AddVarSymbolRecursive(exp);
             }
 
             return false;
@@ -250,7 +243,12 @@ namespace Microsoft.Python.LanguageServer.Indexing {
                 case NameExpression ne:
                     AddVarSymbol(ne);
                     return;
-
+                case ExpressionWithAnnotation ewa:
+                    AddVarSymbolRecursive(ewa.Expression);
+                    return;
+                case ParenthesisExpression parenExpr:
+                    AddVarSymbolRecursive(parenExpr.Expression);
+                    return;
                 case SequenceExpression se:
                     foreach (var item in se.Items.MaybeEnumerate()) {
                         AddVarSymbolRecursive(item);

--- a/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
+++ b/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
@@ -52,6 +52,16 @@ z = y";
         }
 
         [TestMethod, Priority(0)]
+        public void WalkerAssignmentsParenthesized() {
+            var code = @"(x) = 1";
+
+            var symbols = WalkSymbols(code);
+            symbols.Should().BeEquivalentToWithStrictOrdering(new[] {
+                new HierarchicalSymbol("x", SymbolKind.Variable, new SourceSpan(1, 2, 1, 3)),
+            });
+        }
+
+        [TestMethod, Priority(0)]
         public void WalkerMultipleAssignments() {
             var code = @"x = y = z = 1";
 
@@ -241,6 +251,18 @@ from os.path import ( join as osjoin2, exists as osexists, expanduser )
                         new HierarchicalSymbol("x", SymbolKind.Variable, new SourceSpan(2, 24, 2, 25)),
                     }, FunctionKind.Function),
                 }, FunctionKind.Class),
+            });
+        }
+
+        [TestMethod, Priority(0)]
+        public void WalkerComplexAssignmentLeftHand() {
+            var code = @"(x, [y, z]) = (1, [2, 3])";
+
+            var symbols = WalkSymbols(code);
+            symbols.Should().BeEquivalentToWithStrictOrdering(new[] {
+                new HierarchicalSymbol("x", SymbolKind.Variable, new SourceSpan(1, 2, 1, 3)),
+                new HierarchicalSymbol("y", SymbolKind.Variable, new SourceSpan(1, 6, 1, 7)),
+                new HierarchicalSymbol("z", SymbolKind.Variable, new SourceSpan(1, 9, 1, 10)),
             });
         }
 


### PR DESCRIPTION
Calling AddVarSymbolRecursive on each left side when we walk an AssignmentStatement.
I add handling of ExpressionWithAnnotation and ParenthesisExpression to this method.
Fixes #859 .