### PR TITLE
Call methods for binary operators, better handle builtin type conversions

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -80,32 +80,68 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return null;
             }
 
+            var op = binop.Operator;
+
             var left = GetValueFromExpression(binop.Left) ?? UnknownType;
             var right = GetValueFromExpression(binop.Right) ?? UnknownType;
 
-            var (funcName, swappedFuncName) = OpMethodName(binop.Operator);
-
             var leftType = left.GetPythonType();
+            var rightType = right.GetPythonType();
 
-            if (funcName != null && left is IPythonInstance lpi) {
-                var ret = leftType?.Call(lpi, funcName, new ArgumentSet(new[] { right }));
-                if (ret != null) {
-                    return ret;
+            if (leftType == null) {
+                return right;
+            }
+
+            if (rightType == null) {
+                return left;
+            }
+
+            var leftTypeId = leftType.TypeId;
+            var rightTypeId = rightType.TypeId;
+
+            if (op == PythonOperator.Add
+                && leftTypeId == rightTypeId
+                && left is IPythonCollection lc && right is IPythonCollection rc) {
+
+                switch (leftTypeId) {
+                    case BuiltinTypeId.List:
+                        return PythonCollectionType.CreateConcatenatedList(Module.Interpreter, lc, rc);
+                    case BuiltinTypeId.Tuple:
+                        return PythonCollectionType.CreateConcatenatedTuple(Module.Interpreter, lc, rc);
                 }
             }
 
-            var rightType = right.GetPythonType();
+            // Mod-style string formatting; don't bother looking at the right side.
+            if (op == PythonOperator.Mod && (leftTypeId == BuiltinTypeId.Str || leftTypeId == BuiltinTypeId.Unicode)) {
+                return Interpreter.GetBuiltinType(leftTypeId);
+            }
 
-            if (swappedFuncName != null && right is IPythonInstance rpi) {
-                var ret = rightType?.Call(rpi, swappedFuncName, new ArgumentSet(new[] { left }));
-                if (ret != null) {
-                    return ret;
+            if (IsOperableBuiltin(leftTypeId) && IsOperableBuiltin(rightTypeId)) {
+                if (TryGetValueFromBuiltinBinaryOp(op, leftTypeId, rightTypeId, Interpreter.LanguageVersion.Is3x(), out var member)) {
+                    return member;
                 }
+            }
+
+            if (IsOperableBuiltin(leftTypeId)) {
+                // Try calling swapped function on the right side, otherwise just return left.
+                var ret = CallOperator(op, left, leftType, right, rightType, tryLeft: false);
+                return ret.IsUnknown() ? left : ret;
+            }
+
+            if (IsOperableBuiltin(rightTypeId)) {
+                // Try calling the function on the left side, otherwise just return right.
+                var ret = CallOperator(op, left, leftType, right, rightType, tryRight: false);
+                return ret.IsUnknown() ? right : ret;
+            }
+
+            var callRet = CallOperator(op, left, leftType, right, rightType);
+            if (!callRet.IsUnknown()) {
+                return callRet;
             }
 
             // TODO: Specific parsing
             // TODO: warn about incompatible types like 'str' + 1
-            switch (binop.Operator) {
+            switch (op) {
                 case PythonOperator.Equal:
                 case PythonOperator.GreaterThan:
                 case PythonOperator.GreaterThanOrEqual:
@@ -129,31 +165,208 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                     break;
             }
 
-            if (rightType?.TypeId == BuiltinTypeId.Float) {
-                return right;
-            }
-
-
-            if (leftType?.TypeId == BuiltinTypeId.Float) {
-                return left;
-            }
-
-            if (rightType?.TypeId == BuiltinTypeId.Long) {
-                return right;
-            }
-
-            if (leftType?.TypeId == BuiltinTypeId.Long) {
-                return left;
-            }
-
-            if (binop.Operator == PythonOperator.Add
-                && leftType?.TypeId == BuiltinTypeId.List && rightType?.TypeId == BuiltinTypeId.List
-                && left is IPythonCollection lc && right is IPythonCollection rc) {
-
-                return PythonCollectionType.CreateConcatenatedList(Module.Interpreter, lc, rc);
-            }
-
             return left.IsUnknown() ? right : left;
+        }
+
+        private IMember CallOperator(PythonOperator op, IMember left, IPythonType leftType, IMember right, IPythonType rightType, bool tryLeft = true, bool tryRight = true) {
+            var (funcName, swappedFuncName) = OpMethodName(op);
+
+            if (tryLeft && funcName != null && left is IPythonInstance lpi) {
+                var ret = leftType.Call(lpi, funcName, new ArgumentSet(new[] { right }));
+                if (!ret.IsUnknown()) {
+                    return ret;
+                }
+            }
+
+            if (tryRight && swappedFuncName != null && right is IPythonInstance rpi) {
+                var ret = rightType.Call(rpi, swappedFuncName, new ArgumentSet(new[] { left }));
+                if (!ret.IsUnknown()) {
+                    return ret;
+                }
+            }
+
+            return null;
+        }
+
+        // TODO: Proper comment
+        //
+        // This function assumes left/right are builtin types. Maybe change this to better indicate which side needs to be checked in the future.
+        private bool TryGetValueFromBuiltinBinaryOp(PythonOperator op, BuiltinTypeId left, BuiltinTypeId right, bool is3x, out IMember member) {
+            member = null;
+
+            // TODO: comparison operations
+
+            switch (op) {
+                case PythonOperator.MatMultiply:
+                    // No builtins implement this operator.
+                    return true;
+
+                case PythonOperator.BitwiseAnd:
+                case PythonOperator.BitwiseOr:
+                case PythonOperator.Xor:
+                    switch (left) {
+                        case BuiltinTypeId.Bool when right == BuiltinTypeId.Bool:
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Bool);
+                            return true;
+
+                        case BuiltinTypeId.Bool when right == BuiltinTypeId.Int:
+                        case BuiltinTypeId.Int when right == BuiltinTypeId.Bool:
+                        case BuiltinTypeId.Int when right == BuiltinTypeId.Int:
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Int);
+                            return true;
+
+                        case BuiltinTypeId.Long when right == BuiltinTypeId.Long:
+                        case BuiltinTypeId.Long when right == BuiltinTypeId.Int:
+                        case BuiltinTypeId.Long when right == BuiltinTypeId.Bool:
+                        case BuiltinTypeId.Bool when right == BuiltinTypeId.Long:
+                        case BuiltinTypeId.Int when right == BuiltinTypeId.Long:
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Long);
+                            return true;
+                    }
+
+                    // All other combinations of these bitwise operaton on builtin types fail.
+                    return true;
+            }
+
+            // At this point, @ & | ^ are all handled and do not need to be considered.
+
+            // TODO: If one of these is complex and the other a custom time, then the operation
+            // may still be supported; TryGetValueFromBuiltinBinaryOp needs to also return a possible
+            // side of the binop to test. For example, 1.0j + np.array([1.0]) should "fail", but also
+            // indicate that __radd__ should be checked for a possible type.
+            if (CoalesceComplex(left, right)) {
+                switch (op) {
+                    case PythonOperator.Add:
+                    case PythonOperator.Multiply:
+                    case PythonOperator.Power:
+                    case PythonOperator.Subtract:
+                    case PythonOperator.Divide:
+                    case PythonOperator.TrueDivide:
+                    case PythonOperator.FloorDivide when !is3x:
+                        member = Interpreter.GetBuiltinType(BuiltinTypeId.Complex);
+                        return true;
+
+                    case PythonOperator.FloorDivide when is3x:
+                        // Complex numbers cannot be floordiv'd in Python 3.
+                        return true;
+                }
+            }
+
+            if (IsStringLike(left)) {
+                member = HandleStringLike(op, left, right);
+                return true;
+            }
+
+            if (IsStringLike(right)) {
+                member = HandleStringLike(op, right, left);
+                return true;
+            }
+
+            // All string-like cases have been handled.
+
+            // If a complex value made it to here, then it wasn't coalesced or used in a string format; bail.
+            if (left == BuiltinTypeId.Complex || right == BuiltinTypeId.Complex) {
+                return false;
+            }
+
+            switch (op) {
+                case PythonOperator.TrueDivide:
+                    member = Interpreter.GetBuiltinType(BuiltinTypeId.Float);
+                    return true;
+
+                case PythonOperator.LeftShift:
+                case PythonOperator.RightShift:
+                    switch (left) {
+                        case BuiltinTypeId.Bool when right == BuiltinTypeId.Bool:
+                        case BuiltinTypeId.Bool when right == BuiltinTypeId.Int:
+                        case BuiltinTypeId.Int when right == BuiltinTypeId.Bool:
+                        case BuiltinTypeId.Int when right == BuiltinTypeId.Int:
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Int);
+                            return true;
+
+                        case BuiltinTypeId.Long when right == BuiltinTypeId.Long:
+                        case BuiltinTypeId.Long when right == BuiltinTypeId.Bool:
+                        case BuiltinTypeId.Long when right == BuiltinTypeId.Int:
+                        case BuiltinTypeId.Int when right == BuiltinTypeId.Long:
+                        case BuiltinTypeId.Bool when right == BuiltinTypeId.Long:
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Long);
+                            return true;
+                    }
+                    break;
+
+                case PythonOperator.Add:
+                case PythonOperator.Divide:
+                case PythonOperator.FloorDivide:
+                case PythonOperator.Mod:
+                case PythonOperator.Power:
+                case PythonOperator.Subtract:
+                    if (IsIntegerLike(left) && IsIntegerLike(right)) {
+                        if (left == BuiltinTypeId.Long || right == BuiltinTypeId.Long) {
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Long);
+                        } else {
+                            member = Interpreter.GetBuiltinType(BuiltinTypeId.Int);
+                        }
+                        return true;
+                    } else if (left == BuiltinTypeId.Float || right == BuiltinTypeId.Float) {
+                        member = Interpreter.GetBuiltinType(BuiltinTypeId.Float);
+                        return true;
+                    }
+                    break;
+            }
+
+            return false;
+        }
+
+        private static bool IsOperableBuiltin(BuiltinTypeId id) {
+            switch (id) {
+                case BuiltinTypeId.Bool:
+                case BuiltinTypeId.Int:
+                case BuiltinTypeId.Long:
+                case BuiltinTypeId.Float:
+                case BuiltinTypeId.Complex:
+                case BuiltinTypeId.Str:
+                case BuiltinTypeId.Bytes:
+                case BuiltinTypeId.Unicode:
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsIntegerLike(BuiltinTypeId id) => id == BuiltinTypeId.Bool || id == BuiltinTypeId.Int || id == BuiltinTypeId.Long;
+
+        private bool CoalesceComplex(BuiltinTypeId a, BuiltinTypeId b) {
+            if (a != BuiltinTypeId.Complex && b == BuiltinTypeId.Complex) {
+                var tmp = a;
+                a = b;
+                b = tmp;
+            }
+
+            if (a == BuiltinTypeId.Complex) {
+                switch (b) {
+                    case BuiltinTypeId.Bool:
+                    case BuiltinTypeId.Long:
+                    case BuiltinTypeId.Int:
+                    case BuiltinTypeId.Float:
+                    case BuiltinTypeId.Complex:
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsStringLike(BuiltinTypeId id) => id == BuiltinTypeId.Str || id == BuiltinTypeId.Bytes || id == BuiltinTypeId.Unicode;
+
+        private IMember HandleStringLike(PythonOperator op, BuiltinTypeId str, BuiltinTypeId other) {
+            switch (op) {
+                case PythonOperator.Multiply when other == BuiltinTypeId.Bool || other == BuiltinTypeId.Int || other == BuiltinTypeId.Long:
+                case PythonOperator.Add when str == other:
+                case PythonOperator.Add when str == BuiltinTypeId.Unicode || other == BuiltinTypeId.Unicode:
+                    return Interpreter.GetBuiltinType(str);
+            }
+
+            return null;
         }
 
         private static (string name, string swappedName) OpMethodName(PythonOperator op) {
@@ -177,7 +390,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 case PythonOperator.Xor: return ("__xor__", "__rxor__");
                 case PythonOperator.LeftShift: return ("__lshift__", "__rlshift__");
                 case PythonOperator.RightShift: return ("__rshift__", "__rrshift__");
-                case PythonOperator.Power: return ("__pow__", "__ppow__");
+                case PythonOperator.Power: return ("__pow__", "__rpow__");
                 case PythonOperator.FloorDivide: return ("__floordiv__", "__rfloordiv__");
 
                 // Comparison operators

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -85,6 +85,15 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             var left = GetValueFromExpression(binop.Left) ?? UnknownType;
             var right = GetValueFromExpression(binop.Right) ?? UnknownType;
 
+            if (left.IsUnknown() && right.IsUnknown()) {
+                // Fast path for when nothing below will give any results.
+                if (op.IsComparison()) {
+                    return Interpreter.GetBuiltinType(BuiltinTypeId.Bool);
+                }
+
+                return UnknownType;
+            }
+
             var leftType = left.GetPythonType();
             var rightType = right.GetPythonType();
 

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -116,16 +116,16 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return Interpreter.GetBuiltinType(leftTypeId);
             }
 
-            var leftIsOperable = IsOperableBuiltin(leftTypeId);
-            var rightIsOperable = IsOperableBuiltin(rightTypeId);
+            var leftIsSupported = IsSupportedBinopBuiltin(leftTypeId);
+            var rightIsSupported = IsSupportedBinopBuiltin(rightTypeId);
 
-            if (leftIsOperable && rightIsOperable) {
+            if (leftIsSupported && rightIsSupported) {
                 if (TryGetValueFromBuiltinBinaryOp(op, leftTypeId, rightTypeId, Interpreter.LanguageVersion.Is3x(), out var member)) {
                     return member;
                 }
             }
 
-            if (leftIsOperable) {
+            if (leftIsSupported) {
                 IMember ret;
 
                 if (op.IsComparison()) {
@@ -145,7 +145,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return op.IsComparison() ? Interpreter.GetBuiltinType(BuiltinTypeId.Bool) : left;
             }
 
-            if (rightIsOperable) {
+            if (rightIsSupported) {
                 // Try calling the function on the left side, otherwise just return right.
                 var ret = CallOperator(op, left, leftType, right, rightType, tryRight: false);
 
@@ -220,6 +220,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         /// <param name="member">The resulting member.</param>
         /// <returns>True, if member is correct and no further checks should be done.</returns>
         private bool TryGetValueFromBuiltinBinaryOp(PythonOperator op, BuiltinTypeId left, BuiltinTypeId right, bool is3x, out IMember member) {
+            if (op.IsComparison()) {
+                member = Interpreter.GetBuiltinType(BuiltinTypeId.Bool);
+                return true;
+            }
+
             member = UnknownType;
 
             // TODO: comparison operations
@@ -335,7 +340,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return false;
         }
 
-        private static bool IsOperableBuiltin(BuiltinTypeId id) {
+        private static bool IsSupportedBinopBuiltin(BuiltinTypeId id) {
             switch (id) {
                 case BuiltinTypeId.Bool:
                 case BuiltinTypeId.Int:

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -140,9 +140,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 if (op.IsComparison()) {
                     // If the op is a comparison, and the thing on the left is the builtin,
                     // flip the operation and call it instead.
-                    op = op.InvertComparison();
-
-                    ret = CallOperator(op, right, rightType, left, leftType, tryRight: false);
+                    ret = CallOperator(op.InvertComparison(), right, rightType, left, leftType, tryRight: false);
                 } else {
                     ret = CallOperator(op, left, leftType, right, rightType, tryLeft: false);
                 }
@@ -168,6 +166,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             var callRet = CallOperator(op, left, leftType, right, rightType);
             if (!callRet.IsUnknown()) {
                 return callRet;
+            }
+
+            if (op.IsComparison()) {
+                callRet = CallOperator(op.InvertComparison(), right, rightType, left, leftType);
+
+                if (!callRet.IsUnknown()) {
+                    return callRet;
+                }
             }
 
             // TODO: Specific parsing

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -221,13 +221,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         /// <returns>True, if member is correct and no further checks should be done.</returns>
         private bool TryGetValueFromBuiltinBinaryOp(PythonOperator op, BuiltinTypeId left, BuiltinTypeId right, bool is3x, out IMember member) {
             if (op.IsComparison()) {
+                // All builtins compare to bool.
                 member = Interpreter.GetBuiltinType(BuiltinTypeId.Bool);
                 return true;
             }
 
             member = UnknownType;
-
-            // TODO: comparison operations
 
             switch (op) {
                 case PythonOperator.MatMultiply:

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -97,14 +97,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             var leftType = left.GetPythonType();
             var rightType = right.GetPythonType();
 
-            if (leftType == null) {
-                return right;
-            }
-
-            if (rightType == null) {
-                return left;
-            }
-
             var leftTypeId = leftType.TypeId;
             var rightTypeId = rightType.TypeId;
 

--- a/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
+++ b/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
@@ -108,10 +108,18 @@ namespace Microsoft.Python.Analysis.Types.Collections {
             var contents = many?.ExcludeDefault().Select(c => c.Contents).SelectMany().ToList() ?? new List<IMember>();
             return CreateList(interpreter, contents, false, exact: exact);
         }
+
         public static IPythonCollection CreateTuple(IPythonInterpreter interpreter, IReadOnlyList<IMember> contents, bool exact = false) {
             var collectionType = new PythonCollectionType(null, BuiltinTypeId.Tuple, interpreter, false);
             return new PythonCollection(collectionType, contents, exact: exact);
         }
+
+        public static IPythonCollection CreateConcatenatedTuple(IPythonInterpreter interpreter, params IPythonCollection[] many) {
+            var exact = many?.All(c => c != null && c.IsExact) ?? false;
+            var contents = many?.ExcludeDefault().Select(c => c.Contents).SelectMany().ToList() ?? new List<IMember>();
+            return CreateTuple(interpreter, contents, exact: exact);
+        }
+
         public static IPythonCollection CreateSet(IPythonInterpreter interpreter, IReadOnlyList<IMember> contents, bool flatten = true, bool exact = false) {
             var collectionType = new PythonCollectionType(null, BuiltinTypeId.Set, interpreter, true);
             return new PythonCollection(collectionType, contents, flatten, exact: exact);

--- a/src/Analysis/Ast/Impl/Values/PythonInstance.cs
+++ b/src/Analysis/Ast/Impl/Values/PythonInstance.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Python.Analysis.Values {
             }
             // Do NOT call type unless it is specific (see above) since by default Python type
             // implementation delegates down to the instance and this will yield stack overflow.
-            return this;
+            return null;
         }
 
         public virtual IMember Index(object index) => this; // Helps with str slicing

--- a/src/Analysis/Ast/Test/ExpressionsTests.cs
+++ b/src/Analysis/Ast/Test/ExpressionsTests.cs
@@ -41,7 +41,8 @@ b = 1 + 2. + 3.
 c = 1. + 2 + 3.
 d = 1. + 2. + 3 # d is 'int', should be 'float'
 e = 1 + 1L # e is a 'float', should be 'long' under v2.x (error under v3.x)
-f = 1 / 2 # f is 'int', should be 'float' under v3.x";
+f = 1 / 2 # f is 'int', should be 'float' under v3.x
+g = 1. + 2. + 3j";
 
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable2X);
             analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Float)
@@ -49,7 +50,8 @@ f = 1 / 2 # f is 'int', should be 'float' under v3.x";
                 .And.HaveVariable("c").OfType(BuiltinTypeId.Float)
                 .And.HaveVariable("d").OfType(BuiltinTypeId.Float)
                 .And.HaveVariable("e").OfType(BuiltinTypeId.Long)
-                .And.HaveVariable("f").OfType(BuiltinTypeId.Int);
+                .And.HaveVariable("f").OfType(BuiltinTypeId.Int)
+                .And.HaveVariable("g").OfType(BuiltinTypeId.Complex);
         }
 
         [TestMethod, Priority(0)]
@@ -59,14 +61,16 @@ a = 1. + 2. + 3. # no type info for a, b or c
 b = 1 + 2. + 3.
 c = 1. + 2 + 3.
 d = 1. + 2. + 3 # d is 'int', should be 'float'
-f = 1 / 2 # f is 'int', should be 'float' under v3.x";
+f = 1 / 2 # f is 'int', should be 'float' under v3.x
+g = 1. + 2. + 3j";
 
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Float)
                 .And.HaveVariable("b").OfType(BuiltinTypeId.Float)
                 .And.HaveVariable("c").OfType(BuiltinTypeId.Float)
                 .And.HaveVariable("d").OfType(BuiltinTypeId.Float)
-                .And.HaveVariable("f").OfType(BuiltinTypeId.Float);
+                .And.HaveVariable("f").OfType(BuiltinTypeId.Float)
+                .And.HaveVariable("g").OfType(BuiltinTypeId.Complex);
         }
 
         [TestMethod, Priority(0)]

--- a/src/Analysis/Ast/Test/OperatorTests.cs
+++ b/src/Analysis/Ast/Test/OperatorTests.cs
@@ -110,7 +110,6 @@ b = ~~C()
         }
 
         [TestMethod, Priority(0)]
-        [Ignore]
         public async Task TrueDividePython3X() {
             const string code = @"
 class C:

--- a/src/Analysis/Ast/Test/OperatorTests.cs
+++ b/src/Analysis/Ast/Test/OperatorTests.cs
@@ -296,5 +296,28 @@ x = datetime() - datetime()
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             analysis.Should().HaveVariable("x").OfType("timedelta");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task CompareModules() {
+            const string code = @"
+import os
+import sys
+
+x = os < sys
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Bool);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task CompareUnknown() {
+            const string code = @"
+x = foo < bar
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Bool);
+        }
     }
 }

--- a/src/Analysis/Ast/Test/OperatorTests.cs
+++ b/src/Analysis/Ast/Test/OperatorTests.cs
@@ -127,5 +127,158 @@ c = 'abc' / a
             analysis.Should().HaveVariable("b").OfType(BuiltinTypeId.Int)
                 .And.HaveVariable("c").OfType(BuiltinTypeId.Float);
         }
+
+        [DataRow("add", "+")]
+        [DataRow("sub", "-")]
+        [DataRow("mul", "*")]
+        [DataRow("matmul", "@")]
+        [DataRow("truediv", "/")]
+        [DataRow("and", "&")]
+        [DataRow("or", "|")]
+        [DataRow("xor", "^")]
+        [DataRow("lshift", "<<")]
+        [DataRow("rshift", ">>")]
+        [DataRow("pow", "**")]
+        [DataRow("floordiv", "//")]
+        [DataTestMethod, Priority(0)]
+        public async Task CustomOperators(string func, string op) {
+            var code = $@"
+class C:
+    def __{func}__(self, other):
+        return 42
+    def __r{func}__(self, other):
+        return 3.0
+
+a = C()
+b = a {op} 'abc'
+c = 'abc' {op} a
+d = a {op} a
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("b").OfType(BuiltinTypeId.Int)
+                .And.HaveVariable("c").OfType(BuiltinTypeId.Float)
+                .And.HaveVariable("d").OfType(BuiltinTypeId.Int);
+        }
+
+        [DataRow("lt", "ge", "<")]
+        [DataRow("gt", "le", ">")]
+        [DataRow("ge", "lt", ">=")]
+        [DataRow("eq", "ne", "==")]
+        [DataTestMethod, Priority(0)]
+        public async Task CustomComparison(string func1, string func2, string op) {
+            var code = $@"
+class C:
+    def __{func1}__(self, other):
+        return 42
+
+    def __{func2}__(self, other):
+        return 3.0
+
+a = C()
+b = a {op} 'abc'
+c = 'abc' {op} a
+d = a {op} a
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("b").OfType(BuiltinTypeId.Int)
+                .And.HaveVariable("c").OfType(BuiltinTypeId.Float)
+                .And.HaveVariable("d").OfType(BuiltinTypeId.Int);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ModWithString() {
+            const string code = @"
+class C:
+    def __mod__(self, other):
+        return 42
+    def __rmod__(self, other):
+        return 3.0
+
+a = C()
+b = a % 'abc'
+c = 'abc' % a
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("b").OfType(BuiltinTypeId.Int)
+                .And.HaveVariable("c").OfType(BuiltinTypeId.Str);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task BuiltinMatrixMul() {
+            const string code = "x = 1 @ 2";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Unknown);
+        }
+
+        [DataRow("x = 1 ^ 2", BuiltinTypeId.Int, true)]
+        [DataRow("x = True ^ False", BuiltinTypeId.Bool, true)]
+        [DataRow("x = 1 ^ False", BuiltinTypeId.Int, true)]
+        [DataRow("x = False ^ 1", BuiltinTypeId.Int, true)]
+        [DataRow("x = 1L | 2L", BuiltinTypeId.Long, false)]
+        [DataRow("x = False | 1L", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1L | False", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1L & 2", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1 & 2L", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1.0 & 3j", BuiltinTypeId.Unknown, true)]
+        [DataTestMethod, Priority(0)]
+        public async Task BuiltinBitwise(string code, BuiltinTypeId typ, bool is3x) {
+            var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
+            analysis.Should().HaveVariable("x").OfType(typ);
+        }
+
+        [DataRow("x = 1 << 2", BuiltinTypeId.Int, true)]
+        [DataRow("x = True << False", BuiltinTypeId.Int, true)]
+        [DataRow("x = 1 >> False", BuiltinTypeId.Int, true)]
+        [DataRow("x = False >> 1", BuiltinTypeId.Int, true)]
+        [DataRow("x = 1L << 2L", BuiltinTypeId.Long, false)]
+        [DataRow("x = False << 1L", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1L >> False", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1L >> 2", BuiltinTypeId.Long, false)]
+        [DataRow("x = 1 << 2L", BuiltinTypeId.Long, false)]
+        // [DataRow("x = 1.0 << 3j", BuiltinTypeId.Unknown, true)]
+        [DataTestMethod, Priority(0)]
+        public async Task BuiltinShifting(string code, BuiltinTypeId typ, bool is3x) {
+            var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
+            analysis.Should().HaveVariable("x").OfType(typ);
+        }
+
+        [DataRow("x = 'x' + u'x'")]
+        [DataRow("x = u'x' + u'x'")]
+        [DataRow("x = u'x' + 'x'")]
+        [DataTestMethod, Priority(0)]
+        public async Task UnicodeConcat(string code) {
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable2X);
+            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Unicode);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task OperatorNotImplementedDefault() {
+            const string code = @"
+class C:
+    pass
+
+a = C()
+b = a + a
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("b").OfType("C");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DatetimeTimedelta() {
+            const string code = @"
+from datetime import datetime
+
+x = datetime() - datetime()
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x").OfType("timedelta");
+        }
     }
 }

--- a/src/Analysis/Ast/Test/OperatorTests.cs
+++ b/src/Analysis/Ast/Test/OperatorTests.cs
@@ -246,6 +246,22 @@ c = 'abc' % a
             analysis.Should().HaveVariable("x").OfType(typ);
         }
 
+        [DataRow("x = 1 < 2", true)]
+        [DataRow("x = True > False", true)]
+        [DataRow("x = 1 <= False", true)]
+        [DataRow("x = False >= 1", true)]
+        [DataRow("x = 1L == 2L", false)]
+        [DataRow("x = False != 1L", false)]
+        [DataRow("x = 1L < False", false)]
+        [DataRow("x = 1L > 2", false)]
+        [DataRow("x = 1 != 2L", false)]
+        [DataRow("x = 1.0 == 3j", true)]
+        [DataTestMethod, Priority(0)]
+        public async Task BuiltinComparison(string code, bool is3x) {
+            var analysis = await GetAnalysisAsync(code, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X);
+            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Bool);
+        }
+
         [DataRow("x = 'x' + u'x'")]
         [DataRow("x = u'x' + u'x'")]
         [DataRow("x = u'x' + 'x'")]

--- a/src/Parsing/Impl/Ast/PythonOperator.cs
+++ b/src/Parsing/Impl/Ast/PythonOperator.cs
@@ -96,6 +96,12 @@ namespace Microsoft.Python.Parsing {
             return string.Empty;
         }
 
+        public static bool IsUnary(this PythonOperator self) =>
+            self == PythonOperator.Not ||
+            self == PythonOperator.Pos ||
+            self == PythonOperator.Invert ||
+            self == PythonOperator.Negate;
+
         public static bool IsComparison(this PythonOperator self) => self == PythonOperator.LessThan ||
                     self == PythonOperator.LessThanOrEqual ||
                     self == PythonOperator.GreaterThan ||

--- a/src/Parsing/Impl/Ast/PythonOperator.cs
+++ b/src/Parsing/Impl/Ast/PythonOperator.cs
@@ -112,5 +112,22 @@ namespace Microsoft.Python.Parsing {
                     self == PythonOperator.NotIn ||
                     self == PythonOperator.IsNot ||
                     self == PythonOperator.Is;
+
+        public static PythonOperator InvertComparison(this PythonOperator self) {
+            switch (self) {
+                case PythonOperator.LessThan: return PythonOperator.GreaterThanOrEqual;
+                case PythonOperator.LessThanOrEqual: return PythonOperator.GreaterThan;
+                case PythonOperator.GreaterThan: return PythonOperator.LessThanOrEqual;
+                case PythonOperator.GreaterThanOrEqual: return PythonOperator.LessThan;
+                case PythonOperator.Equal: return PythonOperator.NotEqual;
+                case PythonOperator.NotEqual: return PythonOperator.Equal;
+                case PythonOperator.In: return PythonOperator.NotIn;
+                case PythonOperator.NotIn: return PythonOperator.In;
+                case PythonOperator.IsNot: return PythonOperator.Is;
+                case PythonOperator.Is: return PythonOperator.IsNot;
+            }
+
+            return PythonOperator.None;
+        }
     }
 }


### PR DESCRIPTION
Fixes #860.

This should cover the bulk of the operators; some cases which aren't parsed as BinaryExpressions are not yet handled (e.g. `pow()` should call `__pow__`). Builtins are done by hand, as conversions mean that we can't trust their operator methods. I wrote a script to help me write that code; I'll throw it somewhere when I get the chance.

As far as I've measured, there doesn't seem to be any major performance impact when expanding the operators.