### PR TITLE
Fix fstrings in line formatter

### DIFF
--- a/src/LanguageServer/Impl/Formatting/LineFormatter.cs
+++ b/src/LanguageServer/Impl/Formatting/LineFormatter.cs
@@ -310,6 +310,7 @@ namespace Microsoft.Python.LanguageServer.Formatting {
                         break;
 
                     case TokenKind.Constant:
+                    case TokenKind.FString: // TODO: format inside fstrings
                         builder.Append(token);
                         break;
 
@@ -446,7 +447,8 @@ namespace Microsoft.Python.LanguageServer.Formatting {
 
             public bool IsKeyword => (Kind >= TokenKind.FirstKeyword && Kind <= TokenKind.LastKeyword) || Kind == TokenKind.KeywordAsync || Kind == TokenKind.KeywordAwait;
 
-            public bool IsString => Kind == TokenKind.Constant && Token != Tokens.NoneToken && (Token.Value is string || Token.Value is AsciiString);
+            public bool IsString => Kind == TokenKind.FString // TODO: format inside fstrings
+                || (Kind == TokenKind.Constant && Token != Tokens.NoneToken && (Token.Value is string || Token.Value is AsciiString));
 
             public bool IsSimpleSliceToLeft {
                 get {

--- a/src/LanguageServer/Test/LineFormatterTests.cs
+++ b/src/LanguageServer/Test/LineFormatterTests.cs
@@ -417,7 +417,17 @@ limit { limit_num}; """"""", line: 5);
         public void StringConcat(string code, string expected) {
             AssertSingleLineFormat(code, expected);
         }
-        
+
+        [DataRow("f'{x}'", "f'{x}'")]
+        [DataRow("f'{x+1}'", "f'{x+1}'")]
+        [DataRow("f'{x + 1}'", "f'{x + 1}'")]
+        [DataRow("foo(f'{x+1}')", "foo(f'{x+1}')")]
+        [DataRow("foo(    f'{x+1}' )", "foo(f'{x+1}')")]
+        [DataTestMethod, Priority(0)]
+        public void FStrings(string code, string expected) {
+            AssertSingleLineFormat(code, expected);
+        }
+
         [TestMethod, Priority(0)]
         public void GrammarFile() {
             var src = TestData.GetPath("TestData", "Formatting", "pythonGrammar.py");


### PR DESCRIPTION
Fixes #904.

In the future, we'll probably want to actually format inside fstrings, but because of our implementation the first tokenizer pass doesn't give enough information (but we can expose fstring splitting details elsewhere). I'll open a separate issue for that.