### PR TITLE
Handle calls on classes for signature help

### DIFF
--- a/src/LanguageServer/Impl/Definitions/IDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Definitions/IDocumentationSource.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Python.LanguageServer {
     public interface IDocumentationSource {
         InsertTextFormat DocumentationFormat { get; }
         MarkupContent GetHover(string name, IMember member, IPythonType self = null);
-        string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0);
+        string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0, string name = null);
         MarkupContent FormatParameterDocumentation(IParameterInfo parameter);
         MarkupContent FormatDocumentation(string documentation);
     }

--- a/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             return new MarkupContent { kind = MarkupKind.Markdown, value = DocstringConverter.ToMarkdown(documentation) };
         }
 
-        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0) {
+        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0, string name = null) {
             var o = ft.Overloads[overloadIndex];
 
             var parms = GetFunctionParameters(ft);
@@ -81,7 +81,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             var returnDoc = o.GetReturnDocumentation(self);
             var annString = string.IsNullOrEmpty(returnDoc) ? string.Empty : $" -> {returnDoc}";
 
-            return $"{ft.Name}({parmString}){annString}";
+            return $"{name ?? ft.Name}({parmString}){annString}";
         }
 
         public MarkupContent FormatParameterDocumentation(IParameterInfo parameter) {

--- a/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             return new MarkupContent { kind = MarkupKind.PlainText, value = documentation };
         }
 
-        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0) {
+        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0, string name = null) {
             var o = ft.Overloads[overloadIndex];
 
             var parms = GetFunctionParameters(ft);
@@ -81,7 +81,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             var returnDoc = o.GetReturnDocumentation(self);
             var annString = string.IsNullOrEmpty(returnDoc) ? string.Empty : $" -> {returnDoc}";
 
-            return $"{ft.Name}({parmString}){annString}";
+            return $"{name ?? ft.Name}({parmString}){annString}";
         }
 
         public MarkupContent FormatParameterDocumentation(IParameterInfo parameter) {

--- a/src/LanguageServer/Test/SignatureTests.cs
+++ b/src/LanguageServer/Test/SignatureTests.cs
@@ -13,8 +13,11 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Python.Analysis.Analyzer;
+using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Sources;
 using Microsoft.Python.Parsing.Tests;
@@ -50,6 +53,61 @@ C().method()
             sig.activeParameter.Should().Be(0);
             sig.signatures.Length.Should().Be(1);
             sig.signatures[0].label.Should().Be("method(a: int, b) -> float");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInitializer() {
+            const string code = @"
+class C:
+    def __init__(self, a:int, b):
+        pass
+
+C()
+";
+            var analysis = await GetAnalysisAsync(code);
+            var src = new SignatureSource(new PlainTextDocumentationSource());
+
+            var sig = src.GetSignature(analysis, new SourceLocation(6, 3));
+            sig.activeSignature.Should().Be(0);
+            sig.activeParameter.Should().Be(0);
+            sig.signatures.Length.Should().Be(1);
+            sig.signatures[0].label.Should().Be("C(a: int, b)");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ImportedClassInitializer() {
+            const string module1Code = @"
+class C:
+    def __init__(self, a:int, b):
+        pass
+";
+
+            const string appCode = @"
+import module1
+
+module1.C()
+";
+            var module1Uri = TestData.GetTestSpecificUri("module1.py");
+            var appUri = TestData.GetTestSpecificUri("app.py");
+
+            var root = Path.GetDirectoryName(appUri.AbsolutePath);
+            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            var rdt = Services.GetService<IRunningDocumentTable>();
+            var analyzer = Services.GetService<IPythonAnalyzer>();
+
+            rdt.OpenDocument(module1Uri, module1Code);
+
+            var app = rdt.OpenDocument(appUri, appCode);
+            await analyzer.WaitForCompleteAnalysisAsync();
+            var analysis = await app.GetAnalysisAsync(-1);
+
+            var src = new SignatureSource(new PlainTextDocumentationSource());
+
+            var sig = src.GetSignature(analysis, new SourceLocation(4, 11));
+            sig.activeSignature.Should().Be(0);
+            sig.activeParameter.Should().Be(0);
+            sig.signatures.Length.Should().Be(1);
+            sig.signatures[0].label.Should().Be("C(a: int, b)");
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Fixes #983.
See also #982 (will need to do the same `name` passthrough for completion and hover).

When the lookup happened and the call target evaluated to a class type, the help would return early, since a class type is not a function type. Now, if it's a class type, then `__init__` is fetched instead.

Also, take the chance to pass down the "real" name of the call to the tooltip.