### PR TITLE
LineFormatter: Spaces around ':='

### DIFF
--- a/src/LanguageServer/Impl/Formatting/LineFormatter.cs
+++ b/src/LanguageServer/Impl/Formatting/LineFormatter.cs
@@ -197,7 +197,6 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                     case TokenKind.BitwiseAndEqual:
                     case TokenKind.BitwiseOrEqual:
                     case TokenKind.ExclusiveOrEqual:
-
                         AppendTokenEnsureWhiteSpacesAround(builder, token);
                         break;
 

--- a/src/LanguageServer/Impl/Formatting/LineFormatter.cs
+++ b/src/LanguageServer/Impl/Formatting/LineFormatter.cs
@@ -180,7 +180,6 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                         break;
 
                     case TokenKind.Assign:
-                    case TokenKind.ColonEqual:
                         AppendTokenEnsureWhiteSpacesAround(builder, token);
                         break;
 
@@ -198,6 +197,9 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                     case TokenKind.BitwiseAndEqual:
                     case TokenKind.BitwiseOrEqual:
                     case TokenKind.ExclusiveOrEqual:
+                    // Used in expressions as an operator
+                    case TokenKind.ColonEqual:
+
                         AppendTokenEnsureWhiteSpacesAround(builder, token);
                         break;
 

--- a/src/LanguageServer/Impl/Formatting/LineFormatter.cs
+++ b/src/LanguageServer/Impl/Formatting/LineFormatter.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                         break;
 
                     case TokenKind.Assign:
+                    case TokenKind.ColonEqual:
                         AppendTokenEnsureWhiteSpacesAround(builder, token);
                         break;
 

--- a/src/LanguageServer/Impl/Formatting/LineFormatter.cs
+++ b/src/LanguageServer/Impl/Formatting/LineFormatter.cs
@@ -197,8 +197,6 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                     case TokenKind.BitwiseAndEqual:
                     case TokenKind.BitwiseOrEqual:
                     case TokenKind.ExclusiveOrEqual:
-                    // Used in expressions as an operator
-                    case TokenKind.ColonEqual:
 
                         AppendTokenEnsureWhiteSpacesAround(builder, token);
                         break;
@@ -281,6 +279,7 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                     case TokenKind.NotEquals:
                     case TokenKind.LessThanGreaterThan:
                     case TokenKind.Arrow:
+                    case TokenKind.ColonEqual:
                         AppendTokenEnsureWhiteSpacesAround(builder, token);
                         break;
 

--- a/src/LanguageServer/Test/LineFormatterTests.cs
+++ b/src/LanguageServer/Test/LineFormatterTests.cs
@@ -371,6 +371,11 @@ limit { limit_num}; """"""", line: 5);
             AssertSingleLineFormat("'''\nfoo\n''' # comment", "  # comment", line: 2, editStart: 3);
         }
 
+        [TestMethod, Priority(0)]
+        public void NamedExpressions() {
+            AssertSingleLineFormat("if a:=1:", "if a := 1:", languageVersion: PythonLanguageVersion.V38);
+        }
+
         [DataRow("`a`")]
         [DataRow("foo(`a`)")]
         [DataRow("`a` if a else 'oops'")]


### PR DESCRIPTION
We treat ':=' the same as normal assignment operator.