### PR TITLE
Add IsExact to collection interface, check when deciding to use __all__

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Collections.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Collections.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             var oldVariables = CurrentScope.Variables.OfType<Variable>().ToDictionary(k => k.Name, v => v);
             try {
                 ProcessComprehension(node);
+
+                // TODO: Evaluate comprehensions to produce exact contents, if possible.
                 switch (node) {
                     case ListComprehension lc:
                         var v1 = GetValueFromExpression(lc.Item) ?? UnknownType;

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Collections.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Collections.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 var value = GetValueFromExpression(item) ?? UnknownType;
                 contents.Add(value);
             }
-            return PythonCollectionType.CreateList(Module.Interpreter, GetLoc(expression), contents);
+            return PythonCollectionType.CreateList(Module.Interpreter, GetLoc(expression), contents, exact: true);
         }
 
         public IMember GetValueFromDictionary(DictionaryExpression expression) {
@@ -70,7 +70,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 var value = GetValueFromExpression(item.SliceStop) ?? UnknownType;
                 contents[key] = value;
             }
-            return new PythonDictionary(Interpreter, GetLoc(expression), contents);
+            return new PythonDictionary(Interpreter, GetLoc(expression), contents, exact: true);
         }
 
         private IMember GetValueFromTuple(TupleExpression expression) {
@@ -79,7 +79,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 var value = GetValueFromExpression(item) ?? UnknownType;
                 contents.Add(value);
             }
-            return PythonCollectionType.CreateTuple(Module.Interpreter, GetLoc(expression), contents);
+            return PythonCollectionType.CreateTuple(Module.Interpreter, GetLoc(expression), contents, exact: true);
         }
 
         public IMember GetValueFromSet(SetExpression expression) {
@@ -88,7 +88,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 var value = GetValueFromExpression(item) ?? UnknownType;
                 contents.Add(value);
             }
-            return PythonCollectionType.CreateSet(Interpreter, GetLoc(expression), contents);
+            return PythonCollectionType.CreateSet(Interpreter, GetLoc(expression), contents, exact: true);
         }
 
         public IMember GetValueFromGenerator(GeneratorExpression expression) {

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 && leftType?.TypeId == BuiltinTypeId.List && rightType?.TypeId == BuiltinTypeId.List
                 && left is IPythonCollection lc && right is IPythonCollection rc) {
 
-                return PythonCollectionType.CreateConcatenatedList(Module.Interpreter, GetLoc(expr), lc.Contents, rc.Contents);
+                return PythonCollectionType.CreateConcatenatedList(Module.Interpreter, GetLoc(expr), lc, rc);
             }
 
             return left.IsUnknown() ? right : left;

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             if (node.Args.Count == 0) {
                 return;
             }
