### PR TITLE
Misc performance improvements (AnalysisModuleKey hash, dependency graph list Adds)

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/AnalysisModuleKey.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/AnalysisModuleKey.cs
@@ -26,16 +26,20 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public string FilePath { get; }
         public bool IsTypeshed { get; }
 
+        private readonly int _hashCode;
+
         public AnalysisModuleKey(IPythonModule module) {
             Name = module.Name;
             FilePath = module.ModuleType == ModuleType.CompiledBuiltin ? null : module.FilePath;
             IsTypeshed = module is StubPythonModule stub && stub.IsTypeshed;
+            _hashCode = CreateHashCode(Name, FilePath, IsTypeshed);
         }
 
         public AnalysisModuleKey(string name, string filePath, bool isTypeshed) {
             Name = name;
             FilePath = filePath;
             IsTypeshed = isTypeshed;
+            _hashCode = CreateHashCode(Name, FilePath, IsTypeshed);
         }
 
         public bool Equals(AnalysisModuleKey other)
@@ -43,11 +47,13 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
         public override bool Equals(object obj) => obj is AnalysisModuleKey other && Equals(other);
 
-        public override int GetHashCode() {
+        public override int GetHashCode() => _hashCode;
+
+        private static int CreateHashCode(string name, string filePath, bool isTypeshed) {
             unchecked {
-                var hashCode = (Name != null ? Name.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (FilePath != null ? FilePath.GetPathHashCode() : 0);
-                hashCode = (hashCode * 397) ^ IsTypeshed.GetHashCode();
+                var hashCode = (name != null ? name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (filePath != null ? filePath.GetPathHashCode() : 0);
+                hashCode = (hashCode * 397) ^ isTypeshed.GetHashCode();
                 return hashCode;
             }
         }

--- a/src/Analysis/Ast/Impl/Dependencies/DependencyGraph.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/DependencyGraph.cs
@@ -131,12 +131,12 @@ namespace Microsoft.Python.Analysis.Dependencies {
             var missingKeysHashSet = new HashSet<TKey>();
             for (var i = 0; i < _verticesByIndex.Count; i++) {
                 var vertex = _verticesByIndex[i];
-                var newIncoming = ImmutableArray<int>.Empty;
+                var newIncoming = new List<int>(vertex.IncomingKeys.Count);
                 var oldIncoming = vertex.Incoming;
 
                 foreach (var dependencyKey in vertex.IncomingKeys) {
                     if (_keyToVertexIndex.TryGetValue(dependencyKey, out var index)) {
-                        newIncoming = newIncoming.Add(index);
+                        newIncoming.Add(index);
                     } else {
                         missingKeysHashSet.Add(dependencyKey);
                         if (vertex.IsSealed) {
@@ -146,7 +146,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     }
                 }
 
-                if (newIncoming.SequentiallyEquals(oldIncoming)) {
+                if (newIncoming.Count == oldIncoming.Count && newIncoming.SequenceEqual(oldIncoming)) {
                     continue;
                 }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     vertex = CreateNonSealedVertex(vertex, version, i);
                 }
 
-                vertex.SetIncoming(newIncoming);
+                vertex.SetIncoming(newIncoming.ToImmutableArray());
             }
 
             foreach (var vertex in _verticesByIndex) {

--- a/src/Analysis/Ast/Impl/Dependencies/DependencyGraph.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/DependencyGraph.cs
@@ -131,12 +131,13 @@ namespace Microsoft.Python.Analysis.Dependencies {
             var missingKeysHashSet = new HashSet<TKey>();
             for (var i = 0; i < _verticesByIndex.Count; i++) {
                 var vertex = _verticesByIndex[i];
-                var newIncoming = new List<int>(vertex.IncomingKeys.Count);
+                var newIncomingArr = vertex.IncomingKeys;
+                var newIncomingList = new List<int>(newIncomingArr.Count);
                 var oldIncoming = vertex.Incoming;
 
-                foreach (var dependencyKey in vertex.IncomingKeys) {
+                foreach (var dependencyKey in newIncomingArr) {
                     if (_keyToVertexIndex.TryGetValue(dependencyKey, out var index)) {
-                        newIncoming.Add(index);
+                        newIncomingList.Add(index);
                     } else {
                         missingKeysHashSet.Add(dependencyKey);
                         if (vertex.IsSealed) {
@@ -146,7 +147,9 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     }
                 }
 
-                if (newIncoming.Count == oldIncoming.Count && newIncoming.SequenceEqual(oldIncoming)) {
+                var newIncoming = newIncomingList.ToImmutableArray();
+
+                if (newIncoming.SequentiallyEquals(oldIncoming)) {
                     continue;
                 }
 

--- a/src/Analysis/Ast/Impl/Dependencies/DependencyResolver.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/DependencyResolver.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Analyzer;
+using Microsoft.Python.Core;
 using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Core.Threading;
 
@@ -129,12 +130,12 @@ namespace Microsoft.Python.Analysis.Dependencies {
         }
 
         private static ImmutableArray<WalkingVertex<TKey, TValue>> CreateWalkingGraph(ImmutableArray<DependencyVertex<TKey, TValue>> snapshot, ImmutableArray<DependencyVertex<TKey, TValue>> changedVertices) {
-            var analysisGraph = ImmutableArray<WalkingVertex<TKey, TValue>>.Empty;
+            var analysisGraph = new List<WalkingVertex<TKey, TValue>>(changedVertices.Count);
             var nodesByVertexIndex = new Dictionary<int, WalkingVertex<TKey, TValue>>();
 
             foreach (var vertex in changedVertices) {
                 var node = new WalkingVertex<TKey, TValue>(snapshot[vertex.Index]);
-                analysisGraph = analysisGraph.Add(node);
+                analysisGraph.Add(node);
                 nodesByVertexIndex[vertex.Index] = node;
             }
 
@@ -144,7 +145,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 foreach (var outgoingIndex in node.DependencyVertex.Outgoing) {
                     if (!nodesByVertexIndex.TryGetValue(outgoingIndex, out var outgoingNode)) {
                         outgoingNode = new WalkingVertex<TKey, TValue>(snapshot[outgoingIndex]);
-                        analysisGraph = analysisGraph.Add(outgoingNode);
+                        analysisGraph.Add(outgoingNode);
                         nodesByVertexIndex[outgoingIndex] = outgoingNode;
 
                         queue.Enqueue(outgoingNode);
@@ -154,7 +155,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 }
             }
 
-            return analysisGraph;
+            return analysisGraph.ToImmutableArray();
         }
 
         private static int FindLoops(ImmutableArray<WalkingVertex<TKey, TValue>> graph) {


### PR DESCRIPTION
`AnalysisModuleKey.GetHashCode` was getting called a lot; it does nontrivial work producing a hash for the file path. Precompute it at initialization time (as it will always be called; it's used as a key in multiple `HashSet`s).

![image](https://user-images.githubusercontent.com/5341706/56997477-c3580680-6b5c-11e9-940a-113124f97c8b.png)

Next, avoid calling `Add` repeatedly on `ImmutableArray` instances by using a normal `List` with a capacity hint, and a final `ToImmutableArray` when populated. A lot of the time was being spent allocating new arrays over and over.