### PR TITLE
Defer calls to collections to builtin versions

### DIFF
--- a/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
+++ b/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
@@ -14,6 +14,7 @@
 // permissions and limitations under the License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Values;
@@ -75,9 +76,8 @@ namespace Microsoft.Python.Analysis.Types.Collections {
         public override IMember CreateInstance(string typeName, IArgumentSet args)
             => new PythonCollection(this, args.Arguments.Select(a => a.Value).OfType<IMember>().ToArray());
 
-        // Constructor call
         public override IMember Call(IPythonInstance instance, string memberName, IArgumentSet args)
-            => CreateInstance(Name, args);
+            => DeclaringModule.Interpreter.GetBuiltinType(TypeId)?.Call(instance, memberName, args);
 
         public override IMember Index(IPythonInstance instance, object index)
             => (instance as IPythonCollection)?.Index(index) ?? UnknownType;

--- a/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
+++ b/src/Analysis/Ast/Impl/Types/Collections/PythonCollectionType.cs
@@ -14,7 +14,6 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Values;

--- a/src/Analysis/Ast/Impl/Types/Collections/PythonDictionaryType.cs
+++ b/src/Analysis/Ast/Impl/Types/Collections/PythonDictionaryType.cs
@@ -14,7 +14,6 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
-using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Analysis.Values.Collections;
 using Microsoft.Python.Core;
 
@@ -30,10 +29,6 @@ namespace Microsoft.Python.Analysis.Types.Collections {
                 : EmptyDictionary<IMember, IMember>.Instance;
             return new PythonDictionary(this, contents);
         }
-
-        // Constructor call
-        public override IMember Call(IPythonInstance instance, string memberName, IArgumentSet args)
-            => CreateInstance(Name, args);
 
         public override BuiltinTypeId TypeId => BuiltinTypeId.Dict;
         public override PythonMemberType MemberType => PythonMemberType.Class;


### PR DESCRIPTION
Fixes #1046.

Tests pass as before. There does not appear to be any performance impact, memory usage for my tensorflow test is ~400MB.

I did some checking on what `memberName`s are used with `Call`; while analyzing tensorflow only operators happen, there are no instances where `Call` is used as a constructor.