### PR TITLE
Fix hint extraction in Python 2

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Hints.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Hints.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
 
             // Type alone is not a valid syntax, so we need to simulate the annotation.
-            var typeString = content.Substring(hintStart, i - hintStart);
+            var typeString = content.Substring(hintStart, i - hintStart).Trim();
             return GetTypeFromString(typeString);
         }
 
@@ -88,7 +88,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             typeString = $"x: {typeString}";
             using (var sr = new StringReader(typeString)) {
                 var sink = new CollectingErrorSink();
-                var parser = Parser.CreateParser(sr, Module.Interpreter.LanguageVersion, new ParserOptions { ErrorSink = sink });
+                // Always use Python 3 since expression is an annotation which is 3.x
+                var parser = Parser.CreateParser(sr, PythonLanguageVersion.V36, new ParserOptions { ErrorSink = sink });
                 var ast = parser.ParseFile();
                 var exprStatement = (ast?.Body as SuiteStatement)?.Statements?.FirstOrDefault() as ExpressionStatement;
                 if (!(Statement.GetExpression(exprStatement) is ExpressionWithAnnotation annExpr) || sink.Errors.Count > 0) {

--- a/src/Analysis/Ast/Test/PepHintTests.cs
+++ b/src/Analysis/Ast/Test/PepHintTests.cs
@@ -19,6 +19,7 @@ using FluentAssertions;
 using Microsoft.Python.Analysis.Tests.FluentAssertions;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
+using Microsoft.Python.Parsing.Tests;
 using Microsoft.Python.Tests.Utilities.FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
@@ -75,6 +76,19 @@ class Response: # truncated
 
             c.Should().HaveMember<IPythonInstance>("elapsed")
                 .Which.Should().HaveSameMembersAs(timedelta);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task HintsInPython2() {
+            const string code = @"
+def func(x):
+    y = x # type: int
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable2X);
+
+            analysis.Should().HaveFunction("func")
+                .Which.Should().HaveVariable("y")
+                .Which.Should().HaveType(BuiltinTypeId.Int);
         }
     }
 }


### PR DESCRIPTION
Fixes #1073 

Internally expression is extracted and parsed as annotation but since parser was created off the current configuration, in case of 2.7 it was unable to parse type annotations. The fix is to always parse hints as 3.x.