### PR TITLE
Ignore root and dot in search paths

### DIFF
--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -112,7 +112,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             ) {
                 // TODO: Remove this split once the extension is updated and no longer passes the interpreter search paths directly.
                 // This is generally harmless to keep around.
-                SearchPaths = @params.initializationOptions.searchPaths.Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany().ToList(),
+                SearchPaths = @params.initializationOptions.searchPaths
+                    .Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany()
+                    .Where(p => p != "/" && p != ".")
+                    .ToList(),
                 TypeshedPath = @params.initializationOptions.typeStubSearchPaths.FirstOrDefault()
             };
 


### PR DESCRIPTION
I've been seeing these in user screenshots/logs.

- `/` is the root on *nix systems, and it showing up in the search paths seems like an error or misconfiguration more than anything. There shouldn't be code there, so I think we can skip it and prevent lookups to odd places which shouldn't be valid.
- `.` is the current directory, which is generally the workspace root, which is already a place we search for user code, so it could be ignored as well.