### PR TITLE
Fix nullref when renaming in an untitled file or without a workspace root

### DIFF
--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -38,6 +38,8 @@ using Microsoft.Python.LanguageServer.Sources;
 
 namespace Microsoft.Python.LanguageServer.Implementation {
     public sealed partial class Server : IDisposable {
+        private const string EmptyDirectoryName = "Microsoft.Python.LanguageServer.Empty";
+
         private readonly DisposableBag _disposableBag = DisposableBag.Create<Server>();
         private readonly CancellationTokenSource _shutdownCts = new CancellationTokenSource();
         private readonly IServiceManager _services;
@@ -104,10 +106,16 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _rdt = _services.GetService<IRunningDocumentTable>();
 
             _rootDir = @params.rootUri != null ? @params.rootUri.ToAbsolutePath() : @params.rootPath;
-            if (_rootDir != null) {
-                _rootDir = PathUtils.NormalizePath(_rootDir);
-                _rootDir = PathUtils.TrimEndSeparator(_rootDir);
+
+            // If there is no root, create a canonical empty directory to use instead.
+            if (string.IsNullOrWhiteSpace(_rootDir)) {
+                var emptyDir = Path.Combine(Path.GetTempPath(), EmptyDirectoryName);
+                Directory.CreateDirectory(emptyDir);
+                _rootDir = emptyDir;
             }
+
+            _rootDir = PathUtils.NormalizePath(_rootDir);
+            _rootDir = PathUtils.TrimEndSeparator(_rootDir);
 
             Version.TryParse(@params.initializationOptions.interpreter.properties?.Version, out var version);
 
@@ -171,12 +179,11 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         public void DidChangeConfiguration(DidChangeConfigurationParams @params, CancellationToken cancellationToken) {
             _disposableBag.ThrowIfDisposed();
             switch (@params.settings) {
-                case ServerSettings settings: {
+                case ServerSettings settings:
                     if (HandleConfigurationChanges(settings)) {
                         RestartAnalysis();
                     }
                     break;
-                }
                 default:
                     _log?.Log(TraceEventType.Error, "change configuration notification sent unsupported settings");
                     break;
@@ -246,7 +253,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         private void RestartAnalysis() {
-            var analyzer = Services.GetService<IPythonAnalyzer>();;
+            var analyzer = Services.GetService<IPythonAnalyzer>();
             analyzer.ResetAnalyzer();
             foreach (var doc in _rdt.GetDocuments()) {
                 doc.Reset(null);

--- a/src/LanguageServer/Impl/Sources/ReferenceSource.cs
+++ b/src/LanguageServer/Impl/Sources/ReferenceSource.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             await AnalyzeFiles(declaringModule.Interpreter.ModuleResolution, candidateFiles, cancellationToken);
 
             return rootDefinition.References
-                .Select(r => new Reference { uri = new Uri(r.FilePath), range = r.Span })
+                .Select(r => new Reference { uri = r.DocumentUri, range = r.Span })
                 .ToArray();
         }
 
@@ -80,6 +80,10 @@ namespace Microsoft.Python.LanguageServer.Sources {
             var interpreter = _services.GetService<IPythonInterpreter>();
 
             var root = interpreter.ModuleResolution.Root;
+            if (root == null) {
+                return Enumerable.Empty<Uri>();
+            }
+
             var interpreterPaths = interpreter.ModuleResolution.InterpreterPaths.ToArray();
             var files = new List<Uri>();
 

--- a/src/LanguageServer/Impl/Sources/ReferenceSource.cs
+++ b/src/LanguageServer/Impl/Sources/ReferenceSource.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             await AnalyzeFiles(declaringModule.Interpreter.ModuleResolution, candidateFiles, cancellationToken);
 
             return rootDefinition.References
-                .Select(r => new Reference { uri = new Uri(r.FilePath), range = r.Span })
+                .Select(r => new Reference { uri = r.DocumentUri, range = r.Span })
                 .ToArray();
         }
 

--- a/src/LanguageServer/Impl/Sources/ReferenceSource.cs
+++ b/src/LanguageServer/Impl/Sources/ReferenceSource.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             await AnalyzeFiles(declaringModule.Interpreter.ModuleResolution, candidateFiles, cancellationToken);
 
             return rootDefinition.References
-                .Select(r => new Reference { uri = r.DocumentUri, range = r.Span })
+                .Select(r => new Reference { uri = new Uri(r.FilePath), range = r.Span })
                 .ToArray();
         }
 

--- a/src/LanguageServer/Test/IndexManagerTests.cs
+++ b/src/LanguageServer/Test/IndexManagerTests.cs
@@ -64,6 +64,18 @@ namespace Microsoft.Python.LanguageServer.Tests {
         }
 
         [TestMethod, Priority(0)]
+        public void NullDirectoryThrowsException() {
+            var context = new IndexTestContext(this);
+            Action construct = () => {
+                PythonLanguageVersion version = PythonVersions.LatestAvailable3X.Version.ToLanguageVersion();
+                IIndexManager indexManager = new IndexManager(context.FileSystem,
+                                                              version, null, new string[] { }, new string[] { },
+                                                              new IdleTimeService());
+            };
+            construct.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod, Priority(0)]
         public async Task IgnoresNonPythonFiles() {
             var context = new IndexTestContext(this);
 

--- a/src/LanguageServer/Test/IndexManagerTests.cs
+++ b/src/LanguageServer/Test/IndexManagerTests.cs
@@ -64,18 +64,6 @@ namespace Microsoft.Python.LanguageServer.Tests {
         }
 
         [TestMethod, Priority(0)]
-        public void NullDirectoryThrowsException() {
-            var context = new IndexTestContext(this);
-            Action construct = () => {
-                PythonLanguageVersion version = PythonVersions.LatestAvailable3X.Version.ToLanguageVersion();
-                IIndexManager indexManager = new IndexManager(context.FileSystem,
-                                                              version, null, new string[] { }, new string[] { },
-                                                              new IdleTimeService());
-            };
-            construct.Should().Throw<ArgumentNullException>();
-        }
-
-        [TestMethod, Priority(0)]
         public async Task IgnoresNonPythonFiles() {
             var context = new IndexTestContext(this);
 


### PR DESCRIPTION
Fixes #1001.

Check for `null` root before looking for files with references, and use the existing URI instead of attempting to make one so that untitled files without a path will work.

This also deletes a test from the indexer; the fix for #977 made it invalid (as `root` is allowed to be null).