### PR TITLE
Drop file content to conserve memory

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Hints.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Hints.cs
@@ -26,8 +26,15 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
     /// and types in a chain of scopes during analysis.
     /// </summary>
     internal sealed partial class ExpressionEval {
+        private const string _pepHintKey = "PEP Hint";
+
         public IPythonType GetTypeFromPepHint(Node node) {
+            if (Ast.TryGetAttribute(node, _pepHintKey, out var typeStringObject) && typeStringObject is string typeString) {
+                return GetTypeFromString(typeString);
+            }
+
             var location = GetLocationInfo(node);
+
             var content = (Module as IDocument)?.Content;
             if (string.IsNullOrEmpty(content) || !location.EndLine.HasValue) {
                 return null;
@@ -79,7 +86,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
 
             // Type alone is not a valid syntax, so we need to simulate the annotation.
-            var typeString = content.Substring(hintStart, i - hintStart).Trim();
+            typeString = content.Substring(hintStart, i - hintStart).Trim();
+            Ast.SetAttribute(node, _pepHintKey, typeString);
+
             return GetTypeFromString(typeString);
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -79,6 +79,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 if (ctor || annotationType.IsUnknown() || Module.ModuleType == ModuleType.User) {
                     // Return type from the annotation is sufficient for libraries and stubs, no need to walk the body.
                     FunctionDefinition.Body?.Walk(this);
+                    // For libraries remove declared local function variables to free up some memory.
+                    if (Module.ModuleType != ModuleType.User) {
+                        ((VariableCollection)Eval.CurrentScope.Variables).Clear();
+                    }
                 }
             }
             Result = _function;

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                     // Return type from the annotation is sufficient for libraries and stubs, no need to walk the body.
                     FunctionDefinition.Body?.Walk(this);
                     // For libraries remove declared local function variables to free up some memory.
-                    if (Module.ModuleType != ModuleType.User) {
+                    var optionsProvider = Eval.Services.GetService<IAnalysisOptionsProvider>();
+                    if (Module.ModuleType != ModuleType.User && optionsProvider?.Options.KeepLibraryLocalVariables != true) {
                         ((VariableCollection)Eval.CurrentScope.Variables).Clear();
                     }
                 }

--- a/src/Analysis/Ast/Impl/Definitions/AnalysisOptions.cs
+++ b/src/Analysis/Ast/Impl/Definitions/AnalysisOptions.cs
@@ -16,5 +16,18 @@
 namespace Microsoft.Python.Analysis {
     public class AnalysisOptions {
         public bool LintingEnabled { get; set; }
+
+        /// <summary>
+        /// Keep in memory information on local variables declared in
+        /// functions in libraries. Provides ability to navigate to
+        /// symbols used in function bodies in packages and libraries.
+        /// </summary>
+        public bool KeepLibraryLocalVariables { get; set; }
+
+        /// <summary>
+        /// Keep in memory AST of library source code. May somewhat
+        /// improve performance when library code has to be re-analyzed.
+        /// </summary>
+        public bool KeepLibraryAst { get; set; }
     }
 }

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -438,6 +438,10 @@ namespace Microsoft.Python.Analysis.Modules {
                 // as declare additional variables, etc.
                 OnAnalysisComplete();
                 ContentState = State.Analyzed;
+
+                if (ModuleType != ModuleType.User) {
+                    _buffer.Reset(_buffer.Version, string.Empty);
+                }
             }
 
             // Do not report issues with libraries or stubs

--- a/src/Analysis/Ast/Impl/Values/VariableCollection.cs
+++ b/src/Analysis/Ast/Impl/Values/VariableCollection.cs
@@ -122,5 +122,11 @@ namespace Microsoft.Python.Analysis.Values {
                 _variables.Remove(name);
             }
         }
+
+        internal void Clear() {
+            lock (_syncObj) {
+                _variables.Clear();
+            }
+        }
     }
 }

