### PR TITLE
Check _overload when getting docs

### DIFF
--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Python.Analysis.Types {
         #region IPythonFunction
         public FunctionDefinition FunctionDefinition { get; }
         public IPythonType DeclaringType { get; }
-        public override string Documentation => _documentation ?? base.Documentation ?? _overloads.FirstOrDefault()?.Documentation;
+        public override string Documentation => _documentation ?? base.Documentation ?? _overload?.Documentation ?? _overloads?.FirstOrDefault()?.Documentation;
         public virtual bool IsClassMethod { get; private set; }
         public virtual bool IsStatic { get; private set; }
         public override bool IsAbstract => _isAbstract;


### PR DESCRIPTION
The previous PR didn't also update `Documentation`.