### PR TITLE
Python inspector service

### DIFF
--- a/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
+++ b/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
@@ -20,6 +20,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Python.Analysis.Inspection {
     public interface IPythonInspector {
-        Task<IReadOnlyList<string>> GetModuleMemberNames(string moduleName);
+        Task<ModuleMemberNamesResponse> GetModuleMemberNames(string moduleName);
+    }
+
+    public class ModuleMemberNamesResponse {
+        public IReadOnlyList<string> Members;
+        public IReadOnlyList<string> All;
     }
 }

--- a/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
+++ b/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
@@ -21,6 +21,8 @@ using System.Threading.Tasks;
 namespace Microsoft.Python.Analysis.Inspection {
     public interface IPythonInspector {
         Task<ModuleMemberNamesResponse> GetModuleMemberNames(string moduleName);
+
+        Task<string> GetModuleVersion(string moduleName);
     }
 
     public class ModuleMemberNamesResponse {

--- a/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
+++ b/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
@@ -1,0 +1,25 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Python.Analysis.Inspection {
+    public interface IPythonInspector {
+        Task<IReadOnlyList<string>> GetModuleMemberNames(string moduleName);
+    }
+}

--- a/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
+++ b/src/Analysis/Ast/Impl/Inspection/IPythonInspector.cs
@@ -13,16 +13,15 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Python.Analysis.Inspection {
     public interface IPythonInspector {
-        Task<ModuleMemberNamesResponse> GetModuleMemberNames(string moduleName);
+        Task<ModuleMemberNamesResponse> GetModuleMemberNamesAsync(string moduleName, CancellationToken cancellationToken = default);
 
-        Task<string> GetModuleVersion(string moduleName);
+        Task<string> GetModuleVersionAsync(string moduleName, CancellationToken cancellationToken = default);
     }
 
     public class ModuleMemberNamesResponse {

--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -27,6 +27,9 @@
     <Content Include="scrape_module.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="inspector.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Typeshed\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -26,7 +26,8 @@ import inspect
 import importlib
 import os.path
 
-sys.stderr = open(os.path.join(os.path.expanduser("~"), "log.txt"), "a")
+# Uncomment to send stderr somewhere readable.
+# sys.stderr = open(os.path.join(os.path.expanduser("~"), "log.txt"), "a")
 
 if sys.version_info >= (3,):
     stdout = sys.stdout.buffer

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -46,15 +46,12 @@ def write_stdout(data):
     stdout.flush()
 
 
-HEADER = "Content-Length: "
-HEADER_LEN = len(HEADER)
-
 METHOD_NOT_FOUND = -32601
 INTERNAL_ERROR = -32603
 
 
 def read_request():
-    length = None
+    headers = dict()
 
     # Read headers
     while True:
@@ -62,11 +59,13 @@ def read_request():
         if not line:
             break
 
-        if line.startswith(HEADER):
-            length = int(line[HEADER_LEN:])
+        key, _, value = line.partition(":")
+        headers[key] = value
 
-    if length is None:
-        raise IOError("Content-Length is missing")
+    try:
+        length = int(headers["Content-Length"])
+    except (KeyError, ValueError):
+        raise IOError("Content-Length is missing or invalid")
 
     body = ""
     while length > 0:

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -224,6 +224,11 @@ def find_dist(module_name):
         module_name = ".".join(split[:-1])
 
 
+@mux.handler("$/cancelRequest")
+def cancel_request(params):
+    return None
+
+
 @mux.handler("moduleMemberNames")
 def module_member_names(module_name):
     try:

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -180,7 +180,9 @@ def build_dists():
         module_prefixes = top_level.splitlines()
 
         for prefix in module_prefixes:
-            dists[prefix] = d
+            prefix = prefix.strip()
+            if prefix:
+                dists[prefix] = d
 
     return dists
 
@@ -233,9 +235,10 @@ def module_version(module_name):
     except:
         pass
 
-    d = find_dist(module_name)
-    if d:
-        version = d.version
+    if not version:
+        d = find_dist(module_name)
+        if d:
+            version = d.version
 
     return version
 

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -173,7 +173,14 @@ def build_dists():
     dists = dict()
 
     for d in pkg_resources.WorkingSet():
-        top_level = d.get_metadata("top_level.txt")
+        top_level = None
+
+        try:
+            top_level = d.get_metadata("top_level.txt")
+        except:
+            pass
+
+        # TODO: Figure out how to handle dists which don't ship with top_level.txt (like PyQt5)
         if not top_level:
             continue
 

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -24,8 +24,9 @@ import sys
 import time
 import inspect
 import importlib
+import os.path
 
-sys.stderr = open("C:\\Users\\jabaile\\Desktop\\log.txt", "a")
+sys.stderr = open(os.path.join(os.path.expanduser("~"), "log.txt"), "a")
 
 if sys.version_info >= (3,):
     stdout = sys.stdout.buffer
@@ -53,7 +54,6 @@ INTERNAL_ERROR = -32603
 def read_request():
     headers = dict()
 
-    # Read headers
     while True:
         line = sys.stdin.readline().rstrip("\r\n")
         if not line:
@@ -152,7 +152,11 @@ def do_not_inspect(v):
 def module_members(module_name):
     module = importlib.import_module(module_name)
     members = inspect.getmembers(module)
-    return [name for name, _ in members]
+
+    return {
+        "members": [name for name, _ in members],
+        "all": getattr(module, "__all__", None),
+    }
 
 
 def main():

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -236,9 +236,12 @@ def module_version(module_name):
         pass
 
     if not version:
-        d = find_dist(module_name)
-        if d:
-            version = d.version
+        try:
+            d = find_dist(module_name)
+            if d:
+                version = d.version
+        except:
+            pass
 
     return version
 

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -183,11 +183,8 @@ def module_members(module_name):
 
 
 def main():
-    try:
-        for request in requests():
-            mux.handle(request)
-    except EOFError:
-        return
+    for request in requests():
+        mux.handle(request)
 
 
 if __name__ == "__main__":

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -60,7 +60,7 @@ def write_stdout(data):
         data = data.encode("utf-8")
 
     stdout.write(data)
-    # stdout.flush()
+    stdout.flush()
 
 
 METHOD_NOT_FOUND = -32601

--- a/src/Analysis/Ast/Impl/inspector.py
+++ b/src/Analysis/Ast/Impl/inspector.py
@@ -1,0 +1,105 @@
+# Python Tools for Visual Studio
+# Copyright(c) Microsoft Corporation
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+# IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+
+from __future__ import print_function
+
+import json
+import sys
+import time
+import inspect
+import importlib
+
+HEADER = "Content-Length: "
+HEADER_LEN = len(HEADER)
+
+
+def read_request():
+    content_length = None
+
+    # Read headers
+    while True:
+        line = sys.stdin.readline()
+        if not line.rstrip("\r\n"):
+            break
+
+        if line.startswith(HEADER):
+            content_length = int(line[HEADER_LEN:])
+
+    # Content-Length is required
+    assert content_length
+
+    data = sys.stdin.read(content_length)
+    return json.loads(data)
+
+
+def write_response(id, result):
+    # TODO: errors?
+    s = json.dumps({"jsonrpc": "2.0", "id": id, "result": result})
+
+    data = "Content-Length: {}\r\n\r\n".format(len(s)) + s
+    sys.stdout.buffer.write(bytes(data, "utf-8"))
+    sys.stdout.buffer.flush()
+
+
+class Mux(object):
+    def __init__(self):
+        self.handlers = {}
+
+    def handler(self, method):
+        def decorator(func):
+            self.handlers[method] = func
+            return func
+
+        return decorator
+
+    def handle(self, request):
+        handler = self.handlers.get(request["method"], lambda request: None)
+        result = handler(*request["params"])
+        write_response(request["id"], result)
+
+
+mux = Mux()
+
+
+def do_not_inspect(v):
+    # https://github.com/Microsoft/python-language-server/issues/740
+    # https://github.com/cython/cython/issues/1470
+    if type(v).__name__ != "fused_cython_function":
+        return False
+
+    # If a fused function has __defaults__, then attempting to access
+    # __kwdefaults__ will fail if generated before cython 0.29.6.
+    return bool(getattr(v, "__defaults__", False))
+
+
+@mux.handler("moduleMembers")
+def module_members(module_name):
+    try:
+        module = importlib.import_module(module_name)
+        members = inspect.getmembers(module)
+        return [name for name, _ in members]
+    except:
+        # TODO: Don't do this; return an error over RPC.
+        return None
+
+def main():
+    while True:
+        request = read_request()
+        mux.handle(request)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/LanguageServer/Impl/Services/PythonInspectorService.cs
+++ b/src/LanguageServer/Impl/Services/PythonInspectorService.cs
@@ -1,0 +1,101 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Python.Analysis;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.IO;
+using Microsoft.Python.Core.OS;
+using StreamJsonRpc;
+
+namespace Microsoft.Python.LanguageServer.Services {
+    internal class PythonInspectorService : IDisposable {
+        private readonly IProcessServices _procService;
+        private readonly IPythonInterpreter _interpreter;
+
+        private readonly object _lock = new object();
+        private JsonRpc _rpc;
+
+        public PythonInspectorService(IServiceContainer services) {
+            _procService = services.GetService<IProcessServices>();
+            _interpreter = services.GetService<IPythonInterpreter>();
+        }
+
+        private JsonRpc Rpc {
+            get {
+                lock (_lock) {
+                    if (_rpc?.IsDisposed == false) {
+                        return _rpc;
+                    }
+
+                    _rpc = CreateJsonRpc();
+                    return _rpc;
+                }
+            }
+        }
+
+        private JsonRpc CreateJsonRpc() {
+            if (!InstallPath.TryGetFile("inspector.py", out var scriptPath)) {
+                return null;
+            }
+
+            return PythonRpc.Create(_procService, _interpreter.Configuration.InterpreterPath, scriptPath);
+        }
+
+        public Task<List<string>> GetModuleMembers(string moduleName) {
+            return Rpc.InvokeAsync<List<string>>("moduleMembers", moduleName);
+        }
+
+        public void Dispose() {
+            _rpc?.Dispose();
+        }
+
+        private class PythonRpc : JsonRpc {
+            private readonly IProcessServices _procServices;
+            private IProcess _process;
+
+            private PythonRpc(IProcessServices procServices, IProcess process) : base(process.StandardInput.BaseStream, process.StandardOutput.BaseStream) {
+                _procServices = procServices;
+                _process = process;
+                StartListening();
+            }
+
+            public static PythonRpc Create(IProcessServices procServices, string exe, params string[] args) {
+                var startInfo = new ProcessStartInfo(exe, args.AsQuotedArguments()) {
+                    UseShellExecute = false,
+                    ErrorDialog = false,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                };
+
+                var process = procServices.Start(startInfo);
+                return new PythonRpc(procServices, process);
+            }
+
+            protected override void Dispose(bool disposing) {
+                base.Dispose(disposing);
+                if (_process?.HasExited == false) {
+                    _procServices.Kill(_process);
+                    _process = null;
+                }
+            }
+        }
+    }
+}

--- a/src/LanguageServer/Impl/Services/PythonInspectorService.cs
+++ b/src/LanguageServer/Impl/Services/PythonInspectorService.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Python.LanguageServer.Services {
             return Rpc.InvokeAsync<ModuleMemberNamesResponse>("moduleMemberNames", moduleName);
         }
 
+        public Task<string> GetModuleVersion(string moduleName) {
+            return Rpc.InvokeAsync<string>("moduleVersion", moduleName);
+        }
+
         public void Dispose() {
             _rpc?.Dispose();
         }

--- a/src/LanguageServer/Impl/Services/PythonInspectorService.cs
+++ b/src/LanguageServer/Impl/Services/PythonInspectorService.cs
@@ -52,14 +52,14 @@ namespace Microsoft.Python.LanguageServer.Services {
 
         private JsonRpc CreateJsonRpc() {
             if (!InstallPath.TryGetFile("inspector.py", out var scriptPath)) {
-                return null;
+                return null; // Throw?
             }
 
             return PythonRpc.Create(_procService, _interpreter.Configuration.InterpreterPath, scriptPath);
         }
 
-        public Task<List<string>> GetModuleMembers(string moduleName) {
-            return Rpc.InvokeAsync<List<string>>("moduleMembers", moduleName);
+        public Task<List<string>> ModuleMemberNames(string moduleName) {
+            return Rpc.InvokeAsync<List<string>>("moduleMemberNames", moduleName);
         }
 
         public void Dispose() {

--- a/src/LanguageServer/Impl/Services/PythonInspectorService.cs
+++ b/src/LanguageServer/Impl/Services/PythonInspectorService.cs
@@ -59,8 +59,8 @@ namespace Microsoft.Python.LanguageServer.Services {
             return PythonRpc.Create(_procService, _interpreter.Configuration.InterpreterPath, scriptPath);
         }
 
-        public Task<IReadOnlyList<string>> GetModuleMemberNames(string moduleName) {
-            return Rpc.InvokeAsync<List<string>>("moduleMemberNames", moduleName);
+        public Task<ModuleMemberNamesResponse> GetModuleMemberNames(string moduleName) {
+            return Rpc.InvokeAsync<ModuleMemberNamesResponse>("moduleMemberNames", moduleName);
         }
 
         public void Dispose() {

--- a/src/LanguageServer/Impl/Services/PythonInspectorService.cs
+++ b/src/LanguageServer/Impl/Services/PythonInspectorService.cs
@@ -19,13 +19,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
+using Microsoft.Python.Analysis.Inspection;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.IO;
 using Microsoft.Python.Core.OS;
 using StreamJsonRpc;
 
 namespace Microsoft.Python.LanguageServer.Services {
-    internal class PythonInspectorService : IDisposable {
+    internal class PythonInspectorService : IPythonInspector, IDisposable {
         private readonly IProcessServices _procService;
         private readonly IPythonInterpreter _interpreter;
 
@@ -58,7 +59,7 @@ namespace Microsoft.Python.LanguageServer.Services {
             return PythonRpc.Create(_procService, _interpreter.Configuration.InterpreterPath, scriptPath);
         }
 
-        public Task<List<string>> ModuleMemberNames(string moduleName) {
+        public Task<IReadOnlyList<string>> GetModuleMemberNames(string moduleName) {
             return Rpc.InvokeAsync<List<string>>("moduleMemberNames", moduleName);
         }
 

--- a/src/LanguageServer/Impl/Services/PythonInspectorService.cs
+++ b/src/LanguageServer/Impl/Services/PythonInspectorService.cs
@@ -15,8 +15,8 @@
 // permissions and limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Inspection;
@@ -60,12 +60,12 @@ namespace Microsoft.Python.LanguageServer.Services {
             return PythonRpc.Create(procServices, interpreter.Configuration.InterpreterPath, scriptPath);
         }
 
-        public Task<ModuleMemberNamesResponse> GetModuleMemberNames(string moduleName) {
-            return Rpc.InvokeAsync<ModuleMemberNamesResponse>("moduleMemberNames", moduleName);
+        public Task<ModuleMemberNamesResponse> GetModuleMemberNamesAsync(string moduleName, CancellationToken cancellationToken = default) {
+            return Rpc.InvokeWithCancellationAsync<ModuleMemberNamesResponse>("moduleMemberNames", new[] { moduleName }, cancellationToken);
         }
 
-        public Task<string> GetModuleVersion(string moduleName) {
-            return Rpc.InvokeAsync<string>("moduleVersion", moduleName);
+        public Task<string> GetModuleVersionAsync(string moduleName, CancellationToken cancellationToken = default) {
+            return Rpc.InvokeWithCancellationAsync<string>("moduleVersion", new[] { moduleName }, cancellationToken);
         }
 
         public void Dispose() {

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -121,6 +121,22 @@ namespace Microsoft.Python.LanguageServer.Tests {
                 version.Should().BeNull();
             }
         }
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task UseAfterDispose(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                var version = await inspector.GetModuleVersion("setuptools");
+                version.Should().NotBeNullOrEmpty();
+
+                inspector.Dispose();
+
+                version = await inspector.GetModuleVersion("setuptools");
+                version.Should().NotBeNullOrEmpty();
+            }
+        }
     }
 }
 

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Python.LanguageServer.Tests {
         public async Task SysMemberNames(bool is3x) {
             using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                var result = await inspector.ModuleMemberNames("sys");
+                var result = await inspector.GetModuleMemberNames("sys");
                 result.Should().Contain("stdout");
             }
         }

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -45,8 +45,23 @@ namespace Microsoft.Python.LanguageServer.Tests {
                 for (var i = 0; i < 2; i++) {
                     var response = await inspector.GetModuleMemberNames("sys");
                     response.Should().NotBeNull();
-                    response.Members.Should().Contain("stdout");
+                    response.Members.Should().Contain("stdout").And.NotContain("__all__");
                     response.All.Should().BeNull();
+                }
+            }
+        }
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task MemberNamesOsPath(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                for (var i = 0; i < 2; i++) {
+                    var response = await inspector.GetModuleMemberNames("os.path");
+                    response.Should().NotBeNull();
+                    response.Members.Should().Contain("join").And.Contain("__all__");
+                    response.All.Should().Contain("join").And.NotContain("__all__");
                 }
             }
         }

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -99,6 +99,28 @@ namespace Microsoft.Python.LanguageServer.Tests {
                 }
             }
         }
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task ModuleVersionSetuptools(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                var version = await inspector.GetModuleVersion("setuptools");
+                version.Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task ModuleVersionNotFound(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                var version = await inspector.GetModuleVersion("thismoduledoesnotexist");
+                version.Should().BeNull();
+            }
+        }
     }
 }
 

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Python.Analysis.Tests;
+using Microsoft.Python.LanguageServer.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Microsoft.Python.LanguageServer.Tests {
+    [TestClass]
+    public class PythonInspectorServiceTests : AnalysisTestBase {
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod, Priority(0)]
+        public async Task SysStdout() {
+            using (var s = await CreateServicesAsync(null, null, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                var result = await inspector.GetModuleMembers("sys");
+                result.Should().Contain("stdout");
+            }
+        }
+    }
+}
+

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -42,12 +42,10 @@ namespace Microsoft.Python.LanguageServer.Tests {
         public async Task MemberNamesSys(bool is3x) {
             using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                for (var i = 0; i < 2; i++) {
-                    var response = await inspector.GetModuleMemberNames("sys");
-                    response.Should().NotBeNull();
-                    response.Members.Should().Contain("stdout").And.NotContain("__all__");
-                    response.All.Should().BeNull();
-                }
+                var response = await inspector.GetModuleMemberNames("sys");
+                response.Should().NotBeNull();
+                response.Members.Should().Contain("stdout").And.NotContain("__all__");
+                response.All.Should().BeNull();
             }
         }
 
@@ -57,12 +55,10 @@ namespace Microsoft.Python.LanguageServer.Tests {
         public async Task MemberNamesOsPath(bool is3x) {
             using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                for (var i = 0; i < 2; i++) {
-                    var response = await inspector.GetModuleMemberNames("os.path");
-                    response.Should().NotBeNull();
-                    response.Members.Should().Contain("join").And.Contain("__all__");
-                    response.All.Should().Contain("join").And.NotContain("__all__");
-                }
+                var response = await inspector.GetModuleMemberNames("os.path");
+                response.Should().NotBeNull();
+                response.Members.Should().Contain("join").And.Contain("__all__");
+                response.All.Should().Contain("join").And.NotContain("__all__");
             }
         }
 
@@ -72,9 +68,23 @@ namespace Microsoft.Python.LanguageServer.Tests {
         public async Task MemberNamesNotFound(bool is3x) {
             using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                for (var i = 0; i < 2; i++) {
+                var response = await inspector.GetModuleMemberNames("thismoduledoesnotexist");
+                response.Should().BeNull();
+            }
+        }
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task MemberNamesMultipleRequests(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                for (var i = 0; i < 10; i++) {
                     var response = await inspector.GetModuleMemberNames("thismoduledoesnotexist");
                     response.Should().BeNull();
+
+                    response = await inspector.GetModuleMemberNames("os.path");
+                    response.Should().NotBeNull();
                 }
             }
         }

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -39,13 +39,28 @@ namespace Microsoft.Python.LanguageServer.Tests {
         [DataRow(true)]
         [DataRow(false)]
         [DataTestMethod, Priority(0)]
-        public async Task SysMemberNames(bool is3x) {
+        public async Task MemberNamesSys(bool is3x) {
             using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                var response = await inspector.GetModuleMemberNames("sys");
-                response.Should().NotBeNull();
-                response.Members.Should().Contain("stdout");
-                response.All.Should().BeNull();
+                for (var i = 0; i < 2; i++) {
+                    var response = await inspector.GetModuleMemberNames("sys");
+                    response.Should().NotBeNull();
+                    response.Members.Should().Contain("stdout");
+                    response.All.Should().BeNull();
+                }
+            }
+        }
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task MemberNamesNotFound(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
+            using (var inspector = new PythonInspectorService(s)) {
+                for (var i = 0; i < 2; i++) {
+                    var response = await inspector.GetModuleMemberNames("thismoduledoesnotexist");
+                    response.Should().BeNull();
+                }
             }
         }
     }

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Analysis.Tests;
 using Microsoft.Python.LanguageServer.Services;
+using Microsoft.Python.Parsing.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 
@@ -35,11 +36,13 @@ namespace Microsoft.Python.LanguageServer.Tests {
         [TestCleanup]
         public void Cleanup() => TestEnvironmentImpl.TestCleanup();
 
-        [TestMethod, Priority(0)]
-        public async Task SysStdout() {
-            using (var s = await CreateServicesAsync(null, null, null))
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
+        public async Task SysMemberNames(bool is3x) {
+            using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                var result = await inspector.GetModuleMembers("sys");
+                var result = await inspector.ModuleMemberNames("sys");
                 result.Should().Contain("stdout");
             }
         }

--- a/src/LanguageServer/Test/PythonInspectorServiceTests.cs
+++ b/src/LanguageServer/Test/PythonInspectorServiceTests.cs
@@ -42,8 +42,10 @@ namespace Microsoft.Python.LanguageServer.Tests {
         public async Task SysMemberNames(bool is3x) {
             using (var s = await CreateServicesAsync(null, is3x ? PythonVersions.LatestAvailable3X : PythonVersions.LatestAvailable2X, null))
             using (var inspector = new PythonInspectorService(s)) {
-                var result = await inspector.GetModuleMemberNames("sys");
-                result.Should().Contain("stdout");
+                var response = await inspector.GetModuleMemberNames("sys");
+                response.Should().NotBeNull();
+                response.Members.Should().Contain("stdout");
+                response.All.Should().BeNull();
             }
         }
     }


### PR DESCRIPTION
Opening to get some feedback and thoughts.

The inspector is a partial JSON-RPC server, which takes requests from the LS. Adding more methods is pretty simple, just decorate a function.

~Right now, all it does is get the module member names and `__all__`. This is marginally useful (especially since it's not used anywhere), but we can add more methods to do something like the scraper for full type info, or check for installed versions, etc.~

Some things I'm not sure about are:
- If the process dies, it will be restarted, but the requests that were issued to the crashed process will fail and throw.
- The process should periodically be killed to save on memory.
- The scraper takes extra arguments for path modification which I'm not sure I can really handle due to the process persisting (see `initial_import` in `scrape_module.py`).
- Because this uses StreamJsonRpc, I have to implement it in the language server assembly, otherwise the analysis has to depend on that library. The best I can do is declare the interface outside of the LS, but where I've declared it is probably wrong.
- Because StreamJsonRpc is all async, using the inspector in the analyzer requires some weird tasking (I did a hack in PythonModule to call the inspector for GetModuleMembers, which meant `Services.GetService<IPythonInspector>()?.GetModuleMemberNames(Name)?.Result?.Members`; not thrilling).