### PR TITLE
Remove check for indexes in parser tests

### DIFF
--- a/src/Parsing/Impl/ErrorResult.cs
+++ b/src/Parsing/Impl/ErrorResult.cs
@@ -27,20 +27,5 @@ namespace Microsoft.Python.Parsing {
         public string Message { get; }
 
         public SourceSpan Span { get; }
-
-        public override bool Equals(object obj) {
-            if (!(obj is ErrorResult otherError)) {
-                return false;
-            }
-            return otherError.Message.Equals(Message) &&
-                otherError.Span.Equals(Span);
-        }
-
-        public override int GetHashCode() {
-            var hashCode = -954867195;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
-            hashCode = hashCode * -1521134295 + EqualityComparer<SourceSpan>.Default.GetHashCode(Span);
-            return hashCode;
-        }
     }
 }

--- a/src/Parsing/Impl/ErrorResult.cs
+++ b/src/Parsing/Impl/ErrorResult.cs
@@ -14,7 +14,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
 using Microsoft.Python.Core.Text;
 
 namespace Microsoft.Python.Parsing {

--- a/src/Parsing/Impl/ErrorResult.cs
+++ b/src/Parsing/Impl/ErrorResult.cs
@@ -14,6 +14,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Collections.Generic;
 using Microsoft.Python.Core.Text;
 
 namespace Microsoft.Python.Parsing {
@@ -26,5 +27,20 @@ namespace Microsoft.Python.Parsing {
         public string Message { get; }
 
         public SourceSpan Span { get; }
+
+        public override bool Equals(object obj) {
+            if (!(obj is ErrorResult otherError)) {
+                return false;
+            }
+            return otherError.Message.Equals(Message) &&
+                otherError.Span.Equals(Span);
+        }
+
+        public override int GetHashCode() {
+            var hashCode = -954867195;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
+            hashCode = hashCode * -1521134295 + EqualityComparer<SourceSpan>.Default.GetHashCode(Span);
+            return hashCode;
+        }
     }
 }

--- a/src/Parsing/Test/ErrorAssertions.cs
+++ b/src/Parsing/Test/ErrorAssertions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using FluentAssertions.Execution;
+using FluentAssertions.Formatting;
+using FluentAssertions.Primitives;
+
+namespace Microsoft.Python.Parsing.Tests {
+    internal static class ErrorResultArrayExtensions {
+        public static ErrorResultArrayAssertions Should(this ErrorResult[] instance) {
+            return new ErrorResultArrayAssertions(instance);
+        }
+    }
+
+    internal class ErrorResultArrayAssertions : CollectionAssertions<ErrorResult[], ErrorResultArrayAssertions> {
+        public ErrorResultArrayAssertions(ErrorResult[] instance) {
+            Subject = instance;
+        }
+
+        protected override string Identifier => "error result array";
+
+        public AndConstraint<ErrorResultArrayAssertions> HaveErrors(ErrorResult[] expected) {
+            for (var i = 0; i < expected.Length; i++) {
+                Execute.Assertion
+                    .ForCondition(Subject.Length > i)
+                    .FailWith("No error {0}: {1}", i, FormatError(expected[i]));
+
+                Execute.Assertion
+                    .ForCondition(Subject[i].Message == expected[i].Message)
+                    .FailWith("Wrong msg for error {0}: expected {1}, got {2}", i, FormatError(expected[i]), FormatError(Subject[i]));
+
+                Execute.Assertion
+                    .ForCondition(Subject[i].Span == expected[i].Span)
+                    .FailWith("Wrong span for error {0}: expected {1}, got {2}", i, FormatError(expected[i]), FormatError(Subject[i]));
+            }
+
+            Execute.Assertion
+                .ForCondition(expected.Length <= Subject.Length)
+                .FailWith("Unexpected errors occurred");
+
+            return new AndConstraint<ErrorResultArrayAssertions>(this);
+        }
+
+        private string FormatError(ErrorResult err) {
+            var s = err.Span.Start;
+            var e = err.Span.End;
+            return $"new ErrorResult(\"{err.Message}\", new SourceSpan({s.Line}, {s.Column}, {e.Line}, {e.Column}))";
+        }
+    }
+}

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -3696,21 +3696,7 @@ pass
             var finalErrors = foundErrors.ToString();
             Console.WriteLine(finalErrors);
 
-            for (var i = 0; i < errors.Length; i++) {
-                if (sink.Errors.Count <= i) {
-                    Assert.Fail("No error {0}: {1}", i, FormatError(errors[i]));
-                }
-                if (sink.Errors[i].Message != errors[i].Message) {
-                    Assert.Fail("Wrong msg for error {0}: expected {1}, got {2}", i, FormatError(errors[i]), FormatError(sink.Errors[i]));
-                }
-                if (sink.Errors[i].Span != errors[i].Span) {
-                    Assert.Fail("Wrong span for error {0}: expected {1}, got {2}", i, FormatError(errors[i]), FormatError(sink.Errors[i]));
-                }
-                Assert.AreEqual(sink.Errors[i], errors[i]);
-            }
-            if (sink.Errors.Count > errors.Length) {
-                Assert.Fail("Unexpected errors occurred");
-            }
+            sink.Errors.ToArray().Should().HaveErrors(errors);
         }
 
         private static PythonAst ParseFileNoErrors(string filename, PythonLanguageVersion version, Severity indentationInconsistencySeverity = Severity.Hint) {

--- a/src/Parsing/Test/TokenizerTest.cs
+++ b/src/Parsing/Test/TokenizerTest.cs
@@ -37,18 +37,11 @@ namespace Microsoft.Python.Parsing.Tests {
             }
         }
 
