### PR TITLE
Allow root to be null

### DIFF
--- a/src/LanguageServer/Impl/Indexing/IndexManager.cs
+++ b/src/LanguageServer/Impl/Indexing/IndexManager.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Python.LanguageServer.Indexing {
         public IndexManager(IFileSystem fileSystem, PythonLanguageVersion version, string rootPath, string[] includeFiles,
             string[] excludeFiles, IIdleTimeService idleTimeService) {
             Check.ArgumentNotNull(nameof(fileSystem), fileSystem);
-            Check.ArgumentNotNull(nameof(rootPath), rootPath);
             Check.ArgumentNotNull(nameof(includeFiles), includeFiles);
             Check.ArgumentNotNull(nameof(excludeFiles), excludeFiles);
             Check.ArgumentNotNull(nameof(idleTimeService), idleTimeService);


### PR DESCRIPTION
Fixes #977.

This is a weird case, but did work before my search path cleanups. Revert to the old behavior when the root is set to `null`.

To test, open VS Code and close any folders, make a new file and switch its language mode to Python.