### PR TITLE
Fix analysis_complete event name for now, send working MB for *nix platforms

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -165,18 +165,21 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             double privateMB;
             double peakPagedMB;
+            double workingMB;
 
             using (var proc = Process.GetCurrentProcess()) {
                 privateMB = proc.PrivateMemorySize64 / 1e+6;
                 peakPagedMB = proc.PeakPagedMemorySize64 / 1e+6;
+                workingMB = proc.WorkingSet64 / 1e+6;
             }
 
             var e = new TelemetryEvent {
-                EventName = "analysis_complete",
+                EventName = "python_language_server/analysis_complete", // TODO: Move this common prefix into Core.
             };
 
             e.Measurements["privateMB"] = privateMB;
             e.Measurements["peakPagedMB"] = peakPagedMB;
+            e.Measurements["workingMB"] = workingMB;
             e.Measurements["elapsedMs"] = elapsed;
             e.Measurements["entries"] = originalRemaining;
             e.Measurements["version"] = version;


### PR DESCRIPTION
Because this event is created in the analyzer, I didn't use `Telemetry.CreateEvent`, which would have appended the prefix we need. Hardcode it for now until stuff can move into Core. (I tried moving it into Core but ran into strange build issues.)

Also, send the working set size as well, since *nix platforms don't seem to support paged/peak paged at all. That'll need its own fix that's more complicated.