### PR TITLE
Only use __all__ in star imports

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/DocumentAnalysis.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/DocumentAnalysis.cs
@@ -29,14 +29,14 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     internal sealed class DocumentAnalysis : IDocumentAnalysis {
-        public DocumentAnalysis(IDocument document, int version, IGlobalScope globalScope, IExpressionEvaluator eval, ImmutableArray<string> exportedMemberNames) {
+        public DocumentAnalysis(IDocument document, int version, IGlobalScope globalScope, IExpressionEvaluator eval, IReadOnlyList<string> exportedMemberNames) {
             Check.ArgumentNotNull(nameof(document), document);
             Check.ArgumentNotNull(nameof(globalScope), globalScope);
             Document = document;
             Version = version;
             GlobalScope = globalScope;
             ExpressionEvaluator = eval;
-            ExportedMemberNames = exportedMemberNames;
+            StarImportMemberNames = exportedMemberNames;
         }
 
         #region IDocumentAnalysis
@@ -68,9 +68,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public IExpressionEvaluator ExpressionEvaluator { get; }
 
         /// <summary>
-        /// Members of the module explicitly specified for export
+        /// Members of the module which are transferred during a star import. null means __all__ was not defined.
         /// </summary>
-        public ImmutableArray<string> ExportedMemberNames { get; }
+        public IReadOnlyList<string> StarImportMemberNames { get; }
 
         /// <summary>
         /// Analysis diagnostics.
@@ -95,7 +95,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public IGlobalScope GlobalScope { get; }
         public PythonAst Ast => _emptyAst;
         public IExpressionEvaluator ExpressionEvaluator { get; }
-        public ImmutableArray<string> ExportedMemberNames => ImmutableArray<string>.Empty;
+        public IReadOnlyList<string> StarImportMemberNames => null;
         public IEnumerable<DiagnosticsEntry> Diagnostics => Enumerable.Empty<DiagnosticsEntry>();
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/DocumentAnalysis.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/DocumentAnalysis.cs
@@ -22,21 +22,20 @@ using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
-using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Core.Diagnostics;
 using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     internal sealed class DocumentAnalysis : IDocumentAnalysis {
-        public DocumentAnalysis(IDocument document, int version, IGlobalScope globalScope, IExpressionEvaluator eval, IReadOnlyList<string> exportedMemberNames) {
+        public DocumentAnalysis(IDocument document, int version, IGlobalScope globalScope, IExpressionEvaluator eval, IReadOnlyList<string> starImportMemberNames) {
             Check.ArgumentNotNull(nameof(document), document);
             Check.ArgumentNotNull(nameof(globalScope), globalScope);
             Document = document;
             Version = version;
             GlobalScope = globalScope;
             ExpressionEvaluator = eval;
-            StarImportMemberNames = exportedMemberNames;
+            StarImportMemberNames = starImportMemberNames;
         }
 
         #region IDocumentAnalysis

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
@@ -81,7 +81,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                 return;
             }
 
-            foreach (var memberName in variableModule.GetMemberNames()) {
+            // If __all__ is present, take it, otherwise declare all members from the module that do not begin with an underscore.
+            var memberNames = variableModule.Analysis.StarImportMemberNames ?? variableModule.GetMemberNames().Where(s => !s.StartsWithOrdinal("_"));
+
+            foreach (var memberName in memberNames) {
                 var member = variableModule.GetMember(memberName);
                 if (member == null) {
                     Log?.Log(TraceEventType.Verbose, $"Undefined import: {variableModule.Name}, {memberName}");

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -23,7 +23,6 @@ using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Types.Collections;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
-using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Core.Diagnostics;
 using Microsoft.Python.Parsing.Ast;
 
@@ -197,7 +196,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             if (_allIsUsable && _allReferencesCount >= 1 && GlobalScope.Variables.TryGetVariable(AllVariableName, out var variable)
                 && variable?.Value is IPythonCollection collection && collection.IsExact) {
-                ExportedMemberNames = collection.Contents
+                StarImportMemberNames = collection.Contents
                     .OfType<IPythonConstant>()
                     .Select(c => c.GetString())
                     .Where(s => !string.IsNullOrEmpty(s))
@@ -208,7 +207,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         }
 
         public IGlobalScope GlobalScope => Eval.GlobalScope;
-        public IReadOnlyList<string> ExportedMemberNames { get; private set; }
+        public IReadOnlyList<string> StarImportMemberNames { get; private set; }
 
         /// <summary>
         /// Merges data from stub with the data from the module.

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public ModuleWalker(IServiceContainer services, IPythonModule module, PythonAst ast)
             : base(new ExpressionEval(services, module, ast)) {
             _stubAnalysis = Module.Stub is IDocument doc ? doc.GetAnyAnalysis() : null;
-            ExportedMemberNames = ImmutableArray<string>.Empty;
         }
 
         public override bool Walk(NameExpression node) {
@@ -209,7 +208,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         }
 
         public IGlobalScope GlobalScope => Eval.GlobalScope;
-        public ImmutableArray<string> ExportedMemberNames { get; private set; }
+        public IReadOnlyList<string> ExportedMemberNames { get; private set; }
 
         /// <summary>
         /// Merges data from stub with the data from the module.

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             walker.Complete();
             _analyzerCancellationToken.ThrowIfCancellationRequested();
-            var analysis = new DocumentAnalysis((IDocument)module, version, walker.GlobalScope, walker.Eval, walker.ExportedMemberNames);
+            var analysis = new DocumentAnalysis((IDocument)module, version, walker.GlobalScope, walker.Eval, walker.StarImportMemberNames);
 
             analyzable?.NotifyAnalysisComplete(analysis);
             entry.TrySetAnalysis(analysis, version);

--- a/src/Analysis/Ast/Impl/Definitions/IDocumentAnalysis.cs
+++ b/src/Analysis/Ast/Impl/Definitions/IDocumentAnalysis.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Python.Analysis {
         IExpressionEvaluator ExpressionEvaluator { get; }
 
         /// <summary>
-        /// Members of the module explicitly specified for export
+        /// Members of the module which are transferred during a star import. null means __all__ was not defined.
         /// </summary>
-        ImmutableArray<string> ExportedMemberNames { get; }
+        IReadOnlyList<string> StarImportMemberNames { get; }
 
         /// <summary>
         /// Analysis diagnostics.

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -150,11 +150,6 @@ namespace Microsoft.Python.Analysis.Modules {
         #region IMemberContainer
         public virtual IMember GetMember(string name) => Analysis.GlobalScope.Variables[name]?.Value;
         public virtual IEnumerable<string> GetMemberNames() {
-            // TODO: Filter __all__. See: https://github.com/Microsoft/python-language-server/issues/620
-            if (Analysis.ExportedMemberNames.Count > 0) {
-                return Analysis.ExportedMemberNames;
-            }
-
             // drop imported modules and typing.
             return Analysis.GlobalScope.Variables
                 .Where(v => !(v.Value?.GetPythonType() is PythonModule)


### PR DESCRIPTION
Fixes #867.

I had to change the DocumentAnalysis interface to swap out the ImmutableArray for something that's nullable, to distinguish when `__all__` isn't specified or is unusable. #867 mentions exposing this list through the module; I just accessed it directly through Analysis (since it was there), but I can move it out into its own function/property of the module if that feels better.

Needs a bit more testing, but as far as I can tell, numpy/tensorflow/django (major users of `__all__`) appear to be unaffected by this.