-        [DataTestMethod, Priority(0)]
-        [DataRow(true)]
-        [DataRow(false)]
-        public void NewLines(bool useCRLF) {
+        [TestMethod, Priority(0)]
+        public void CRLFNewLines() {
             foreach (var version in AllVersions) {
-                var code = @"
-x
-y
-";
-                if (!useCRLF) {
-                    code = code.Replace("\r\n", "\n");
-                }
+                var code = "\r\nx\r\ny\r\n";
+
                 var initialLocation = SourceLocation.MinValue;
                 var tokenizer = MakeTokenizer(version, TokenizerOptions.None, code,
                     initialLocation);
@@ -58,6 +51,23 @@ y
                 CheckAndReadNext(tokenizer, new IndexSpan(3, 2), TokenKind.NewLine);
                 CheckAndReadNext(tokenizer, new IndexSpan(5, 1), TokenKind.Name);
                 CheckAndReadNext(tokenizer, new IndexSpan(6, 2), TokenKind.NewLine);
+            }
+        }
+
+        [TestMethod, Priority(0)]
+        public void LFNewLines() {
+            foreach (var version in AllVersions) {
+                var code = "\nx\ny\n";
+
+                var initialLocation = SourceLocation.MinValue;
+                var tokenizer = MakeTokenizer(version, TokenizerOptions.None, code,
+                    initialLocation);
+
+                CheckAndReadNext(tokenizer, new IndexSpan(0, 1), TokenKind.NLToken);
+                CheckAndReadNext(tokenizer, new IndexSpan(1, 1), TokenKind.Name);
+                CheckAndReadNext(tokenizer, new IndexSpan(2, 1), TokenKind.NewLine);
+                CheckAndReadNext(tokenizer, new IndexSpan(3, 1), TokenKind.Name);
+                CheckAndReadNext(tokenizer, new IndexSpan(4, 1), TokenKind.NewLine);
             }
         }
 

--- a/src/Parsing/Test/TokenizerTest.cs
+++ b/src/Parsing/Test/TokenizerTest.cs
@@ -55,6 +55,23 @@ namespace Microsoft.Python.Parsing.Tests {
         }
 
         [TestMethod, Priority(0)]
+        public void CombineNewLines() {
+            foreach (var version in AllVersions) {
+                var code = "\r\nx\ny\r\n";
+
+                var initialLocation = SourceLocation.MinValue;
+                var tokenizer = MakeTokenizer(version, TokenizerOptions.None, code,
+                    initialLocation);
+
+                CheckAndReadNext(tokenizer, new IndexSpan(0, 2), TokenKind.NLToken);
+                CheckAndReadNext(tokenizer, new IndexSpan(2, 1), TokenKind.Name);
+                CheckAndReadNext(tokenizer, new IndexSpan(3, 1), TokenKind.NewLine);
+                CheckAndReadNext(tokenizer, new IndexSpan(4, 1), TokenKind.Name);
+                CheckAndReadNext(tokenizer, new IndexSpan(5, 2), TokenKind.NewLine);
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public void LFNewLines() {
             foreach (var version in AllVersions) {
                 var code = "\nx\ny\n";
@@ -88,13 +105,6 @@ namespace Microsoft.Python.Parsing.Tests {
 
             tokenizer.Initialize(null, reader, initialSourceLocation ?? SourceLocation.MinValue);
             return tokenizer;
-        }
-
-        /* == operator doesn't compare indexes */
-        private void ShouldEqual(SourceLocation s1, SourceLocation s2) {
-            s1.Index.Should().Be(s2.Index);
-            s1.Line.Should().Be(s2.Line);
-            s1.Column.Should().Be(s2.Column);
         }
     }
 }


### PR DESCRIPTION
Tests that check errors reported by parser were expecting specific index numbers.
Index numbers differ by OS (based on usage of CRLF/LF, etc) so I removed the check fixing the tests for other platforms. Notice that index numbers remain there unused.
This prepares us for a different commit which would delete ErrorInfo and all those numbers from our tests.
I also added tokenizer tests for different newlines.
