### PR TITLE
Send telemetry event on analysis complete

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -144,39 +144,39 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 if (!isCanceled) {
                     _progress.ReportRemaining(walker.Remaining);
                 }
+            }
 
-                var elapsed = stopWatch.Elapsed.TotalMilliseconds;
+            var elapsed = stopWatch.Elapsed.TotalMilliseconds;
 
-                if (_telemetry != null && remaining == 0 && originalRemaining > 100) {
-                    double privateMB;
-                    double peakPagedMB;
+            if (_telemetry != null && remaining == 0 && originalRemaining > 100) {
+                double privateMB;
+                double peakPagedMB;
 
-                    using (var proc = Process.GetCurrentProcess()) {
-                        privateMB = proc.PrivateMemorySize64 / 1e+6;
-                        peakPagedMB = proc.PeakPagedMemorySize64 / 1e+6;
-                    }
-
-                    var e = new TelemetryEvent() {
-                        EventName = "analysis_complete",
-                    };
-
-                    e.Measurements["privateMB"] = privateMB;
-                    e.Measurements["peakPagedMB"] = peakPagedMB;
-                    e.Measurements["elapsedMs"] = elapsed;
-                    e.Measurements["entries"] = originalRemaining;
-                    e.Measurements["version"] = walker.Version;
-
-                    _telemetry.SendTelemetryAsync(e).DoNotWait();
+                using (var proc = Process.GetCurrentProcess()) {
+                    privateMB = proc.PrivateMemorySize64 / 1e+6;
+                    peakPagedMB = proc.PeakPagedMemorySize64 / 1e+6;
                 }
 
-                if (_log != null) {
-                    if (remaining == 0) {
-                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been completed in {elapsed} ms.");
-                    } else if (remaining < originalRemaining) {
-                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} has been completed in {stopWatch.Elapsed.TotalMilliseconds} ms with {originalRemaining - remaining} entries analyzed and {remaining} entries skipped.");
-                    } else {
-                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been canceled after {elapsed}.");
-                    }
+                var e = new TelemetryEvent() {
+                    EventName = "analysis_complete",
+                };
+
+                e.Measurements["privateMB"] = privateMB;
+                e.Measurements["peakPagedMB"] = peakPagedMB;
+                e.Measurements["elapsedMs"] = elapsed;
+                e.Measurements["entries"] = originalRemaining;
+                e.Measurements["version"] = walker.Version;
+
+                _telemetry.SendTelemetryAsync(e).DoNotWait();
+            }
+
+            if (_log != null) {
+                if (remaining == 0) {
+                    _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been completed in {elapsed} ms.");
+                } else if (remaining < originalRemaining) {
+                    _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} has been completed in {stopWatch.Elapsed.TotalMilliseconds} ms with {originalRemaining - remaining} entries analyzed and {remaining} entries skipped.");
+                } else {
+                    _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been canceled after {elapsed}.");
                 }
             }
         }

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private readonly IProgressReporter _progress;
         private readonly IPythonAnalyzer _analyzer;
         private readonly ILogger _log;
+        private readonly ITelemetryService _telemetry;
 
         private State _state;
         private bool _isCanceled;
@@ -63,7 +64,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             AsyncManualResetEvent analysisCompleteEvent,
             Action<Task> startNextSession,
             CancellationToken analyzerToken,
-            CancellationToken sessionToken, 
+            CancellationToken sessionToken,
             IDependencyChainWalker<AnalysisModuleKey, PythonAnalyzerEntry> walker,
             int version,
             PythonAnalyzerEntry entry) {
@@ -81,6 +82,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             _progress = progress;
             _analyzer = _services.GetService<IPythonAnalyzer>();
             _log = _services.GetService<ILogger>();
+            _telemetry = _services.GetService<ITelemetryService>();
         }
 
         public void Start(bool analyzeEntry) {
@@ -143,13 +145,37 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     _progress.ReportRemaining(walker.Remaining);
                 }
 
+                var elapsed = stopWatch.Elapsed.TotalMilliseconds;
+
+                if (_telemetry != null && remaining == 0 && originalRemaining > 100) {
+                    double privateMB;
+                    double peakPagedMB;
+
+                    using (var proc = Process.GetCurrentProcess()) {
+                        privateMB = proc.PrivateMemorySize64 / 1e+6;
+                        peakPagedMB = proc.PeakPagedMemorySize64 / 1e+6;
+                    }
+
+                    var e = new TelemetryEvent() {
+                        EventName = "analysis_complete",
+                    };
+
+                    e.Measurements["privateMB"] = privateMB;
+                    e.Measurements["peakPagedMB"] = peakPagedMB;
+                    e.Measurements["elapsedMs"] = elapsed;
+                    e.Measurements["entries"] = originalRemaining;
+                    e.Measurements["version"] = walker.Version;
+
+                    _telemetry.SendTelemetryAsync(e).DoNotWait();
+                }
+
                 if (_log != null) {
                     if (remaining == 0) {
-                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been completed in {stopWatch.Elapsed.TotalMilliseconds} ms.");
+                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been completed in {elapsed} ms.");
                     } else if (remaining < originalRemaining) {
                         _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} has been completed in {stopWatch.Elapsed.TotalMilliseconds} ms with {originalRemaining - remaining} entries analyzed and {remaining} entries skipped.");
                     } else {
-                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been canceled after {stopWatch.Elapsed.TotalMilliseconds}.");
+                        _log.Log(TraceEventType.Verbose, $"Analysis version {walker.Version} of {originalRemaining} entries has been canceled after {elapsed}.");
                     }
                 }
             }


### PR DESCRIPTION
Closes #851.

Using the same definition of "complete" as the log message. If it did fewer than 100 items, then nothing is sent to prevent spamming for every small change. Open to suggestions for another arbitrary condition instead.

I'd include the system memory, but that'd require a bunch of code to make it work cross platform (or waiting for dotnet/corefx#22660).