### PR TITLE
Prevent SO on documentation fetch

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -135,7 +135,8 @@ namespace Microsoft.Python.Analysis.Modules {
                     _documentation = m.TryGetConstant<string>(out var s) ? s : string.Empty;
                     if (string.IsNullOrEmpty(_documentation)) {
                         m = GetMember($"_{Name}");
-                        _documentation = m?.GetPythonType()?.Documentation;
+                        var t = m?.GetPythonType();
+                        _documentation = t != null && !t.Equals(this) ? t.Documentation : null;
                         if (string.IsNullOrEmpty(_documentation)) {
                             _documentation = TryGetDocFromModuleInitFile();
                         }
@@ -496,7 +497,7 @@ namespace Microsoft.Python.Analysis.Modules {
                         // Also, handle quadruple+ quotes.
                         line = line.Trim();
                         line = line.All(c => c == quote[0]) ? quote : line;
-                        if (line.EndsWithOrdinal(quote) && line.IndexOf(quote, StringComparison.Ordinal) < line.LastIndexOf(quote, StringComparison.Ordinal)) { 
+                        if (line.EndsWithOrdinal(quote) && line.IndexOf(quote, StringComparison.Ordinal) < line.LastIndexOf(quote, StringComparison.Ordinal)) {
                             return line.Substring(quote.Length, line.Length - 2 * quote.Length).Trim();
                         }
                         var sb = new StringBuilder();

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -81,8 +81,12 @@ namespace Microsoft.Python.Analysis.Types {
             FunctionDefinition = fd;
             DeclaringType = declaringType;
 
+            // For __init__ documentation may either come from the function node of the the declaring
+            // type. Note that if there is no documentation on the class node, the class will try and
+            // get documentation from its __init__ function, delegating down to this type. So we need
+            // to set documentation statically for __init__ here or we may end up/ with stack overflows.
             if (fd.Name == "__init__") {
-                _documentation = declaringType?.Documentation;
+                _documentation = declaringType?.Documentation ?? fd.Documentation;
             }
             ProcessDecorators(fd);
         }
@@ -139,7 +143,7 @@ namespace Microsoft.Python.Analysis.Types {
 
         internal ImmutableArray<string> Dependencies { get; private set; } = ImmutableArray<string>.Empty;
 
-        internal void AddOverload(IPythonFunctionOverload overload) 
+        internal void AddOverload(IPythonFunctionOverload overload)
             => _overloads = _overloads.Count > 0 ? _overloads.Add(overload) : ImmutableArray<IPythonFunctionOverload>.Create(overload);
 
         internal IPythonFunctionType ToUnbound() => new PythonUnboundMethod(this);

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -553,5 +553,24 @@ a = y().a()
             analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Int);
         }
 
+        [TestMethod, Priority(0)]
+        public async Task DocumentationWithCycleInBases() {
+            const string code = @"
+class A(C):
+    '''class A doc'''
+
+class B(A):
+    def __init__(self):
+        '''class B doc'''
+        pass
+
+class C(B):
+    '''class C doc'''
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveClass("A").Which.Should().HaveDocumentation("class A doc");
+            analysis.Should().HaveClass("B").Which.Should().HaveDocumentation("class B doc");
+            analysis.Should().HaveClass("C").Which.Should().HaveDocumentation("class C doc");
+        }
     }
 }

--- a/src/Core/Impl/Extensions/IOExtensions.cs
+++ b/src/Core/Impl/Extensions/IOExtensions.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Python.Core.IO {
             for (var retries = 100; retries > 0; --retries) {
                 try {
                     fs.WriteAllText(filePath, text);
-                } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is ObjectDisposedException) {
+                } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
                     failed = true;
                     Thread.Sleep(10);
                 }

--- a/src/Core/Impl/Extensions/IOExtensions.cs
+++ b/src/Core/Impl/Extensions/IOExtensions.cs
@@ -114,9 +114,7 @@ namespace Microsoft.Python.Core.IO {
             for (var retries = 100; retries > 0; --retries) {
                 try {
                     return fs.ReadAllText(file);
-                } catch (UnauthorizedAccessException) {
-                    Thread.Sleep(10);
-                } catch (IOException) {
+                } catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException || ex is ObjectDisposedException) {
                     Thread.Sleep(10);
                 }
             }
@@ -124,18 +122,20 @@ namespace Microsoft.Python.Core.IO {
         }
 
         public static void WriteTextWithRetry(this IFileSystem fs, string filePath, string text) {
-            try {
-                using (var stream = fs.OpenWithRetry(filePath, FileMode.Create, FileAccess.Write, FileShare.Read)) {
-                    if (stream != null) {
-                        var bytes = Encoding.UTF8.GetBytes(text);
-                        stream.Write(bytes, 0, bytes.Length);
-                        return;
-                    }
+            var failed = false;
+            for (var retries = 100; retries > 0; --retries) {
+                try {
+                    fs.WriteAllText(filePath, text);
+                } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is ObjectDisposedException) {
+                    failed = true;
+                    Thread.Sleep(10);
                 }
-            } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            }
 
             try {
-                fs.DeleteFile(filePath);
+                if (failed) {
+                    fs.DeleteFile(filePath);
+                }
             } catch (IOException) { } catch (UnauthorizedAccessException) { }
         }
     }

--- a/src/Core/Impl/Extensions/IOExtensions.cs
+++ b/src/Core/Impl/Extensions/IOExtensions.cs
@@ -122,20 +122,17 @@ namespace Microsoft.Python.Core.IO {
         }
 
         public static void WriteTextWithRetry(this IFileSystem fs, string filePath, string text) {
-            var failed = false;
             for (var retries = 100; retries > 0; --retries) {
                 try {
                     fs.WriteAllText(filePath, text);
+                    return;
                 } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
-                    failed = true;
                     Thread.Sleep(10);
                 }
             }
 
             try {
-                if (failed) {
-                    fs.DeleteFile(filePath);
-                }
+                fs.DeleteFile(filePath);
             } catch (IOException) { } catch (UnauthorizedAccessException) { }
         }
     }


### PR DESCRIPTION
Fixes #1100 

Also harden writing of scraped content as it may occasionally collide scraping same file (I've seen exceptions thrown inside CLR on writing to a closed file. 