-            
+
             var arg = node.Args[0].Expression;
             var v = Eval.GetValueFromExpression(arg);
             if (v == null) {

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -76,14 +76,14 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
 
             var rightVar = Eval.GetValueFromExpression(node.Right);
-            var rightContents = (rightVar as IPythonCollection)?.Contents;
+            var right = rightVar as IPythonCollection;
 
-            if (rightContents == null) {
+            if (right == null) {
                 _allIsUsable = false;
                 return;
             }
 
-            ExtendAll(node.Left, rightContents);
+            ExtendAll(node.Left, right);
         }
 
         private void HandleAllAppendExtend(CallExpression node) {
@@ -98,32 +98,34 @@ namespace Microsoft.Python.Analysis.Analyzer {
             if (node.Args.Count == 0) {
                 return;
             }
-
-            IReadOnlyList<IMember> contents = null;
-            var v = Eval.GetValueFromExpression(node.Args[0].Expression);
+            
+            var arg = node.Args[0].Expression;
+            var v = Eval.GetValueFromExpression(arg);
             if (v == null) {
                 _allIsUsable = false;
                 return;
             }
 
+            IPythonCollection values = null;
+
             switch (me.Name) {
                 case "append":
-                    contents = new List<IMember>() { v };
+                    values = PythonCollectionType.CreateList(Module.Interpreter, Eval.GetLoc(arg), new List<IMember>() { v }, exact: true);
                     break;
                 case "extend":
-                    contents = (v as IPythonCollection)?.Contents;
+                    values = v as IPythonCollection;
                     break;
             }
 
-            if (contents == null) {
+            if (values == null) {
                 _allIsUsable = false;
                 return;
             }
 
-            ExtendAll(node, contents);
+            ExtendAll(node, values);
         }
 
-        private void ExtendAll(Node declNode, IReadOnlyList<IMember> values) {
+        private void ExtendAll(Node declNode, IPythonCollection values) {
             Eval.LookupNameInScopes(AllVariableName, out var scope, LookupOptions.Normal);
             if (scope == null) {
                 return;
@@ -131,9 +133,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             var loc = Eval.GetLoc(declNode);
 
-            var allContents = (scope.Variables[AllVariableName].Value as IPythonCollection)?.Contents;
+            var all = scope.Variables[AllVariableName].Value as IPythonCollection;
 
-            var list = PythonCollectionType.CreateConcatenatedList(Module.Interpreter, loc, allContents, values);
+            var list = PythonCollectionType.CreateConcatenatedList(Module.Interpreter, loc, all, values);
             var source = list.IsGeneric() ? VariableSource.Generic : VariableSource.Declaration;
 
             Eval.DeclareVariable(AllVariableName, list, source, loc);
@@ -199,7 +201,8 @@ namespace Microsoft.Python.Analysis.Analyzer {
             SymbolTable.ReplacedByStubs.Clear();
             MergeStub();
 
-            if (_allIsUsable && _allReferencesCount >= 1 && GlobalScope.Variables.TryGetVariable(AllVariableName, out var variable) && variable?.Value is IPythonCollection collection) {
+            if (_allIsUsable && _allReferencesCount >= 1 && GlobalScope.Variables.TryGetVariable(AllVariableName, out var variable)
+                && variable?.Value is IPythonCollection collection && collection.IsExact) {
                 ExportedMemberNames = collection.Contents
                     .OfType<IPythonConstant>()
                     .Select(c => c.GetString())

--- a/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
+++ b/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
@@ -84,34 +84,39 @@ namespace Microsoft.Python.Analysis.Types.Collections {
         #endregion
 
         public static IPythonCollection CreateList(IPythonInterpreter interpreter, LocationInfo location, IArgumentSet args) {
-            IReadOnlyList<IMember> contents = null;
+            var exact = true;
+            IReadOnlyList<IMember> contents;
+
             if (args.Arguments.Count > 1) {
                 // self and list like in list.__init__ and 'list([1, 'str', 3.0])'
-                contents = (args.Arguments[1].Value as PythonCollection)?.Contents;
+                var arg = args.Arguments[1].Value as PythonCollection;
+                exact = arg?.IsExact ?? false;
+                contents = arg?.Contents;
             } else {
-                // Try list argument as n '__init__(self, *args, **kwargs)'
                 contents = args.ListArgument?.Values;
             }
-            return CreateList(interpreter, location, contents ?? Array.Empty<IMember>());
+
+            return CreateList(interpreter, location, contents ?? Array.Empty<IMember>(), exact: exact);
         }
 
-        public static IPythonCollection CreateList(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyList<IMember> contents, bool flatten = true) {
+        public static IPythonCollection CreateList(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyList<IMember> contents, bool flatten = true, bool exact = false) {
             var collectionType = new PythonCollectionType(null, BuiltinTypeId.List, interpreter, true);
-            return new PythonCollection(collectionType, location, contents, flatten);
+            return new PythonCollection(collectionType, location, contents, flatten, exact);
         }
 
-        public static IPythonCollection CreateConcatenatedList(IPythonInterpreter interpreter, LocationInfo location, params IReadOnlyList<IMember>[] manyContents) {
-            var contents = manyContents?.ExcludeDefault().SelectMany().ToList() ?? new List<IMember>();
-            return CreateList(interpreter, location, contents);
+        public static IPythonCollection CreateConcatenatedList(IPythonInterpreter interpreter, LocationInfo location, params IPythonCollection[] many) {
+            var exact = many?.All(c => c != null && c.IsExact) ?? false;
+            var contents = many?.ExcludeDefault().Select(c => c.Contents).SelectMany().ToList() ?? new List<IMember>();
+            return CreateList(interpreter, location, contents, false, exact: exact);
         }
 
-        public static IPythonCollection CreateTuple(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyList<IMember> contents) {
+        public static IPythonCollection CreateTuple(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyList<IMember> contents, bool exact = false) {
             var collectionType = new PythonCollectionType(null, BuiltinTypeId.Tuple, interpreter, false);
-            return new PythonCollection(collectionType, location, contents);
+            return new PythonCollection(collectionType, location, contents, exact: exact);
         }
-        public static IPythonCollection CreateSet(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyList<IMember> contents, bool flatten = true) {
+        public static IPythonCollection CreateSet(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyList<IMember> contents, bool flatten = true, bool exact = false) {
             var collectionType = new PythonCollectionType(null, BuiltinTypeId.Set, interpreter, true);
-            return new PythonCollection(collectionType, location, contents, flatten);
+            return new PythonCollection(collectionType, location, contents, flatten, exact: exact);
         }
 
         public override bool Equals(object obj) 

--- a/src/Analysis/Ast/Impl/Values/Collections/PythonCollection.cs
+++ b/src/Analysis/Ast/Impl/Values/Collections/PythonCollection.cs
@@ -76,6 +76,6 @@ namespace Microsoft.Python.Analysis.Values.Collections {
             }
         }
 
-        public bool IsExact { get; protected set; }
+        public bool IsExact { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Values/Collections/PythonCollection.cs
+++ b/src/Analysis/Ast/Impl/Values/Collections/PythonCollection.cs
@@ -25,14 +25,16 @@ namespace Microsoft.Python.Analysis.Values.Collections {
         /// <param name="collectionType">Collection type.</param>
         /// <param name="contents">Contents of the collection (typically elements from the initialization).</param>
         /// <param name="location">Declaring location.</param>
-        /// <param name="flatten">If true and contents is a single element
+        /// <param name="flatten">If true and contents is a single element</param>
+        /// <param name="exact">True if the contents are an exact representation of the collection contents.</param>
         /// and is a sequence, the sequence elements are copied rather than creating
         /// a sequence of sequences with a single element.</param>
         public PythonCollection(
             IPythonType collectionType,
             LocationInfo location,
             IReadOnlyList<IMember> contents,
-            bool flatten = true
+            bool flatten = true,
+            bool exact = false
         ) : base(collectionType, location) {
             var c = contents ?? Array.Empty<IMember>();
             if (flatten && c.Count == 1 && c[0] is IPythonCollection seq) {
@@ -40,6 +42,7 @@ namespace Microsoft.Python.Analysis.Values.Collections {
             } else {
                 Contents = c;
             }
+            IsExact = exact;
         }
 
         /// <summary>
@@ -72,5 +75,7 @@ namespace Microsoft.Python.Analysis.Values.Collections {
                     return 0;
             }
         }
+
+        public bool IsExact { get; protected set; }
     }
 }

--- a/src/Analysis/Ast/Impl/Values/Collections/PythonDictionary.cs
+++ b/src/Analysis/Ast/Impl/Values/Collections/PythonDictionary.cs
@@ -28,16 +28,16 @@ namespace Microsoft.Python.Analysis.Values.Collections {
         private readonly Dictionary<IMember, IMember> _contents = new Dictionary<IMember, IMember>(new KeyComparer());
         private readonly IPythonInterpreter _interpreter;
 
-        public PythonDictionary(PythonDictionaryType dictType, LocationInfo location, IReadOnlyDictionary<IMember, IMember> contents) :
-            base(dictType, location, contents.Keys.ToArray()) {
+        public PythonDictionary(PythonDictionaryType dictType, LocationInfo location, IReadOnlyDictionary<IMember, IMember> contents, bool exact = false) :
+            base(dictType, location, contents.Keys.ToArray(), exact: exact) {
             foreach (var kvp in contents) {
                 _contents[kvp.Key] = kvp.Value;
             }
             _interpreter = dictType.DeclaringModule.Interpreter;
         }
 
-        public PythonDictionary(IPythonInterpreter interpreter, LocationInfo location, IMember contents) :
-            base(new PythonDictionaryType(interpreter), location, Array.Empty<IMember>()) {
+        public PythonDictionary(IPythonInterpreter interpreter, LocationInfo location, IMember contents, bool exact = false) :
+            base(new PythonDictionaryType(interpreter), location, Array.Empty<IMember>(), exact: exact) {
             if (contents is IPythonDictionary dict) {
                 foreach (var key in dict.Keys) {
                     _contents[key] = dict[key];
@@ -47,8 +47,8 @@ namespace Microsoft.Python.Analysis.Values.Collections {
             _interpreter = interpreter;
         }
 
-        public PythonDictionary(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyDictionary<IMember, IMember> contents) :
-            this(new PythonDictionaryType(interpreter), location, contents) {
+        public PythonDictionary(IPythonInterpreter interpreter, LocationInfo location, IReadOnlyDictionary<IMember, IMember> contents, bool exact = false) :
+            this(new PythonDictionaryType(interpreter), location, contents, exact: exact) {
             _interpreter = interpreter;
         }
 

--- a/src/Analysis/Ast/Impl/Values/Definitions/IPythonCollection.cs
+++ b/src/Analysis/Ast/Impl/Values/Definitions/IPythonCollection.cs
@@ -25,5 +25,10 @@ namespace Microsoft.Python.Analysis.Values {
         /// Collection contents
         /// </summary>
         IReadOnlyList<IMember> Contents { get; }
+
+        /// <summary>
+        /// True if the collection contents contain an accurate representation of the collection's contents.
+        /// </summary>
+        bool IsExact { get; }
     }
 }

--- a/src/LanguageServer/Test/ImportsTests.cs
+++ b/src/LanguageServer/Test/ImportsTests.cs
@@ -586,6 +586,8 @@ __all__.extend(123)")]
         [DataRow(@"
 __all__ = ['A']
 __all__.extend(nothing)")]
+        [DataRow(@"
+__all__ = [chr(x + 65) for x in range(1, 2)]")]
         [DataTestMethod, Priority(0)]
         public async Task AllUnsupported(string allCode) {
             var module1Code = @"


### PR DESCRIPTION
Fixes #881.

This adds `IsExact` to `IPythonCollection`, which is true when `Contents` contains an exact representation of the contents, meaning that the values are set and are known. This boolean is propagated around, and used when looking up `__all__`.

Tensorflow broke because it assigns `__all__` via a comprehension; the comprehension evaluator doesn't actually populate a real collection, instead producing a collection which contains a single member. This could be improved in the future, but by not setting `IsExact` true when that collection is produced, that incomplete value won't be used when looking at `__all__`.