### PR TITLE
Use normal Dictionary/HashSet instead of concurent versions for ModuleSymbolTable

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ModuleSymbolTable.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ModuleSymbolTable.cs
@@ -13,7 +13,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Analyzer.Evaluation;
@@ -28,9 +27,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
     /// or there is nothing left to walk.
     /// </summary>
     internal sealed class ModuleSymbolTable {
-        private readonly ConcurrentDictionary<ScopeStatement, MemberEvaluator> _evaluators
-            = new ConcurrentDictionary<ScopeStatement, MemberEvaluator>();
-        private readonly ConcurrentBag<ScopeStatement> _processed = new ConcurrentBag<ScopeStatement>();
+        private readonly Dictionary<ScopeStatement, MemberEvaluator> _evaluators = new Dictionary<ScopeStatement, MemberEvaluator>();
+        private readonly HashSet<ScopeStatement> _processed = new HashSet<ScopeStatement>();
 
         public HashSet<Node> ReplacedByStubs { get; } = new HashSet<Node>();
 
@@ -98,7 +96,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // NOTE: first add then remove so we don't get moment when
             // walker is missing from either set.
             _processed.Add(e.Target);
-            _evaluators.TryRemove(e.Target, out _);
+            _evaluators.Remove(e.Target);
             e.Evaluate();
         }
     }


### PR DESCRIPTION
For #875.

The table seems to only be used in the same thread. I found that most of the time analyzing PyQt5 (which has some 30k+ things to process after we scrape it) is inside the concurrent types themselves. Switch them to unlocked types.

It's a bit difficult to verify that this is safe (in lieu of a race detector), so I hacked something in to check accesses to these members to record the thread IDs, which shows only a single thread touching them:

![image](https://user-images.githubusercontent.com/5341706/56003595-0456ac80-5c7c-11e9-9630-baeaa183c8a9.png)

This may not be the end-all-be-all when it comes to PyQt, but this helps significantly. With:

```python
from PyQt5 import QtCore
QtCore.QProcess()
```

Before:

```
Analysis version 358 of 270 entries has been completed in 170094.9184 ms.
```

After:

```
Analysis version 358 of 269 entries has been completed in 10890.3092 ms.
```