### PR TITLE
Treat configuration search paths not under the root as library code

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -208,9 +208,16 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             addedRoots.UnionWith(PathResolver.SetRoot(Root));
 
             InterpreterPaths = await GetSearchPathsAsync(cancellationToken);
-            addedRoots.UnionWith(PathResolver.SetInterpreterSearchPaths(InterpreterPaths));
 
             var userSearchPaths = _interpreter.Configuration.SearchPaths.Except(InterpreterPaths, StringExtensions.PathsStringComparer);
+
+            if (Root != null) {
+                var underRoot = userSearchPaths.ToLookup(p => _fs.IsPathUnderRoot(Root, p));
+                userSearchPaths = underRoot[true];
+                InterpreterPaths = underRoot[false].Concat(InterpreterPaths);
+            }
+
+            addedRoots.UnionWith(PathResolver.SetInterpreterSearchPaths(InterpreterPaths));
             addedRoots.UnionWith(SetUserSearchPaths(userSearchPaths));
             ReloadModulePaths(addedRoots);
         }


### PR DESCRIPTION
To be sure that renames can't happen on things that come from `extraPaths` or `PYTHONPATH` when files are outside the workspace. This isn't a perfect solution due to symlinks, I believe, but this is better than nothing.

`ILookup` accesses return empty iterators, hence the lack of error checking when doing `[true]` and `[false]`.

`Root` is `null` checked because the MRO test manages to create an analyzer without it set.