### PR TITLE
Allow document change event range to be empty

### DIFF
--- a/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
@@ -41,6 +41,13 @@ namespace Microsoft.Python.Analysis.Documents {
             var lineLoc = SplitLines(_sb).ToArray();
 
             foreach (var change in changes) {
+                if (change.ReplaceAllText) {
+                    _sb = new StringBuilder(change.InsertedText);
+                    lastStart = int.MaxValue;
+                    lineLoc = SplitLines(_sb).ToArray();
+                    continue;
+                }
+
                 var start = NewLineLocation.LocationToIndex(lineLoc, change.ReplacedSpan.Start, _sb.Length);
                 if (start > lastStart) {
                     throw new InvalidOperationException("changes must be in reverse order of start location");

--- a/src/Analysis/Ast/Impl/Documents/DocumentChange.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentChange.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Python.Analysis.Documents {
     public sealed class DocumentChange {
         public string InsertedText { get; set; }
         public SourceSpan ReplacedSpan { get; set; }
+        public bool ReplaceAllText { get; set; }
 
         public static DocumentChange Insert(string text, SourceLocation start) 
             => new DocumentChange { InsertedText = text, ReplacedSpan = new SourceSpan(start, start) };
@@ -41,5 +42,8 @@ namespace Microsoft.Python.Analysis.Documents {
             => Replace(new SourceSpan(start, end), text);
         public static DocumentChange Replace(PythonAst tree, int start, int length, string text)
             => Replace(new SourceSpan(tree.IndexToLocation(start), tree.IndexToLocation(start + length)), text);
+
+        public static DocumentChange ReplaceAll(string text)
+            => new DocumentChange { InsertedText = text, ReplaceAllText = true };
     }
 }

--- a/src/Analysis/Ast/Test/DocumentBufferTests.cs
+++ b/src/Analysis/Ast/Test/DocumentBufferTests.cs
@@ -89,5 +89,43 @@ def g(y):
             Assert.AreEqual(@"abcdef", doc.Text);
             Assert.AreEqual(0, doc.Version);
         }
+
+        [TestMethod, Priority(0)]
+        public void ReplaceAllDocumentBuffer() {
+            var doc = new DocumentBuffer();
+
+            doc.Reset(0, string.Empty);
+            Assert.AreEqual(string.Empty, doc.Text);
+
+            doc.Update(new[] {
+                DocumentChange.ReplaceAll("text")
+            });
+
+            Assert.AreEqual("text", doc.Text);
+            Assert.AreEqual(1, doc.Version);
+
+            doc.Update(new[] {
+                DocumentChange.ReplaceAll("abcdef")
+            });
+
+            Assert.AreEqual(@"abcdef", doc.Text);
+            Assert.AreEqual(2, doc.Version);
+
+            doc.Update(new[] {
+                DocumentChange.Insert("text", SourceLocation.MinValue),
+                DocumentChange.ReplaceAll("1234")
+            });
+
+            Assert.AreEqual(@"1234", doc.Text);
+            Assert.AreEqual(3, doc.Version);
+
+            doc.Update(new[] {
+                DocumentChange.ReplaceAll("1234"),
+                DocumentChange.Insert("text", SourceLocation.MinValue)
+            });
+
+            Assert.AreEqual(@"text1234", doc.Text);
+            Assert.AreEqual(4, doc.Version);
+        }
     }
 }

--- a/src/LanguageServer/Impl/Implementation/Server.Documents.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Documents.cs
@@ -37,11 +37,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             if (doc != null) {
                 var changes = new List<DocumentChange>();
                 foreach (var c in @params.contentChanges) {
-                    Debug.Assert(c.range.HasValue);
-                    var change = new DocumentChange {
-                        InsertedText = c.text,
-                        ReplacedSpan = c.range.Value
-                    };
+                    var change = c.range.HasValue ? DocumentChange.Replace(c.range.Value, c.text) : DocumentChange.ReplaceAll(c.text);
                     changes.Add(change);
                 }
                 doc.Update(changes);


### PR DESCRIPTION
Fixes #1058.

The loop in DocumentBuffer could be improved to skip over changes until the last change with `ReplaceAllText` set, but since the function takes an enumerable I'd need to collect it. I think this case is rare, though.