### PR TITLE
Add telemetry event and timer for RPC requests

### DIFF
--- a/src/LanguageServer/Impl/Services/TelemetryService.cs
+++ b/src/LanguageServer/Impl/Services/TelemetryService.cs
@@ -19,9 +19,7 @@ using System.Threading.Tasks;
 using Microsoft.Python.Core.Services;
 
 namespace Microsoft.Python.LanguageServer.Services {
-#pragma warning disable CS0612 // Type or member is obsolete
     public sealed class TelemetryService : ITelemetryService {
-#pragma warning restore CS0612 // Type or member is obsolete
         private readonly IClientApplication _clientApp;
         private readonly string _plsVersion;
 

--- a/src/LanguageServer/Impl/Telemetry/RequestTimer.cs
+++ b/src/LanguageServer/Impl/Telemetry/RequestTimer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Python.LanguageServer.Telemetry {
                 _events.TryGetValue(method, out var eventNum);
 
                 if (eventNum >= MaxEvents) {
-                    return new Timer();
+                    return Timer.Disabled;
                 }
 
                 _events[method] = eventNum + 1;
@@ -55,7 +55,9 @@ namespace Microsoft.Python.LanguageServer.Telemetry {
             private Dictionary<string, string> _extraProperties;
             private Dictionary<string, double> _extraMeasures;
 
-            public Timer() {
+            public static Timer Disabled = new Timer();
+
+            private Timer() {
                 _disabled = true;
             }
 
@@ -66,13 +68,17 @@ namespace Microsoft.Python.LanguageServer.Telemetry {
             }
 
             public void AddProperty(string name, string property) {
-                _extraProperties = _extraProperties ?? new Dictionary<string, string>();
-                _extraProperties[name] = property;
+                if (!_disabled) {
+                    _extraProperties = _extraProperties ?? new Dictionary<string, string>();
+                    _extraProperties[name] = property;
+                }
             }
 
             public void AddMeasure(string name, double measure) {
-                _extraMeasures = _extraMeasures ?? new Dictionary<string, double>();
-                _extraMeasures[name] = measure;
+                if (!_disabled) {
+                    _extraMeasures = _extraMeasures ?? new Dictionary<string, double>();
+                    _extraMeasures[name] = measure;
+                }
             }
 
             public void Dispose() {

--- a/src/LanguageServer/Impl/Telemetry/RequestTimer.cs
+++ b/src/LanguageServer/Impl/Telemetry/RequestTimer.cs
@@ -1,0 +1,105 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.Services;
+
+namespace Microsoft.Python.LanguageServer.Telemetry {
+    internal class RequestTimer {
+        private const int MaxEvents = 10;
+
+        private readonly ITelemetryService _telemetryService;
+
+        private readonly Dictionary<string, int> _events = new Dictionary<string, int>();
+        private readonly object _lock = new object();
+
+        public RequestTimer(ITelemetryService telemetryService) {
+            _telemetryService = telemetryService;
+        }
+
+        public Timer Time(string method) {
+            lock (_lock) {
+                _events.TryGetValue(method, out var eventNum);
+
+                if (eventNum >= MaxEvents) {
+                    return new Timer();
+                }
+
+                _events[method] = eventNum + 1;
+
+                return new Timer(method, _telemetryService);
+            }
+        }
+
+        public class Timer : IDisposable {
+            private readonly bool _disabled;
+            private readonly string _method;
+            private readonly ITelemetryService _telemetryService;
+            private readonly Stopwatch _stopwatch;
+
+            private Dictionary<string, string> _extraProperties;
+            private Dictionary<string, double> _extraMeasures;
+
+            public Timer() {
+                _disabled = true;
+            }
+
+            public Timer(string method, ITelemetryService telemetryService) {
+                _method = method;
+                _telemetryService = telemetryService;
+                _stopwatch = Stopwatch.StartNew();
+            }
+
+            public void AddProperty(string name, string property) {
+                _extraProperties = _extraProperties ?? new Dictionary<string, string>();
+                _extraProperties[name] = property;
+            }
+
+            public void AddMeasure(string name, double measure) {
+                _extraMeasures = _extraMeasures ?? new Dictionary<string, double>();
+                _extraMeasures[name] = measure;
+            }
+
+            public void Dispose() {
+                if (_disabled) {
+                    return;
+                }
+
+                _stopwatch.Stop();
+
+                var e = Telemetry.CreateEvent("rpc.request");
+                e.Properties["method"] = _method;
+                e.Measurements["elapsedMs"] = _stopwatch.Elapsed.TotalMilliseconds;
+
+                if (_extraProperties != null) {
+                    foreach (var (key, value) in _extraProperties) {
+                        e.Properties[key] = value;
+                    }
+                }
+
+                if (_extraMeasures != null) {
+                    foreach (var (key, value) in _extraMeasures) {
+                        e.Measurements[key] = value;
+                    }
+                }
+
+                _telemetryService.SendTelemetryAsync(e).DoNotWait();
+            }
+        }
+    }
+}

--- a/src/LanguageServer/Impl/Telemetry/Telemetry.cs
+++ b/src/LanguageServer/Impl/Telemetry/Telemetry.cs
@@ -22,7 +22,7 @@ using Microsoft.Python.Core.Services;
 using Microsoft.Python.LanguageServer.Protocol;
 using StreamJsonRpc;
 
-namespace Microsoft.Python.LanguageServer.Implementation {
+namespace Microsoft.Python.LanguageServer.Telemetry {
     internal class Telemetry {
         private const string EventPrefix = "python_language_server/";
 


### PR DESCRIPTION
Closes #1068.

I did this in `LanguageServer.cs` instead of further downstream in order to get the "true" request time, i.e. I want to see the time that was spent waiting in the prioritizer if any. Where required, some functions now await their result instead of returning the task, otherwise the timing will only capture the time to create a task and not to complete it.

To limit the number of events sent, it'll only send up to 10 per method. Another solution might be to debounce it using a few IdleTimeActions that reset a boolean per event.

I only added this to the methods I thought would be interesting to examine. Some were explicitly skipped (document changes, line formatting, etc). The `Timer` supports adding extra measures and properties, which are used to send the number of completion items, symbols, etc, for profiling.