### PR TITLE
Preprocess search paths

### DIFF
--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -118,14 +118,14 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 // 2) Normalize paths.
                 // 3) If a path isn't rooted, then root it relative to the workspace root.
                 // 4) Trim off any ending separator for a consistent style.
-                // 5) Filter out any entries which are the same as the workspace root; they are redundant.
+                // 5) Filter out any entries which are the same as the workspace root; they are redundant. Also ignore "/" to work around the extension (for now).
                 // 6) Remove duplicates.
                 SearchPaths = @params.initializationOptions.searchPaths
                     .Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany()
                     .Select(PathUtils.NormalizePath)
                     .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(p, _rootDir))
                     .Select(PathUtils.TrimEndSeparator)
-                    .Where(p => !string.IsNullOrWhiteSpace(p) && !p.PathEquals(_rootDir))
+                    .Where(p => !string.IsNullOrWhiteSpace(p) && p != "/" && !p.PathEquals(_rootDir))
                     .Distinct(PathEqualityComparer.Instance)
                     .ToList(),
                 TypeshedPath = @params.initializationOptions.typeStubSearchPaths.FirstOrDefault()

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-#define WAIT_FOR_DEBUGGER
+// #define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-// #define WAIT_FOR_DEBUGGER
+#define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;


### PR DESCRIPTION
Fixes #849.

This does some preprocessing of searchPaths, removing redundant entries and rooting relative paths.