### PR TITLE
Update signature parameter handling to LSP 3.14

### DIFF
--- a/src/Analysis/Ast/Impl/Types/Definitions/IParameterInfo.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IParameterInfo.cs
@@ -13,6 +13,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using Microsoft.Python.Core.Text;
+
 namespace Microsoft.Python.Analysis.Types {
     /// <summary>
     /// Represents information about an individual parameter.  Used for providing
@@ -60,5 +62,10 @@ namespace Microsoft.Python.Analysis.Types {
         /// Default value.
         /// </summary>
         IMember DefaultValue { get; }
+
+        /// <summary>
+        /// Position of the parameter in the source code.
+        /// </summary>
+        IndexSpan IndexSpan { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/Definitions/IParameterInfo.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IParameterInfo.cs
@@ -62,10 +62,5 @@ namespace Microsoft.Python.Analysis.Types {
         /// Default value.
         /// </summary>
         IMember DefaultValue { get; }
-
-        /// <summary>
-        /// Position of the parameter in the source code.
-        /// </summary>
-        IndexSpan IndexSpan { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/ParameterInfo.cs
+++ b/src/Analysis/Ast/Impl/Types/ParameterInfo.cs
@@ -14,18 +14,20 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.Python.Core.Text;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Types {
     internal sealed class ParameterInfo : IParameterInfo {
-        public ParameterInfo(PythonAst ast, Parameter p, IPythonType type, IMember defaultValue, bool isGeneric) :
-        this(p?.Name, type, p?.Kind, defaultValue) {
+        public ParameterInfo(PythonAst ast, Parameter p, IPythonType type, IMember defaultValue, bool isGeneric)
+            : this(p?.Name, type, p?.Kind, defaultValue) {
             Documentation = string.Empty;
             DefaultValueString = p?.DefaultValue?.ToCodeString(ast).Trim();
             if (DefaultValueString == "...") {
                 DefaultValueString = null;
             }
             IsGeneric = isGeneric;
+            IndexSpan = p?.IndexSpan ?? default;
         }
 
         public ParameterInfo(string name, IPythonType type, ParameterKind? kind, IMember defaultValue) {
@@ -45,5 +47,6 @@ namespace Microsoft.Python.Analysis.Types {
         public IPythonType Type { get; }
         public string DefaultValueString { get; }
         public IMember DefaultValue { get; }
+        public IndexSpan IndexSpan { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/ParameterInfo.cs
+++ b/src/Analysis/Ast/Impl/Types/ParameterInfo.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Python.Analysis.Types {
                 DefaultValueString = null;
             }
             IsGeneric = isGeneric;
-            IndexSpan = p?.IndexSpan ?? default;
         }
 
         public ParameterInfo(string name, IPythonType type, ParameterKind? kind, IMember defaultValue) {
@@ -47,6 +46,5 @@ namespace Microsoft.Python.Analysis.Types {
         public IPythonType Type { get; }
         public string DefaultValueString { get; }
         public IMember DefaultValue { get; }
-        public IndexSpan IndexSpan { get; }
     }
 }

--- a/src/LanguageServer/Impl/Definitions/IDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Definitions/IDocumentationSource.cs
@@ -14,13 +14,14 @@
 // permissions and limitations under the License.
 
 using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Protocol;
 
 namespace Microsoft.Python.LanguageServer {
     public interface IDocumentationSource {
         InsertTextFormat DocumentationFormat { get; }
         MarkupContent GetHover(string name, IMember member, IPythonType self = null);
-        string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0, string name = null);
+        string GetSignatureString(IPythonFunctionType ft, IPythonType self, out IndexSpan[] parameterSpans, int overloadIndex = 0, string name = null);
         MarkupContent FormatParameterDocumentation(IParameterInfo parameter);
         MarkupContent FormatDocumentation(string documentation);
     }

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -77,7 +77,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     triggerCharacters = new[] { "." }
                 },
                 hoverProvider = true,
-                signatureHelpProvider = new SignatureHelpOptions { triggerCharacters = new[] { "(", ",", ")" } },
+                signatureHelpProvider = new SignatureHelpOptions {
+                    triggerCharacters = new[] { "(", ",", ")" },
+                    
+                },
                 definitionProvider = true,
                 referencesProvider = true,
                 workspaceSymbolProvider = true,
@@ -156,8 +159,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 ChooseDocumentationSource(_clientCaps?.textDocument?.hover?.contentFormat)
             );
 
+            var sigInfo = _clientCaps?.textDocument?.signatureHelp?.signatureInformation;
             _signatureSource = new SignatureSource(
-                ChooseDocumentationSource(_clientCaps?.textDocument?.signatureHelp?.signatureInformation?.documentationFormat)
+                ChooseDocumentationSource(sigInfo?.documentationFormat),
+                sigInfo?.parameterInformation?.labelOffsetSupport == true
             );
 
             return GetInitializeResult();

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -77,10 +77,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     triggerCharacters = new[] { "." }
                 },
                 hoverProvider = true,
-                signatureHelpProvider = new SignatureHelpOptions {
-                    triggerCharacters = new[] { "(", ",", ")" },
-                    
-                },
+                signatureHelpProvider = new SignatureHelpOptions { triggerCharacters = new[] { "(", ",", ")" } },
                 definitionProvider = true,
                 referencesProvider = true,
                 workspaceSymbolProvider = true,

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-#define WAIT_FOR_DEBUGGER
+// #define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-// #define WAIT_FOR_DEBUGGER
+#define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;

--- a/src/LanguageServer/Impl/Protocol/Classes.cs
+++ b/src/LanguageServer/Impl/Protocol/Classes.cs
@@ -278,13 +278,17 @@ namespace Microsoft.Python.LanguageServer.Protocol {
                 /// property.The order describes the preferred format of the client.
                 /// </summary>
                 public string[] documentationFormat;
-
+                
                 /// <summary>
-                /// When true, the label in the returned signature information will
-                /// only contain the function name. Otherwise, the label will contain
-                /// the full signature.
+                /// Client capabilities specific to parameter information.
                 /// </summary>
-                public bool? _shortLabel;
+                public struct ParameterInformationCapabilities {
+                    /// <summary>
+                    ///  The client supports processing label offsets instead of a simple label string
+                    /// </summary>
+                    public bool? labelOffsetSupport;
+                }
+                public ParameterInformationCapabilities? parameterInformation;
             }
             public SignatureInformationCapabilities? signatureInformation;
         }
@@ -567,10 +571,6 @@ namespace Microsoft.Python.LanguageServer.Protocol {
         /// The document version that range applies to.
         /// </summary>
         public int? _version;
-        /// <summary>
-        /// List of fully qualified type names for the expression
-        /// </summary>
-        public string[] _typeNames;
     }
 
     [Serializable]
@@ -585,13 +585,21 @@ namespace Microsoft.Python.LanguageServer.Protocol {
         public string label;
         public MarkupContent documentation;
         public ParameterInformation[] parameters;
-
-        public string[] _returnTypes;
     }
 
     [Serializable]
     public sealed class ParameterInformation {
-        public string label;
+        /// <summary>
+        /// The label of this signature.
+        /// </summary>
+        /// <remarks>
+        /// LSP before 3.14: string label.
+        /// LSP 3.14.0+: (int, int) range.
+        /// Either a string or inclusive start and exclusive end offsets within its containing
+        /// [signature label] (#SignatureInformation.label). *Note*: A label of type string must be
+        /// a substring of its containing signature information's [label](#SignatureInformation.label).
+        /// </remarks>
+        public object label;
         public MarkupContent documentation;
     }
 

--- a/src/LanguageServer/Impl/Sources/DocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/DocumentationSource.cs
@@ -1,0 +1,56 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Python.Analysis;
+using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Core.Text;
+using Microsoft.Python.LanguageServer.Protocol;
+
+namespace Microsoft.Python.LanguageServer.Sources {
+    internal abstract class DocumentationSource {
+        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, out IndexSpan[] parameterSpans, int overloadIndex = 0, string name = null) {
+            var o = ft.Overloads[overloadIndex];
+
+            var parms = GetFunctionParameters(ft).ToArray();
+            var parmString = string.Join(", ", parms);
+            var returnDoc = o.GetReturnDocumentation(self);
+            var annString = string.IsNullOrEmpty(returnDoc) ? string.Empty : $" -> {returnDoc}";
+
+            // Calculate parameter spans
+            parameterSpans = new IndexSpan[parms.Length];
+            name = name ?? ft.Name;
+            var offset = name.Length + 1;
+            for(var i = 0; i < parms.Length; i++) {
+                parameterSpans[i]= IndexSpan.FromBounds(offset, offset + parms[i].Length);
+                offset += parms[i].Length + 2; // name,<space>
+            }
+
+            return $"{name}({parmString}){annString}";
+        }
+
+        private IEnumerable<string> GetFunctionParameters(IPythonFunctionType ft, int overloadIndex = 0) {
+            var o = ft.Overloads[overloadIndex]; // TODO: display all?
+            var skip = ft.IsStatic || ft.IsUnbound ? 0 : 1;
+            return o.Parameters.Skip(skip).Select(p => {
+                if (!string.IsNullOrEmpty(p.DefaultValueString)) {
+                    return $"{p.Name}={p.DefaultValueString}";
+                }
+                return p.Type.IsUnknown() ? p.Name : $"{p.Name}: {p.Type.Name}";
+            });
+        }
+    }
+}

--- a/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
@@ -13,12 +13,9 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
-using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Documentation;
 using Microsoft.Python.LanguageServer.Protocol;
 

--- a/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
@@ -13,12 +13,9 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
-using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Documentation;
 using Microsoft.Python.LanguageServer.Protocol;
 

--- a/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
@@ -18,11 +18,12 @@ using System.Linq;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
+using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Documentation;
 using Microsoft.Python.LanguageServer.Protocol;
 
 namespace Microsoft.Python.LanguageServer.Sources {
-    internal sealed class PlainTextDocumentationSource : IDocumentationSource {
+    internal sealed class PlainTextDocumentationSource : DocumentationSource, IDocumentationSource {
         public InsertTextFormat DocumentationFormat => InsertTextFormat.PlainText;
 
         public MarkupContent GetHover(string name, IMember member, IPythonType self) {
@@ -69,20 +70,8 @@ namespace Microsoft.Python.LanguageServer.Sources {
             };
         }
 
-        public MarkupContent FormatDocumentation(string documentation) {
-            return new MarkupContent { kind = MarkupKind.PlainText, value = documentation };
-        }
-
-        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0, string name = null) {
-            var o = ft.Overloads[overloadIndex];
-
-            var parms = GetFunctionParameters(ft);
-            var parmString = string.Join(", ", parms);
-            var returnDoc = o.GetReturnDocumentation(self);
-            var annString = string.IsNullOrEmpty(returnDoc) ? string.Empty : $" -> {returnDoc}";
-
-            return $"{name ?? ft.Name}({parmString}){annString}";
-        }
+        public MarkupContent FormatDocumentation(string documentation) 
+            => new MarkupContent { kind = MarkupKind.PlainText, value = documentation };
 
         public MarkupContent FormatParameterDocumentation(IParameterInfo parameter) {
             if (!string.IsNullOrEmpty(parameter.Documentation)) {
@@ -100,21 +89,10 @@ namespace Microsoft.Python.LanguageServer.Sources {
         }
 
         private string GetFunctionHoverString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0) {
-            var sigString = GetSignatureString(ft, self, overloadIndex);
+            var sigString = GetSignatureString(ft, self, out _, overloadIndex);
             var decTypeString = ft.DeclaringType != null ? $"{ft.DeclaringType.Name}." : string.Empty;
             var funcDoc = !string.IsNullOrEmpty(ft.Documentation) ? $"\n\n{ft.PlaintextDoc()}" : string.Empty;
             return $"{decTypeString}{sigString}{funcDoc}";
-        }
-
-        private IEnumerable<string> GetFunctionParameters(IPythonFunctionType ft, int overloadIndex = 0) {
-            var o = ft.Overloads[overloadIndex]; // TODO: display all?
-            var skip = ft.IsStatic || ft.IsUnbound ? 0 : 1;
-            return o.Parameters.Skip(skip).Select(p => {
-                if (!string.IsNullOrEmpty(p.DefaultValueString)) {
-                    return $"{p.Name}={p.DefaultValueString}";
-                }
-                return p.Type.IsUnknown() ? p.Name : $"{p.Name}: {p.Type.Name}";
-            });
         }
     }
 }

--- a/src/LanguageServer/Impl/Sources/SignatureSource.cs
+++ b/src/LanguageServer/Impl/Sources/SignatureSource.cs
@@ -82,15 +82,24 @@ namespace Microsoft.Python.LanguageServer.Sources {
             for (var i = 0; i < ft.Overloads.Count; i++) {
                 var o = ft.Overloads[i];
 
-                var parameters = o.Parameters.Skip(skip).Select(p => new ParameterInformation {
-                    label = _labelOffsetSupport ? (p.IndexSpan.Start, p.IndexSpan.End) : (object)p.Name,
-                    documentation = _docSource.FormatParameterDocumentation(p)
-                }).ToArray();
+                var signatureLabel = _docSource.GetSignatureString(ft, selfType, out var parameterSpans, i, name);
+
+                var visibleParameterCount = o.Parameters.Count - skip;
+                var parameterInfo = new ParameterInformation[visibleParameterCount];
+                for (var j = 0; j < visibleParameterCount; j++) {
+                    var p = o.Parameters[j + skip];
+                    var ps = parameterSpans[j];
+
+                    parameterInfo[j] = new ParameterInformation {
+                        label = _labelOffsetSupport ? new[] { ps.Start, ps.End } : (object)p.Name,
+                        documentation = _docSource.FormatParameterDocumentation(p)
+                    };
+                }
 
                 signatures[i] = new SignatureInformation {
-                    label = _docSource.GetSignatureString(ft, selfType, i, name),
+                    label = signatureLabel,
                     documentation = _docSource.FormatDocumentation(ft.Documentation),
-                    parameters = parameters
+                    parameters = parameterInfo
                 };
             }
 

--- a/src/LanguageServer/Impl/Sources/SignatureSource.cs
+++ b/src/LanguageServer/Impl/Sources/SignatureSource.cs
@@ -27,9 +27,12 @@ using Microsoft.Python.Parsing.Ast;
 namespace Microsoft.Python.LanguageServer.Sources {
     internal sealed class SignatureSource {
         private readonly IDocumentationSource _docSource;
+        private readonly bool _labelOffsetSupport;
 
-        public SignatureSource(IDocumentationSource docSource) {
+        public SignatureSource(IDocumentationSource docSource, bool labelOffsetSupport = true) {
             _docSource = docSource;
+            // TODO: deprecate eventually.
+            _labelOffsetSupport = labelOffsetSupport; // LSP 3.14.0+
         }
 
         public SignatureHelp GetSignature(IDocumentAnalysis analysis, SourceLocation location) {
@@ -80,7 +83,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
                 var o = ft.Overloads[i];
 
                 var parameters = o.Parameters.Skip(skip).Select(p => new ParameterInformation {
-                    label = p.Name,
+                    label = _labelOffsetSupport ? (p.IndexSpan.Start, p.IndexSpan.End) : (object)p.Name,
                     documentation = _docSource.FormatParameterDocumentation(p)
                 }).ToArray();
 

--- a/src/LanguageServer/Test/FluentAssertions/SignatureInformationAssertions.cs
+++ b/src/LanguageServer/Test/FluentAssertions/SignatureInformationAssertions.cs
@@ -13,6 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -42,14 +43,14 @@ namespace Microsoft.Python.LanguageServer.Tests.FluentAssertions {
             return new AndConstraint<SignatureInformationAssertions>(this);
         }
 
-        public AndConstraint<SignatureInformationAssertions> OnlyHaveParameterLabels(params string[] labels)
+        public AndConstraint<SignatureInformationAssertions> OnlyHaveParameterLabels(params int[][] labels)
             => OnlyHaveParameterLabels(labels, string.Empty);
 
-        public AndConstraint<SignatureInformationAssertions> OnlyHaveParameterLabels(IEnumerable<string> labels, string because = "", params object[] reasonArgs) {
+        public AndConstraint<SignatureInformationAssertions> OnlyHaveParameterLabels(IEnumerable<int[]> labelOffsets, string because = "", params object[] reasonArgs) {
             NotBeNull(because, reasonArgs);
 
-            var actual = Subject.parameters?.Select(i => i.label).ToArray() ?? new string[0];
-            var expected = labels.ToArray();
+            var actual = Subject.parameters?.Select(i => i.label).ToArray() ?? Array.Empty<int[]>();
+            var expected = labelOffsets.ToArray();
 
             var errorMessage = AssertionsUtilities.GetAssertCollectionOnlyContainsMessage(actual, expected, $"signature '{Subject.label}'", "parameter label", "parameter labels");
 

--- a/src/LanguageServer/Test/SignatureTests.cs
+++ b/src/LanguageServer/Test/SignatureTests.cs
@@ -14,6 +14,7 @@
 // permissions and limitations under the License.
 
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Analysis.Analyzer;
@@ -53,6 +54,9 @@ C().method()
             sig.activeParameter.Should().Be(0);
             sig.signatures.Length.Should().Be(1);
             sig.signatures[0].label.Should().Be("method(a: int, b) -> float");
+
+            var parameterSpans = sig.signatures[0].parameters.Select(p => p.label).OfType<int[]>().SelectMany(x => x).ToArray();
+            parameterSpans.Should().ContainInOrder(7, 13, 15, 16);
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Fixes #1038
Fixes #679 

Inactive until extension upgrades to
```json
  "vscode-languageclient": "^5.2.1",
  "vscode-languageserver": "^5.2.1",
  "vscode-languageserver-protocol": "^3.14.1",
```