--- a/src/LanguageServer/Impl/Definitions/ServerSettings.cs
+++ b/src/LanguageServer/Impl/Definitions/ServerSettings.cs
@@ -29,6 +29,22 @@ namespace Microsoft.Python.LanguageServer {
             public string[] warnings { get; private set; } = Array.Empty<string>();
             public string[] information { get; private set; } = Array.Empty<string>();
             public string[] disabled { get; private set; } = Array.Empty<string>();
+
+            public class AnalysisMemoryOptions {
+                /// <summary>
+                /// Keep in memory information on local variables declared in
+                /// functions in libraries. Provides ability to navigate to
+                /// symbols used in function bodies in packages and libraries.
+                /// </summary>
+                public bool keepLibraryLocalVariables;
+
+                /// <summary>
+                /// Keep in memory AST of library source code. May somewhat
+                /// improve performance when library code has to be re-analyzed.
+                /// </summary>
+                public bool keepLibraryAst;
+            }
+            public AnalysisMemoryOptions memory;
         }
         public readonly PythonAnalysisOptions analysis = new PythonAnalysisOptions();
 

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -212,6 +212,11 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 return true;
             }
 
+            if(newSettings.analysis?.memory?.keepLibraryAst != oldSettings.analysis?.memory?.keepLibraryAst ||
+               newSettings.analysis?.memory?.keepLibraryLocalVariables != oldSettings.analysis?.memory?.keepLibraryLocalVariables) {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/LanguageServer/Impl/LanguageServer.Configuration.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Configuration.cs
@@ -73,6 +73,11 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             var linting = pythonSection["linting"];
             HandleLintingOnOff(_services, GetSetting(linting, "enabled", true));
+
+            var memory = analysis["memory"];
+            var optionsProvider = _services.GetService<IAnalysisOptionsProvider>();
+            optionsProvider.Options.KeepLibraryLocalVariables = GetSetting(memory, "keepLibraryLocalVariables", false);
+            optionsProvider.Options.KeepLibraryAst = GetSetting(memory, "keepLibraryAst", false);
         }
 
         internal static void HandleLintingOnOff(IServiceContainer services, bool linterEnabled) {

--- a/src/LanguageServer/Impl/Sources/DocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/DocumentationSource.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Types;
@@ -50,8 +50,9 @@ namespace Microsoft.Python.LanguageServer.Sources {
             var o = ft.Overloads[overloadIndex]; // TODO: display all?
             var skip = ft.IsStatic || ft.IsUnbound ? 0 : 1;
 
-            var parameters = new string[o.Parameters.Count - skip];
-            parameterNameLengths = new int[o.Parameters.Count - skip];
+            var count = Math.Max(0, o.Parameters.Count - skip);
+            var parameters = new string[count];
+            parameterNameLengths = new int[count];
             for (var i = skip; i < o.Parameters.Count; i++) {
                 string paramString;
                 var p = o.Parameters[i];

--- a/src/LanguageServer/Test/GoToDefinitionTests.cs
+++ b/src/LanguageServer/Test/GoToDefinitionTests.cs
@@ -332,6 +332,9 @@ class MainClass:
             var mainPath = TestData.GetTestSpecificUri("main.py");
             var doc = rdt.OpenDocument(mainPath, code);
 
+            var analyzer = Services.GetService<IPythonAnalyzer>();
+            await analyzer.WaitForCompleteAnalysisAsync();
+
             var analysis = await doc.GetAnalysisAsync(Timeout.Infinite);
             var ds = new DefinitionSource(Services);
 

--- a/src/Parsing/Impl/Ast/PythonAst.cs
+++ b/src/Parsing/Impl/Ast/PythonAst.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Python.Parsing.Ast {
 
         public PythonLanguageVersion LanguageVersion { get; }
 
-        internal bool TryGetAttribute(Node node, object key, out object value) {
+        public bool TryGetAttribute(Node node, object key, out object value) {
             if (_attributes.TryGetValue(node, out var nodeAttrs)) {
                 return nodeAttrs.TryGetValue(key, out value);
             }
@@ -104,7 +104,7 @@ namespace Microsoft.Python.Parsing.Ast {
             return false;
         }
 
-        internal void SetAttribute(Node node, object key, object value) {
+        public void SetAttribute(Node node, object key, object value) {
             if (!_attributes.TryGetValue(node, out var nodeAttrs)) {
                 nodeAttrs = _attributes[node] = new Dictionary<object, object>();
             }


### PR DESCRIPTION
When analysis completes for libraries we no longer need file content. However, we do need to cache some strings for PEP hints to be available if new analysis is requested.

Fixes #1132