### PR TITLE
Move strings in parser to resources issue #647

### DIFF
--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -1805,7 +1805,7 @@ namespace Microsoft.Python.Parsing {
                     res = cls;
                 } else {
                     // Class was an error...
-                    res = ErrorStmt(Resources.ClassDecoratorsRequire2dot6ErrorMsg, decorators, cls);
+                    res = ErrorStmt(Resources.ClassDecoratorsRequireTwodotSixErrorMsg, decorators, cls);//Resources.ClassDecoratorsRequireTwodotSixErrorMsg
                 }
             } else {
                 ReportSyntaxError(_lookahead);

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -262,11 +262,11 @@ namespace Microsoft.Python.Parsing {
         private static string GetErrorMessage(Token t, int errorCode) {
             string msg;
             if ((errorCode & ~ErrorCodes.IncompleteMask) == ErrorCodes.IndentationError) {
-                msg = "expected an indented block";
+                msg = Resources.ExpectedIndentedBlockErrorMsg;//"expected an indented block";
             } else if (t.Kind != TokenKind.EndOfFile) {
-                msg = "unexpected token '{0}'".FormatUI(t.Image);
+                msg = Resources.UnexpectedTokenErrorMsg.FormatUI(t.Image); //"unexpected token '{0}'".FormatUI(t.Image);
             } else {
-                msg = "unexpected EOF while parsing";
+                msg = Resources.UnexpectedEndOfFileWhileParsingErrorMsg;//"unexpected EOF while parsing";
             }
 
             return msg;
@@ -318,7 +318,7 @@ namespace Microsoft.Python.Parsing {
             }
 
             var prevTokenEnd = prevTokenStart + prevTokenLength;
-            var message = "syntax error";
+            var message = Resources.SyntaxErrorMsg;//"syntax error";
             if (_lookahead.Token.Kind == TokenKind.NewLine) {
                 // Incomplete member expression, report next character unless there is none.
                 // If there is none, then point to the newline. If we are at EOF, report the dot.
@@ -456,7 +456,7 @@ namespace Microsoft.Python.Parsing {
                     return ParseWithStmt(isAsync: true);
             }
 
-            ReportSyntaxError("syntax error");
+            ReportSyntaxError(Resources.SyntaxErrorMsg);//"syntax error"
             return ParseStmt();
         }
 
@@ -543,14 +543,14 @@ namespace Microsoft.Python.Parsing {
                     return FinishSmallStmt(new EmptyStatement());
                 case TokenKind.KeywordBreak:
                     if (!_inLoop) {
-                        ReportSyntaxError("'break' outside loop");
+                        ReportSyntaxError(Resources.BreakOustideLoopErrorMsg);//"'break' outside loop"
                     }
                     return FinishSmallStmt(new BreakStatement());
                 case TokenKind.KeywordContinue:
                     if (!_inLoop) {
-                        ReportSyntaxError("'continue' not properly in loop");
+                        ReportSyntaxError(Resources.ContinueNotInLoopErrorMsg);//'continue' not properly in loop
                     } else if (_inFinally) {
-                        ReportSyntaxError("'continue' not supported inside 'finally' clause");
+                        ReportSyntaxError(Resources.ContinueNotSupportedInsideFinallyErrorMsg);//'continue' not supported inside 'finally' clause
                     }
                     return FinishSmallStmt(new ContinueStatement());
                 case TokenKind.KeywordReturn:
@@ -589,7 +589,7 @@ namespace Microsoft.Python.Parsing {
 
             DelStatement ret;
             if (PeekToken(TokenKind.NewLine) || PeekToken(TokenKind.EndOfFile)) {
-                ReportSyntaxError(curLookahead.Span.Start, curLookahead.Span.End, "expected expression after del");
+                ReportSyntaxError(curLookahead.Span.Start, curLookahead.Span.End, Resources.ExpectedExpressionAfterDelErrorMsg);//expected expression after del
                 ret = new DelStatement(ImmutableArray<Expression>.Empty);
             } else {
                 var l = ParseExprList(out var itemWhiteSpace);
@@ -618,7 +618,7 @@ namespace Microsoft.Python.Parsing {
 
         private Statement ParseReturnStmt() {
             if (!AllowReturnSyntax) {
-                ReportSyntaxError("'return' outside function");
+                ReportSyntaxError(Resources.ReturnOutsideFunctionErrorMsg);//'return' outside function
             }
             var returnToken = _lookahead;
             NextToken();
@@ -631,7 +631,7 @@ namespace Microsoft.Python.Parsing {
 
             if (expr != null && _langVersion < PythonLanguageVersion.V33) {
                 if (_isGenerator) {
-                    ReportSyntaxError(returnToken.Span.Start, expr.EndIndex, "'return' with argument inside generator");
+                    ReportSyntaxError(returnToken.Span.Start, expr.EndIndex, Resources.ReturnWithArgumentInGeneratorErrorMsg);//'return' with argument inside generator
                 } else {
                     if (_returnsWithValue == null) {
                         _returnsWithValue = new List<IndexSpan>();
@@ -663,16 +663,16 @@ namespace Microsoft.Python.Parsing {
             // This gives us better syntax error reporting for yield-statements than for yield-expressions.
             if (!AllowYieldSyntax) {
                 if (AllowAsyncAwaitSyntax) {
-                    ReportSyntaxError("'yield' inside async function");
+                    ReportSyntaxError(Resources.YieldInsideAsyncErrorMsg);//'yield' inside async function
                 } else {
-                    ReportSyntaxError("misplaced yield");
+                    ReportSyntaxError(Resources.MisplacedYieldErrorMsg);//misplaced yield
                 }
             }
 
             _isGenerator = true;
             if (_returnsWithValue != null && _langVersion < PythonLanguageVersion.V33) {
                 foreach (var span in _returnsWithValue) {
-                    ReportSyntaxError(span.Start, span.End, "'return' with argument inside generator");
+                    ReportSyntaxError(span.Start, span.End, Resources.ReturnWithArgumentInGeneratorErrorMsg);//'return' with argument inside generator
                 }
             }
 
@@ -721,7 +721,7 @@ namespace Microsoft.Python.Parsing {
             if (isYieldFrom) {
                 if (_langVersion < PythonLanguageVersion.V33) {
                     // yield from added to 3.3
-                    ReportSyntaxError("invalid syntax");
+                    ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);
                     suppressSyntaxError = true;
                 }
                 NextToken();
@@ -731,17 +731,17 @@ namespace Microsoft.Python.Parsing {
             if (l.Count == 0) {
                 if (_langVersion < PythonLanguageVersion.V25 && !suppressSyntaxError) {
                     // 2.4 doesn't allow plain yield
-                    ReportSyntaxError("invalid syntax");
+                    ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);
                 } else if (isYieldFrom && !suppressSyntaxError) {
                     // yield from requires one expression
-                    ReportSyntaxError("invalid syntax");
+                    ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);
                 }
                 // Check empty expression and convert to 'none'
                 yieldResult = new ConstantExpression(null);
             } else if (l.Count != 1) {
                 if (isYieldFrom && !suppressSyntaxError) {
                     // yield from requires one expression
-                    ReportSyntaxError(l[0].StartIndex, l[l.Count - 1].EndIndex, "invalid syntax");
+                    ReportSyntaxError(l[0].StartIndex, l[l.Count - 1].EndIndex, Resources.InvalidSyntaxErrorMsg);
                 }
                 // make a tuple
                 yieldResult = MakeTupleOrExpr(l, itemWhiteSpace, trailingComma, true);
@@ -791,7 +791,7 @@ namespace Microsoft.Python.Parsing {
                     singleLeft = right;
                 } else {
                     if (thereCanBeOnlyOne) {
-                        ReportSyntaxError(GetStart(), GetEnd(), "invalid syntax");
+                        ReportSyntaxError(GetStart(), GetEnd(), Resources.InvalidSyntaxErrorMsg);
                     }
                     if (left == null) {
                         left = new List<Expression> { singleLeft };
@@ -801,7 +801,7 @@ namespace Microsoft.Python.Parsing {
 
                 if (_langVersion >= PythonLanguageVersion.V25 && PeekToken(TokenKind.KeywordYield)) {
                     if (!AllowYieldSyntax && AllowAsyncAwaitSyntax) {
-                        ReportSyntaxError("'yield' inside async function");
+                        ReportSyntaxError(Resources.YieldInsideAsyncErrorMsg);//'yield' inside async function
                     }
                     Eat(TokenKind.KeywordYield);
                     right = ParseYieldExpression();
@@ -870,9 +870,9 @@ namespace Microsoft.Python.Parsing {
                 inex is NameExpression || inex is MemberExpression || inex is IndexExpression) {
                 // pass
             } else if (expr is TupleExpression) {
-                return ReadLineAsError(expr, "only single target (not tuple) can be annotated");
+                return ReadLineAsError(expr, Resources.SingleTargetCanBeAnnotatedErrorMsg);//only single target (not tuple) can be annotated
             } else {
-                return ReadLineAsError(expr, "illegal target for annotation");
+                return ReadLineAsError(expr, Resources.IllegalTargetAnnotationErrorMsg);//illegal target for annotation
             }
 
             Eat(TokenKind.Colon);
@@ -932,7 +932,7 @@ namespace Microsoft.Python.Parsing {
                         for (var i = 0; i < seq.Items.Count; i++) {
                             if (seq.Items[i] is StarredExpression) {
                                 if (hasStar) {
-                                    ReportSyntaxError(seq.Items[i].StartIndex, seq.Items[i].EndIndex, "two starred expressions in assignment");
+                                    ReportSyntaxError(seq.Items[i].StartIndex, seq.Items[i].EndIndex, Resources.TwoStarredExpressionErrorMsg);//two starred expressions in assignment
                                 }
                                 hasStar = true;
                             }
@@ -950,7 +950,7 @@ namespace Microsoft.Python.Parsing {
 
                     if (_langVersion >= PythonLanguageVersion.V25 && PeekToken(TokenKind.KeywordYield)) {
                         if (!AllowYieldSyntax && AllowAsyncAwaitSyntax) {
-                            ReportSyntaxError("'yield' inside async function");
+                            ReportSyntaxError(Resources.YieldInsideAsyncErrorMsg);//'yield' inside async function
                         }
                         Eat(TokenKind.KeywordYield);
                         rhs = ParseYieldExpression();
@@ -1120,7 +1120,7 @@ namespace Microsoft.Python.Parsing {
                 }
             } else {
                 if (names.Count == 0) {
-                    ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.End, "missing module name");
+                    ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.End, Resources.MissingModuleNameErrorMsg);
                 }
                 ret = new ModuleName(names);
                 if (nameWhiteSpace != null) {
@@ -1128,7 +1128,7 @@ namespace Microsoft.Python.Parsing {
                 }
             }
 
-            Debug.Assert(isStartSetCorrectly, "Start location was not set correctly");
+            Debug.Assert(isStartSetCorrectly, Resources.IncorrectStartLocationErrorMsg);//Start location was not set correctly
             ret.SetLoc(start, GetEnd());
             return ret;
         }
@@ -1193,7 +1193,7 @@ namespace Microsoft.Python.Parsing {
 
                 if (_langVersion.Is3x() && ((_functions != null && _functions.Count > 0) || _classDepth > 0)) {
                     foreach (var n in names.Where(n => n.Name == "*")) {
-                        ReportSyntaxError(n.StartIndex, n.EndIndex, "import * only allowed at module level");
+                        ReportSyntaxError(n.StartIndex, n.EndIndex, Resources.ImportOnlyAllowedAtModuleErrorMsg);//import * only allowed at module level
                     }
                 }
             }
@@ -1232,10 +1232,10 @@ namespace Microsoft.Python.Parsing {
 
         private bool ProcessFutureStatements(int start, ImmutableArray<NameExpression> names, bool fromFuture) {
             if (!_fromFutureAllowed) {
-                ReportSyntaxError(start, GetEnd(), "from __future__ imports must occur at the beginning of the file");
+                ReportSyntaxError(start, GetEnd(), Resources.FutureImportsMustOccorAtBeginningOfFileErrorMsg);//from __future__ imports must occur at the beginning of the file
             }
             if (names.Count == 1 && names[0].Name == "*") {
-                ReportSyntaxError(start, GetEnd(), "future statement does not support import *");
+                ReportSyntaxError(start, GetEnd(), Resources.FutureStatementDoesNotSupportImportErrorMsg);//future statement does not support import *
             }
             fromFuture = true;
             foreach (var name in names) {
@@ -1272,10 +1272,10 @@ namespace Microsoft.Python.Parsing {
                     var strName = name.Name;
 
                     if (strName != "braces") {
-                        ReportSyntaxError(start, GetEnd(), "future feature is not defined: " + strName);
+                        ReportSyntaxError(start, GetEnd(), Resources.FutureFeatureNotDefinedErrorMsg + strName);//future feature is not defined: 
                     } else {
                         // match CPython error message
-                        ReportSyntaxError(start, GetEnd(), "not a chance");
+                        ReportSyntaxError(start, GetEnd(), Resources.NotAChanceErrorMsg);//not a chance
                     }
                 }
             }
@@ -1396,7 +1396,7 @@ namespace Microsoft.Python.Parsing {
 
         private NonlocalStatement ParseNonlocalStmt() {
             if (_functions != null && _functions.Count == 0 && _classDepth == 0) {
-                ReportSyntaxError("nonlocal declaration not allowed at module level");
+                ReportSyntaxError(Resources.NonLocalDeclarationAtModuleErrorMsg);//nonlocal declaration not allowed at module level
             }
 
             Eat(TokenKind.KeywordNonlocal);
@@ -1461,7 +1461,7 @@ namespace Microsoft.Python.Parsing {
                     valueFieldStart = GetEnd();
                     value = ParseExpression();
                     if (_stubFile || _langVersion.Is3x()) {
-                        ReportSyntaxError(commaStart, GetEnd(), "invalid syntax, only exception value is allowed in 3.x.");
+                        ReportSyntaxError(commaStart, GetEnd(), Resources.InvalidSyntaxAllowedInVersion3XErrorMsg);//invalid syntax, only exception value is allowed in 3.x.
                     }
                     if (MaybeEat(TokenKind.Comma)) {
                         secondCommaWhiteSpace = _tokenWhiteSpace;
@@ -1476,7 +1476,7 @@ namespace Microsoft.Python.Parsing {
                     isFromForm = true;
 
                     if (!_stubFile && _langVersion.Is2x()) {
-                        ReportSyntaxError(fromStart, cause.EndIndex, "invalid syntax, from cause not allowed in 2.x.");
+                        ReportSyntaxError(fromStart, cause.EndIndex, Resources.FromCauseNotAllowedIn2XErrorMsg);//invalid syntax, from cause not allowed in 2.x.
                     }
                 }
 
@@ -1569,7 +1569,7 @@ namespace Microsoft.Python.Parsing {
                     expressions = ImmutableArray<Expression>.Create(exprList);
                 }
             } else if (needNonEmptyTestList) {
-                ReportSyntaxError(start, end, "print statement expected expression to be printed");
+                ReportSyntaxError(start, end, Resources.ExpectedExpressionToBePrintedErrorMsg);//print statement expected expression to be printed
                 expressions = expressions.Add(Error(""));
             }
 
@@ -1634,7 +1634,7 @@ namespace Microsoft.Python.Parsing {
                 if (!_stubFile && _langVersion.Is2x()) {
                     foreach (var a in args) {
                         if (a.Name != null) {
-                            ReportSyntaxError(a.StartIndex, a.EndIndex, "invalid syntax");
+                            ReportSyntaxError(a.StartIndex, a.EndIndex, Resources.InvalidSyntaxErrorMsg);
                         }
                     }
                 }
@@ -1796,7 +1796,7 @@ namespace Microsoft.Python.Parsing {
                 res = fnc;
             } else if (next == Tokens.KeywordClassToken) {
                 if (_langVersion < PythonLanguageVersion.V26) {
-                    ReportSyntaxError("invalid syntax, class decorators require 2.6 or later.");
+                    ReportSyntaxError("");//invalid syntax, class decorators require 2.6 or later.
                 }
                 var cls = ParseClassDef();
                 if (cls is ClassDefinition) {
@@ -1805,7 +1805,7 @@ namespace Microsoft.Python.Parsing {
                     res = cls;
                 } else {
                     // Class was an error...
-                    res = ErrorStmt("", decorators, cls);
+                    res = ErrorStmt(Resources.ClassDecoratorsRequire2dot6ErrorMsg, decorators, cls);
                 }
             } else {
                 ReportSyntaxError(_lookahead);
@@ -1886,7 +1886,7 @@ namespace Microsoft.Python.Parsing {
                 var arrStart = GetStart();
                 returnAnnotation = ParseExpression();
                 if (!_stubFile && _langVersion.Is2x()) {
-                    ReportSyntaxError(arrStart, returnAnnotation.EndIndex, "invalid syntax, return annotations require 3.x");
+                    ReportSyntaxError(arrStart, returnAnnotation.EndIndex, Resources.ReturnAnnotationsRequire3dotXErrorMsg);//invalid syntax, return annotations require 3.x
                 }
             }
 
@@ -2025,17 +2025,17 @@ namespace Microsoft.Python.Parsing {
             foreach (var p in parameters) {
                 if (p.Annotation != null) {
                     if (!_stubFile && _langVersion.Is2x()) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "invalid syntax, parameter annotations require 3.x");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.ParameterAnnotationsRequire3dotXErrorMsg);//invalid syntax, parameter annotations require 3.x
                         continue;
                     } else if (!allowAnnotations) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "invalid syntax");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.InvalidSyntaxErrorMsg);//invalid syntax
                         continue;
                     }
                 }
 
                 if (p.DefaultValue == null) {
                     if (seenDefault && p.Kind == ParameterKind.Normal) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "default value must be specified here");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DefaultValueMustBeSpecifiedErrorMsg);//default value must be specified here
                     }
                 } else {
                     seenDefault = true;
@@ -2043,7 +2043,7 @@ namespace Microsoft.Python.Parsing {
 
                 if (p is SublistParameter sp) {
                     if (_stubFile || _langVersion.Is3x()) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "sublist parameters are not supported in 3.x");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.SublistParametersNotSupported3dotXErrorMsg);//sublist parameters are not supported in 3.x
                     } else {
                         ValidateSublistParameter(sp.Tuple?.Items, seenNames);
                     }
@@ -2051,40 +2051,40 @@ namespace Microsoft.Python.Parsing {
                 }
 
                 if (p is ErrorParameter) {
-                    ReportSyntaxError(p.StartIndex, p.EndIndex, "invalid parameter");
+                    ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.InvalidParameterErrorMsg);//Invalid Parameter
                     continue;
                 }
 
                 if (string.IsNullOrEmpty(p.Name)) {
                     if (p.Kind != ParameterKind.List || !(_stubFile || _langVersion.Is3x())) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "invalid syntax");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.InvalidSyntaxErrorMsg);//Invalid Syntax
                         continue;
                     }
                 } else if (!seenNames.Add(p.Name)) {
-                    ReportSyntaxError(p.StartIndex, p.EndIndex, "duplicate argument '{0}' in function definition".FormatUI(p.Name));
+                    ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgumentInFunctionErrorMsg.FormatUI(p.Name));
                 }
 
                 if (p.Kind == ParameterKind.List) {
                     if (seenListArg) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "duplicate * args arguments");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgsArgumentErrorMsg.FormatInvariant("*"));//duplicate * args arguments
                     }
                     seenListArg = true;
                 } else if (p.Kind == ParameterKind.Dictionary) {
                     if (seenDictArg) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, "duplicate ** args arguments");
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgsArgumentErrorMsg.FormatInvariant("**"));//duplicate ** args arguments
                     }
                     seenDictArg = true;
                 } else if (seenListArg && p.Kind != ParameterKind.KeywordOnly) {
-                    ReportSyntaxError(p.StartIndex, p.EndIndex, "positional parameter after * args not allowed");
+                    ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.PositionalParameterNotAllowedErrorMsg);//positional parameter after * args not allowed
                 } else if (seenDictArg) {
-                    ReportSyntaxError(p.StartIndex, p.EndIndex, "invalid syntax");
+                    ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.InvalidSyntaxErrorMsg);//invalid syntax
                 }
             }
 
             if (parameters.Count > 0 && seenListArg) {
                 var p = parameters.Last();
                 if (p.Kind == ParameterKind.List && string.IsNullOrEmpty(p.Name)) {
-                    ReportSyntaxError(p.StartIndex, p.EndIndex, "named arguments must follow bare *");
+                    ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.NamedArgumentsMustFollowBareErrorMsg);//named arguments must follow bare *
                 }
             }
 
@@ -2109,7 +2109,7 @@ namespace Microsoft.Python.Parsing {
                 MoveNodeAttributes(p, sublist, NodeAttributes.ErrorMissingCloseGrouping);
                 AddIsAltForm(p);
             } else {
-                ReportSyntaxError(sublist.StartIndex, sublist.EndIndex, "invalid sublist parameter");
+                ReportSyntaxError(sublist.StartIndex, sublist.EndIndex, Resources.InvalidSublistParameterErrorMsg);//invalid sublist parameter
                 p = new ErrorParameter(sublist, ParameterKind.Normal);
                 p.SetLoc(sublist.StartIndex, sublist.EndIndex);
                 if (!(sublist is ParenthesisExpression) && !(sublist is TupleExpression)) {
@@ -2129,12 +2129,12 @@ namespace Microsoft.Python.Parsing {
                     ValidateSublistParameter(te.Items, seenNames);
                 } else if (e is NameExpression ne) {
                     if (string.IsNullOrEmpty(ne.Name)) {
-                        ReportSyntaxError(e.StartIndex, e.EndIndex, "invalid sublist parameter");
+                        ReportSyntaxError(e.StartIndex, e.EndIndex, Resources.InvalidSublistParameterErrorMsg);//invalid sublist parameter
                     } else if (!seenNames.Add(ne.Name)) {
-                        ReportSyntaxError(e.StartIndex, e.EndIndex, "duplicate argument '{0}' in function definition".FormatUI(ne.Name));
+                        ReportSyntaxError(e.StartIndex, e.EndIndex, Resources.DuplicateArgumentInFunctionDefinitionErrorMsg.FormatUI(ne.Name));
                     }
                 } else {
-                    ReportSyntaxError(e.StartIndex, e.EndIndex, "invalid sublist parameter");
+                    ReportSyntaxError(e.StartIndex, e.EndIndex, Resources.InvalidSublistParameterErrorMsg);//Invalid sublist parameter
                 }
             }
         }
@@ -2161,7 +2161,7 @@ namespace Microsoft.Python.Parsing {
                 expr = ParseExpression(allowNamedExpressions: false);
             } else {
                 expr = Error(string.Empty);
-                ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.Start, "expected ':'");
+                ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.Start, Resources.ExpectedCharacterErrorMsg.FormatInvariant(":"));//"expected ':'"
             }
             return ParseLambdaHelperEnd(func, expr, whitespace, colonWhiteSpace, commaWhiteSpace, ateTerminator);
         }
@@ -2512,7 +2512,7 @@ namespace Microsoft.Python.Parsing {
                     handlers.Add(handler);
 
                     if (dh != null) {
-                        ReportSyntaxError(dh.StartIndex, dh.HeaderIndex, "default 'except' must be last");
+                        ReportSyntaxError(dh.StartIndex, dh.HeaderIndex, Resources.DefaultExceptMustBeLastErrorMsg);//default 'except' must be last
                     }
                     if (handler.Test == null) {
                         dh = handler;
@@ -2580,7 +2580,7 @@ namespace Microsoft.Python.Parsing {
                 if (MaybeEat(TokenKind.KeywordAs) || MaybeEatName("as")) {
                     commaWhiteSpace = _tokenWhiteSpace;
                     if (_langVersion < PythonLanguageVersion.V26 && !_stubFile) {
-                        ReportSyntaxError(lookahead.Span.Start, lookahead.Span.End, "'as' requires Python 2.6 or later");
+                        ReportSyntaxError(lookahead.Span.Start, lookahead.Span.End, Resources.AsRequiresPython2dot6OrlaterErrorMsg);//'as' requires Python 2.6 or later
                     }
                     test2 = ParseExpression();
                     altForm = true;
@@ -2588,7 +2588,7 @@ namespace Microsoft.Python.Parsing {
                     commaWhiteSpace = _tokenWhiteSpace;
                     test2 = ParseExpression();
                     if (_langVersion.Is3x() || _stubFile) {
-                        ReportSyntaxError(lookahead.Span.Start, GetEnd(), "\", variable\" not allowed in 3.x - use \"as variable\" instead.");
+                        ReportSyntaxError(lookahead.Span.Start, GetEnd(), Resources.VariableIn3dotXErrorMsg);//"\", variable\" not allowed in 3.x - use \"as variable\" instead."
                     }
                 }
             }
@@ -2651,7 +2651,7 @@ namespace Microsoft.Python.Parsing {
                 if (!MaybeEat(TokenKind.Indent)) {
                     // no indent?  report the indentation error.
                     if (cur.Token.Kind == TokenKind.Dedent) {
-                        ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.End, "expected an indented block", ErrorCodes.SyntaxError | ErrorCodes.IncompleteStatement);
+                        ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.End, Resources.ExpectedIndentedBlockErrorMsg, ErrorCodes.SyntaxError | ErrorCodes.IncompleteStatement);
                     } else {
                         ReportSyntaxError(cur, ErrorCodes.IndentationError);
                     }
@@ -2674,7 +2674,7 @@ namespace Microsoft.Python.Parsing {
                     l.Add(s);
 
                     if (PeekToken().Kind == TokenKind.EndOfFile) {
-                        ReportSyntaxError("unexpected end of file");
+                        ReportSyntaxError(Resources.UnexpectedEndOfFileErrorMsg);//"unexpected end of file"
                         break; // error handling
                     }
                 }
@@ -3187,7 +3187,7 @@ namespace Microsoft.Python.Parsing {
                     }
                     hasAsciiStrings = true;
                 } else {
-                    Debug.Fail("Unhandled string token");
+                    Debug.Fail(Resources.UnhandledStringTokenErrorMsg);//Unhandled string token
                     if (IsStringToken(PeekToken())) {
                         NextToken();
                     }
@@ -3366,7 +3366,7 @@ namespace Microsoft.Python.Parsing {
                             break;
                         case TokenKind.Constant:
                             // abc.1, abc"", abc 1L, abc 0j
-                            ReportSyntaxError("invalid syntax");
+                            ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);//invalid syntax
                             ret = Error(_verbatim ? _lookaheadWhiteSpace + _lookahead.Token.VerbatimImage : null, ret);
                             NextToken();
                             break;
@@ -3571,7 +3571,7 @@ namespace Microsoft.Python.Parsing {
 
             string name;
             if (!(t is NameExpression n)) {
-                ReportSyntaxError(t.StartIndex, t.EndIndex, "expected name");
+                ReportSyntaxError(t.StartIndex, t.EndIndex, Resources.ExpectedNameErrorMsg);//expected name
                 name = null;
             } else {
                 name = n.Name;
@@ -3593,7 +3593,7 @@ namespace Microsoft.Python.Parsing {
                 var name = arg.Name;
                 for (var i = 0; i < names.Count; i++) {
                     if (names[i].Name == arg.Name) {
-                        ReportSyntaxError("duplicate keyword argument");
+                        ReportSyntaxError(Resources.DuplicateKeywordArgumentErrorMsg);//duplicate keyword argument
                     }
                 }
             }
@@ -3666,7 +3666,7 @@ namespace Microsoft.Python.Parsing {
             var l = ParseOldExpressionList(out var trailingComma, out var itemWhiteSpace);
             //  the case when no expression was parsed e.g. when we have an empty expression list
             if (l.Count == 0 && !trailingComma) {
-                ReportSyntaxError("invalid syntax");
+                ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);//invalid syntax
             }
             return MakeTupleOrExpr(l, itemWhiteSpace, trailingComma, true);
         }
@@ -3725,7 +3725,7 @@ namespace Microsoft.Python.Parsing {
             if ((token == TokenKind.Multiply || token == TokenKind.Power) && Eat(token)) {
                 var whitespace = _tokenWhiteSpace;
                 if (_langVersion.Is2x() && !_stubFile) {
-                    ReportSyntaxError("invalid syntax");
+                    ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);//invalid syntax
                 }
                 var start = GetStart();
                 var expr = ParseExpr();
@@ -3798,7 +3798,7 @@ namespace Microsoft.Python.Parsing {
                 // indent if we're at an EOF.  It'a also an indentation error instead of a syntax error.
                 var indentVerbatim = _verbatim ? _tokenWhiteSpace + _token.Token.VerbatimImage : null;
                 NextToken();
-                ReportSyntaxError(GetStart(), GetEnd(), "unexpected indent", ErrorCodes.IndentationError);
+                ReportSyntaxError(GetStart(), GetEnd(), Resources.UnexpectedIndentErrorMsg, ErrorCodes.IndentationError);
                 return Error(_verbatim ? (indentVerbatim + _tokenWhiteSpace + _token.Token.VerbatimImage) : null);
             } else {
                 ReportSyntaxError(_lookahead);
@@ -3855,7 +3855,7 @@ namespace Microsoft.Python.Parsing {
                 hasRightParenthesis = true;
             } else if (PeekToken(TokenKind.KeywordYield)) {
                 if (!AllowYieldSyntax && AllowAsyncAwaitSyntax) {
-                    ReportSyntaxError("'yield' inside async function");
+                    ReportSyntaxError(Resources.YieldInsideAsyncErrorMsg);//'yield' inside async function
                 }
                 Eat(TokenKind.KeywordYield);
                 ret = new ParenthesisExpression(ParseYieldExpression());
@@ -3872,14 +3872,14 @@ namespace Microsoft.Python.Parsing {
                     } else if (PeekTokenForOrAsyncForToStartGenerator) {
                         // "(" expression "for" ...
                         if (expr is StarredExpression) {
-                            ReportSyntaxError(expr.StartIndex, expr.EndIndex, "iterable unpacking cannot be used in comprehension");
+                            ReportSyntaxError(expr.StartIndex, expr.EndIndex, Resources.IterableUnpackingErrorMsg);//iterable unpacking cannot be used in comprehension
                         }
                         ret = ParseGeneratorExpression(expr, startingWhiteSpace);
                     } else {
                         // "(" expression ")"
                         ret = new ParenthesisExpression(expr);
                         if (expr is StarredExpression) {
-                            ReportSyntaxError(expr.StartIndex, expr.EndIndex, "can't use starred expression here");
+                            ReportSyntaxError(expr.StartIndex, expr.EndIndex, Resources.CantUseStarredExpErrorMsg);//can't use starred expression here
                         }
                     }
                     hasRightParenthesis = Eat(TokenKind.RightParenthesis);
@@ -4012,7 +4012,7 @@ namespace Microsoft.Python.Parsing {
 
                         if (!reportedError) {
                             if (setMembers != null || hasSequenceUnpack || isSequenceUnpack || isDictUnpack) {
-                                ReportSyntaxError(e1.StartIndex, e2.EndIndex, "invalid syntax");
+                                ReportSyntaxError(e1.StartIndex, e2.EndIndex, Resources.InvalidSyntaxErrorMsg);//Invalid Syntax
                                 reportedError = true;
                             }
                         }
@@ -4026,7 +4026,7 @@ namespace Microsoft.Python.Parsing {
 
                         if (PeekTokenForOrAsyncFor) {
                             if (!first || (!_stubFile && _langVersion < PythonLanguageVersion.V27)) {
-                                ReportSyntaxError("invalid syntax");
+                                ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);//Invalid Syntax
                             }
 
                             var dictComp = FinishDictComp(se, out ateTerminator);
@@ -4048,14 +4048,14 @@ namespace Microsoft.Python.Parsing {
                         }
                     } else { // set literal or dict unpack
                         if (!_stubFile && _langVersion < PythonLanguageVersion.V27 && !reportedError) {
-                            ReportSyntaxError(e1.StartIndex, e1.EndIndex, "invalid syntax, set literals require Python 2.7 or later.");
+                            ReportSyntaxError(e1.StartIndex, e1.EndIndex, Resources.SetLiteralsRequirePython2dot7ErrorMsg);//invalid syntax, set literals require Python 2.7 or later.
                             reportedError = true;
                         }
 
                         if (isDictUnpack && hasDictUnpack) {
                             // **{}, we don't have a colon and a value...
                             if (setMembers != null && !reportedError) {
-                                ReportSyntaxError(e1.StartIndex, e1.EndIndex, "invalid syntax");
+                                ReportSyntaxError(e1.StartIndex, e1.EndIndex, Resources.InvalidSyntaxErrorMsg);//Invalid Syntax
                                 reportedError = true;
                             }
 
@@ -4066,7 +4066,7 @@ namespace Microsoft.Python.Parsing {
                         } else {
                             if (dictMembers != null) {
                                 if (!reportedError) {
-                                    ReportSyntaxError(e1.StartIndex, e1.EndIndex, "invalid syntax");
+                                    ReportSyntaxError(e1.StartIndex, e1.EndIndex, Resources.InvalidSyntaxErrorMsg);//Invalid Syntax
                                     reportedError = true;
                                 }
                             } else if (setMembers == null) {
@@ -4076,7 +4076,7 @@ namespace Microsoft.Python.Parsing {
 
                             if (PeekTokenForOrAsyncFor) {
                                 if (!first) {
-                                    ReportSyntaxError("invalid syntax");
+                                    ReportSyntaxError(Resources.InvalidSyntaxErrorMsg);//invalid syntax
                                 }
                                 var setComp = FinishSetComp(e1, out ateTerminator);
                                 if (_verbatim) {
@@ -4527,32 +4527,32 @@ namespace Microsoft.Python.Parsing {
                 if (arg.Name == null) {
                     if (_stubFile || _langVersion >= PythonLanguageVersion.V35) {
                         if (hasKeywordDict) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, "positional argument follows keyword argument unpacking");
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.PositionalArgumentKeywardArgumentUnpackingErrorMsg);//positional argument follows keyword argument unpacking
                         } else if (keywordCount > 0) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, "positional argument follows keyword argument");
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.PositionalArgumentKeywardArgumentErrorMsg);//positional argument follows keyword argument
                         }
                     } else if (hasArgsTuple || hasKeywordDict || keywordCount > 0) {
-                        ReportSyntaxError(arg.StartIndex, arg.EndIndex, "non-keyword arg after keyword arg");
+                        ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.NonKeywordArgAfterKeywordArgErrorMsg);//non-keyword arg after keyword arg
                     }
                 } else if (arg.Name == "*") {
                     if (hasArgsTuple || hasKeywordDict) {
                         if (!_stubFile && _langVersion < PythonLanguageVersion.V35) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, "only one * allowed");
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.OnlyOneAllowedErrorMsg.FormatInvariant("*"));//"only one * allowed"
                         } else if (hasKeywordDict) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, "iterable argument unpacking follows keyword argument unpacking");
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.IterableArgumentFollowsKeywordArgumentErrorMsg);//iterable argument unpacking follows keyword argument unpacking
                         }
                     }
                     hasArgsTuple = true; extraArgs++;
                 } else if (arg.Name == "**") {
                     if (hasKeywordDict) {
                         if (!_stubFile && _langVersion < PythonLanguageVersion.V35) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, "only one ** allowed");
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.OnlyOneAllowedErrorMsg.FormatInvariant("**"));//only one ** allowed
                         }
                     }
                     hasKeywordDict = true; extraArgs++;
                 } else {
                     if (hasKeywordDict && !_stubFile && _langVersion < PythonLanguageVersion.V35) {
-                        ReportSyntaxError(arg.StartIndex, arg.EndIndex, "keywords must come before ** args");
+                        ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.KeywordsMustComeBeforeArgsErrorMsg);//keywords must come before ** args
                     }
                     keywordCount++;
                 }
@@ -4779,7 +4779,7 @@ namespace Microsoft.Python.Parsing {
 
         private void StartParsing() {
             if (_parsingStarted) {
-                throw new InvalidOperationException("Parsing already started. Use Restart to start again.");
+                throw new InvalidOperationException(Resources.ParsingAlreadyStartedErrorMsg);//Parsing already started. Use Restart to start again.
             }
 
             _parsingStarted = true;
@@ -5011,7 +5011,7 @@ namespace Microsoft.Python.Parsing {
                 if ((gotEncoding == null || gotEncoding == true) && isUtf8 && encodingName != "utf-8") {
                     // we have both a BOM & an encoding type, throw an error
                     errors.Add(
-                        "file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present.",
+                        Resources.Utf8EncodingErrorMsg,//"file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present."
                         GetEncodingLineNumbers(readBytes),
                         encodingIndex,
                         encodingIndex + encodingName.Length,
@@ -5025,7 +5025,7 @@ namespace Microsoft.Python.Parsing {
                     if (gotEncoding == null) {
                         // get line number information for the bytes we've read...
                         errors.Add(
-                            "encoding problem: unknown encoding (line {0})".FormatUI(lineNo),
+                            Resources.UnknownEncodingErrorMsg.FormatUI(lineNo),
                             GetEncodingLineNumbers(readBytes),
                             encodingIndex,
                             encodingIndex + encodingName.Length,

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -2066,12 +2066,12 @@ namespace Microsoft.Python.Parsing {
 
                 if (p.Kind == ParameterKind.List) {
                     if (seenListArg) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgsArgumentErrorMsg.FormatInvariant("*"));//duplicate * args arguments
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgsSingleArgumentErrorMsg);//duplicate * args arguments
                     }
                     seenListArg = true;
                 } else if (p.Kind == ParameterKind.Dictionary) {
-                    if (seenDictArg) {
-                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgsArgumentErrorMsg.FormatInvariant("**"));//duplicate ** args arguments
+                    if (seenDictArg) {  
+                        ReportSyntaxError(p.StartIndex, p.EndIndex, Resources.DuplicateArgsDoubleArgumentErrorMsg);//duplicate ** args arguments
                     }
                     seenDictArg = true;
                 } else if (seenListArg && p.Kind != ParameterKind.KeywordOnly) {
@@ -2161,7 +2161,7 @@ namespace Microsoft.Python.Parsing {
                 expr = ParseExpression(allowNamedExpressions: false);
             } else {
                 expr = Error(string.Empty);
-                ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.Start, Resources.ExpectedCharacterErrorMsg.FormatInvariant(":"));//"expected ':'"
+                ReportSyntaxError(_lookahead.Span.Start, _lookahead.Span.Start, Resources.ExpectedColonErrorMsg);//"expected ':'"
             }
             return ParseLambdaHelperEnd(func, expr, whitespace, colonWhiteSpace, commaWhiteSpace, ateTerminator);
         }
@@ -4537,7 +4537,7 @@ namespace Microsoft.Python.Parsing {
                 } else if (arg.Name == "*") {
                     if (hasArgsTuple || hasKeywordDict) {
                         if (!_stubFile && _langVersion < PythonLanguageVersion.V35) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.OnlyOneAllowedErrorMsg.FormatInvariant("*"));//"only one * allowed"
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.OnlyOneAllowedSingleErrorMsg);//"only one * allowed"
                         } else if (hasKeywordDict) {
                             ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.IterableArgumentFollowsKeywordArgumentErrorMsg);//iterable argument unpacking follows keyword argument unpacking
                         }
@@ -4546,7 +4546,7 @@ namespace Microsoft.Python.Parsing {
                 } else if (arg.Name == "**") {
                     if (hasKeywordDict) {
                         if (!_stubFile && _langVersion < PythonLanguageVersion.V35) {
-                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.OnlyOneAllowedErrorMsg.FormatInvariant("**"));//only one ** allowed
+                            ReportSyntaxError(arg.StartIndex, arg.EndIndex, Resources.OnlyOneAllowedDoubleErrorMsg);//only one ** allowed
                         }
                     }
                     hasKeywordDict = true; extraArgs++;

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -1796,7 +1796,7 @@ namespace Microsoft.Python.Parsing {
                 res = fnc;
             } else if (next == Tokens.KeywordClassToken) {
                 if (_langVersion < PythonLanguageVersion.V26) {
-                    ReportSyntaxError("");//invalid syntax, class decorators require 2.6 or later.
+                    ReportSyntaxError(Resources.ClassDecoratorsRequireTwodotSixErrorMsg);//invalid syntax, class decorators require 2.6 or later.
                 }
                 var cls = ParseClassDef();
                 if (cls is ClassDefinition) {
@@ -1805,7 +1805,7 @@ namespace Microsoft.Python.Parsing {
                     res = cls;
                 } else {
                     // Class was an error...
-                    res = ErrorStmt(Resources.ClassDecoratorsRequireTwodotSixErrorMsg, decorators, cls);//Resources.ClassDecoratorsRequireTwodotSixErrorMsg
+                    res = ErrorStmt("", decorators, cls);
                 }
             } else {
                 ReportSyntaxError(_lookahead);

--- a/src/Parsing/Impl/Resources.Designer.cs
+++ b/src/Parsing/Impl/Resources.Designer.cs
@@ -61,11 +61,47 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;as&apos; requires Python 2.6 or later.
+        /// </summary>
+        internal static string AsRequiresPython2dot6OrlaterErrorMsg {
+            get {
+                return ResourceManager.GetString("AsRequiresPython2dot6OrlaterErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to f-string expression part cannot include a backslash.
         /// </summary>
         internal static string BackslashFStringExpressionErrorMsg {
             get {
                 return ResourceManager.GetString("BackslashFStringExpressionErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;break&apos; outside loop.
+        /// </summary>
+        internal static string BreakOustideLoopErrorMsg {
+            get {
+                return ResourceManager.GetString("BreakOustideLoopErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to can&apos;t use starred expression here.
+        /// </summary>
+        internal static string CantUseStarredExpErrorMsg {
+            get {
+                return ResourceManager.GetString("CantUseStarredExpErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid syntax, class decorators require 2.6 or later..
+        /// </summary>
+        internal static string ClassDecoratorsRequire2dot6ErrorMsg {
+            get {
+                return ResourceManager.GetString("ClassDecoratorsRequire2dot6ErrorMsg", resourceCulture);
             }
         }
         
@@ -79,11 +115,128 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;continue&apos; not properly in loop.
+        /// </summary>
+        internal static string ContinueNotInLoopErrorMsg {
+            get {
+                return ResourceManager.GetString("ContinueNotInLoopErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;continue&apos; not supported inside &apos;finally&apos; clause.
+        /// </summary>
+        internal static string ContinueNotSupportedInsideFinallyErrorMsg {
+            get {
+                return ResourceManager.GetString("ContinueNotSupportedInsideFinallyErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to default &apos;except&apos; must be last.
+        /// </summary>
+        internal static string DefaultExceptMustBeLastErrorMsg {
+            get {
+                return ResourceManager.GetString("DefaultExceptMustBeLastErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to default value must be specified here.
+        /// </summary>
+        internal static string DefaultValueMustBeSpecifiedErrorMsg {
+            get {
+                return ResourceManager.GetString("DefaultValueMustBeSpecifiedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to duplicate &apos;{0}&apos; args arguments.
+        /// </summary>
+        internal static string DuplicateArgsArgumentErrorMsg {
+            get {
+                return ResourceManager.GetString("DuplicateArgsArgumentErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to duplicate argument &apos;{0}&apos; in function definition.
+        /// </summary>
+        internal static string DuplicateArgumentInFunctionDefinitionErrorMsg {
+            get {
+                return ResourceManager.GetString("DuplicateArgumentInFunctionDefinitionErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to duplicate argument &apos;{0}&apos; in function definition.
+        /// </summary>
+        internal static string DuplicateArgumentInFunctionErrorMsg {
+            get {
+                return ResourceManager.GetString("DuplicateArgumentInFunctionErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to duplicate keyword argument.
+        /// </summary>
+        internal static string DuplicateKeywordArgumentErrorMsg {
+            get {
+                return ResourceManager.GetString("DuplicateKeywordArgumentErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to f-string: empty expression not allowed.
         /// </summary>
         internal static string EmptyExpressionFStringErrorMsg {
             get {
                 return ResourceManager.GetString("EmptyExpressionFStringErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to expected &apos;&apos;{0}&apos;&apos;.
+        /// </summary>
+        internal static string ExpectedCharacterErrorMsg {
+            get {
+                return ResourceManager.GetString("ExpectedCharacterErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to expected expression after del.
+        /// </summary>
+        internal static string ExpectedExpressionAfterDelErrorMsg {
+            get {
+                return ResourceManager.GetString("ExpectedExpressionAfterDelErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to print statement expected expression to be printed.
+        /// </summary>
+        internal static string ExpectedExpressionToBePrintedErrorMsg {
+            get {
+                return ResourceManager.GetString("ExpectedExpressionToBePrintedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to expected an indented block.
+        /// </summary>
+        internal static string ExpectedIndentedBlockErrorMsg {
+            get {
+                return ResourceManager.GetString("ExpectedIndentedBlockErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to expected name.
+        /// </summary>
+        internal static string ExpectedNameErrorMsg {
+            get {
+                return ResourceManager.GetString("ExpectedNameErrorMsg", resourceCulture);
             }
         }
         
@@ -102,6 +255,69 @@ namespace Microsoft.Python.Parsing {
         internal static string ExpectingCharFStringErrorMsg {
             get {
                 return ResourceManager.GetString("ExpectingCharFStringErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid syntax, from cause not allowed in 2.x..
+        /// </summary>
+        internal static string FromCauseNotAllowedIn2XErrorMsg {
+            get {
+                return ResourceManager.GetString("FromCauseNotAllowedIn2XErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to future feature is not defined: .
+        /// </summary>
+        internal static string FutureFeatureNotDefinedErrorMsg {
+            get {
+                return ResourceManager.GetString("FutureFeatureNotDefinedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to from __future__ imports must occur at the beginning of the file.
+        /// </summary>
+        internal static string FutureImportsMustOccorAtBeginningOfFileErrorMsg {
+            get {
+                return ResourceManager.GetString("FutureImportsMustOccorAtBeginningOfFileErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to future statement does not support import *.
+        /// </summary>
+        internal static string FutureStatementDoesNotSupportImportErrorMsg {
+            get {
+                return ResourceManager.GetString("FutureStatementDoesNotSupportImportErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to illegal target for annotation.
+        /// </summary>
+        internal static string IllegalTargetAnnotationErrorMsg {
+            get {
+                return ResourceManager.GetString("IllegalTargetAnnotationErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to import * only allowed at module level.
+        /// </summary>
+        internal static string ImportOnlyAllowedAtModuleErrorMsg {
+            get {
+                return ResourceManager.GetString("ImportOnlyAllowedAtModuleErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start location was not set correctly.
+        /// </summary>
+        internal static string IncorrectStartLocationErrorMsg {
+            get {
+                return ResourceManager.GetString("IncorrectStartLocationErrorMsg", resourceCulture);
             }
         }
         
@@ -133,11 +349,65 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to invalid parameter.
+        /// </summary>
+        internal static string InvalidParameterErrorMsg {
+            get {
+                return ResourceManager.GetString("InvalidParameterErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid sublist parameter.
+        /// </summary>
+        internal static string InvalidSublistParameterErrorMsg {
+            get {
+                return ResourceManager.GetString("InvalidSublistParameterErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid syntax, only exception value is allowed in 3.x..
+        /// </summary>
+        internal static string InvalidSyntaxAllowedInVersion3XErrorMsg {
+            get {
+                return ResourceManager.GetString("InvalidSyntaxAllowedInVersion3XErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to invalid syntax.
         /// </summary>
         internal static string InvalidSyntaxErrorMsg {
             get {
                 return ResourceManager.GetString("InvalidSyntaxErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to iterable argument unpacking follows keyword argument unpacking.
+        /// </summary>
+        internal static string IterableArgumentFollowsKeywordArgumentErrorMsg {
+            get {
+                return ResourceManager.GetString("IterableArgumentFollowsKeywordArgumentErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to iterable unpacking cannot be used in comprehension.
+        /// </summary>
+        internal static string IterableUnpackingErrorMsg {
+            get {
+                return ResourceManager.GetString("IterableUnpackingErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to keywords must come before ** args.
+        /// </summary>
+        internal static string KeywordsMustComeBeforeArgsErrorMsg {
+            get {
+                return ResourceManager.GetString("KeywordsMustComeBeforeArgsErrorMsg", resourceCulture);
             }
         }
         
@@ -151,11 +421,38 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to misplaced yield.
+        /// </summary>
+        internal static string MisplacedYieldErrorMsg {
+            get {
+                return ResourceManager.GetString("MisplacedYieldErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to missing module name.
+        /// </summary>
+        internal static string MissingModuleNameErrorMsg {
+            get {
+                return ResourceManager.GetString("MissingModuleNameErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to cannot mix bytes and nonbytes literals.
         /// </summary>
         internal static string MixingBytesAndNonBytesErrorMsg {
             get {
                 return ResourceManager.GetString("MixingBytesAndNonBytesErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to named arguments must follow bare *.
+        /// </summary>
+        internal static string NamedArgumentsMustFollowBareErrorMsg {
+            get {
+                return ResourceManager.GetString("NamedArgumentsMustFollowBareErrorMsg", resourceCulture);
             }
         }
         
@@ -178,11 +475,128 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to non-keyword arg after keyword arg.
+        /// </summary>
+        internal static string NonKeywordArgAfterKeywordArgErrorMsg {
+            get {
+                return ResourceManager.GetString("NonKeywordArgAfterKeywordArgErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nonlocal declaration not allowed at module level.
+        /// </summary>
+        internal static string NonLocalDeclarationAtModuleErrorMsg {
+            get {
+                return ResourceManager.GetString("NonLocalDeclarationAtModuleErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to not a chance.
+        /// </summary>
+        internal static string NotAChanceErrorMsg {
+            get {
+                return ResourceManager.GetString("NotAChanceErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to f-string expression part cannot include &apos;#&apos;.
         /// </summary>
         internal static string NumberSignFStringExpressionErrorMsg {
             get {
                 return ResourceManager.GetString("NumberSignFStringExpressionErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to only one &apos;{0}&apos; allowed.
+        /// </summary>
+        internal static string OnlyOneAllowedErrorMsg {
+            get {
+                return ResourceManager.GetString("OnlyOneAllowedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid syntax, parameter annotations require 3.x.
+        /// </summary>
+        internal static string ParameterAnnotationsRequire3dotXErrorMsg {
+            get {
+                return ResourceManager.GetString("ParameterAnnotationsRequire3dotXErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parsing already started. Use Restart to start again..
+        /// </summary>
+        internal static string ParsingAlreadyStartedErrorMsg {
+            get {
+                return ResourceManager.GetString("ParsingAlreadyStartedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to positional argument follows keyword argument.
+        /// </summary>
+        internal static string PositionalArgumentKeywardArgumentErrorMsg {
+            get {
+                return ResourceManager.GetString("PositionalArgumentKeywardArgumentErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to positional argument follows keyword argument unpacking.
+        /// </summary>
+        internal static string PositionalArgumentKeywardArgumentUnpackingErrorMsg {
+            get {
+                return ResourceManager.GetString("PositionalArgumentKeywardArgumentUnpackingErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to positional parameter after * args not allowed.
+        /// </summary>
+        internal static string PositionalParameterNotAllowedErrorMsg {
+            get {
+                return ResourceManager.GetString("PositionalParameterNotAllowedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid syntax, return annotations require 3.x.
+        /// </summary>
+        internal static string ReturnAnnotationsRequire3dotXErrorMsg {
+            get {
+                return ResourceManager.GetString("ReturnAnnotationsRequire3dotXErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;return&apos; outside function.
+        /// </summary>
+        internal static string ReturnOutsideFunctionErrorMsg {
+            get {
+                return ResourceManager.GetString("ReturnOutsideFunctionErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;return&apos; with argument inside generator.
+        /// </summary>
+        internal static string ReturnWithArgumentInGeneratorErrorMsg {
+            get {
+                return ResourceManager.GetString("ReturnWithArgumentInGeneratorErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to invalid syntax, set literals require Python 2.7 or later..
+        /// </summary>
+        internal static string SetLiteralsRequirePython2dot7ErrorMsg {
+            get {
+                return ResourceManager.GetString("SetLiteralsRequirePython2dot7ErrorMsg", resourceCulture);
             }
         }
         
@@ -196,11 +610,128 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to only single target (not tuple) can be annotated.
+        /// </summary>
+        internal static string SingleTargetCanBeAnnotatedErrorMsg {
+            get {
+                return ResourceManager.GetString("SingleTargetCanBeAnnotatedErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to sublist parameters are not supported in 3.x.
+        /// </summary>
+        internal static string SublistParametersNotSupported3dotXErrorMsg {
+            get {
+                return ResourceManager.GetString("SublistParametersNotSupported3dotXErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to syntax error.
+        /// </summary>
+        internal static string SyntaxErrorMsg {
+            get {
+                return ResourceManager.GetString("SyntaxErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to two starred expressions in assignment.
+        /// </summary>
+        internal static string TwoStarredExpressionErrorMsg {
+            get {
+                return ResourceManager.GetString("TwoStarredExpressionErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unexpected end of file.
+        /// </summary>
+        internal static string UnexpectedEndOfFileErrorMsg {
+            get {
+                return ResourceManager.GetString("UnexpectedEndOfFileErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unexpected EOF while parsing.
+        /// </summary>
+        internal static string UnexpectedEndOfFileWhileParsingErrorMsg {
+            get {
+                return ResourceManager.GetString("UnexpectedEndOfFileWhileParsingErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unexpected indent.
+        /// </summary>
+        internal static string UnexpectedIndentErrorMsg {
+            get {
+                return ResourceManager.GetString("UnexpectedIndentErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unexpected token &apos;{0}&apos;.
+        /// </summary>
+        internal static string UnexpectedTokenErrorMsg {
+            get {
+                return ResourceManager.GetString("UnexpectedTokenErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unhandled string token.
+        /// </summary>
+        internal static string UnhandledStringTokenErrorMsg {
+            get {
+                return ResourceManager.GetString("UnhandledStringTokenErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to encoding problem: unknown encoding (line {0}).
+        /// </summary>
+        internal static string UnknownEncodingErrorMsg {
+            get {
+                return ResourceManager.GetString("UnknownEncodingErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to f-string: unmatched &apos;{0}&apos;.
         /// </summary>
         internal static string UnmatchedFStringErrorMsg {
             get {
                 return ResourceManager.GetString("UnmatchedFStringErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to file has both Unicode marker and PEP-263 file encoding.  You must use \&quot;utf-8\&quot; as the encoding name when a BOM is present..
+        /// </summary>
+        internal static string Utf8EncodingErrorMsg {
+            get {
+                return ResourceManager.GetString("Utf8EncodingErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to \&quot;, variable\&quot; not allowed in 3.x - use \&quot;as variable\&quot; instead..
+        /// </summary>
+        internal static string VariableIn3dotXErrorMsg {
+            get {
+                return ResourceManager.GetString("VariableIn3dotXErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;yield&apos; inside async function.
+        /// </summary>
+        internal static string YieldInsideAsyncErrorMsg {
+            get {
+                return ResourceManager.GetString("YieldInsideAsyncErrorMsg", resourceCulture);
             }
         }
     }

--- a/src/Parsing/Impl/Resources.Designer.cs
+++ b/src/Parsing/Impl/Resources.Designer.cs
@@ -151,11 +151,20 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to duplicate {0} args arguments.
+        ///   Looks up a localized string similar to duplicate ** args arguments.
         /// </summary>
-        internal static string DuplicateArgsArgumentErrorMsg {
+        internal static string DuplicateArgsDoubleArgumentErrorMsg {
             get {
-                return ResourceManager.GetString("DuplicateArgsArgumentErrorMsg", resourceCulture);
+                return ResourceManager.GetString("DuplicateArgsDoubleArgumentErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to duplicate * args arguments.
+        /// </summary>
+        internal static string DuplicateArgsSingleArgumentErrorMsg {
+            get {
+                return ResourceManager.GetString("DuplicateArgsSingleArgumentErrorMsg", resourceCulture);
             }
         }
         
@@ -196,11 +205,11 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to expected &apos;{0}&apos;.
+        ///   Looks up a localized string similar to expected &apos;:&apos;.
         /// </summary>
-        internal static string ExpectedCharacterErrorMsg {
+        internal static string ExpectedColonErrorMsg {
             get {
-                return ResourceManager.GetString("ExpectedCharacterErrorMsg", resourceCulture);
+                return ResourceManager.GetString("ExpectedColonErrorMsg", resourceCulture);
             }
         }
         
@@ -511,11 +520,20 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to only one {0} allowed.
+        ///   Looks up a localized string similar to only one ** allowed.
         /// </summary>
-        internal static string OnlyOneAllowedErrorMsg {
+        internal static string OnlyOneAllowedDoubleErrorMsg {
             get {
-                return ResourceManager.GetString("OnlyOneAllowedErrorMsg", resourceCulture);
+                return ResourceManager.GetString("OnlyOneAllowedDoubleErrorMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to only one * allowed.
+        /// </summary>
+        internal static string OnlyOneAllowedSingleErrorMsg {
+            get {
+                return ResourceManager.GetString("OnlyOneAllowedSingleErrorMsg", resourceCulture);
             }
         }
         

--- a/src/Parsing/Impl/Resources.Designer.cs
+++ b/src/Parsing/Impl/Resources.Designer.cs
@@ -99,9 +99,9 @@ namespace Microsoft.Python.Parsing {
         /// <summary>
         ///   Looks up a localized string similar to invalid syntax, class decorators require 2.6 or later..
         /// </summary>
-        internal static string ClassDecoratorsRequire2dot6ErrorMsg {
+        internal static string ClassDecoratorsRequireTwodotSixErrorMsg {
             get {
-                return ResourceManager.GetString("ClassDecoratorsRequire2dot6ErrorMsg", resourceCulture);
+                return ResourceManager.GetString("ClassDecoratorsRequireTwodotSixErrorMsg", resourceCulture);
             }
         }
         
@@ -151,7 +151,7 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to duplicate &apos;{0}&apos; args arguments.
+        ///   Looks up a localized string similar to duplicate {0} args arguments.
         /// </summary>
         internal static string DuplicateArgsArgumentErrorMsg {
             get {
@@ -196,7 +196,7 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to expected &apos;&apos;{0}&apos;&apos;.
+        ///   Looks up a localized string similar to expected &apos;{0}&apos;.
         /// </summary>
         internal static string ExpectedCharacterErrorMsg {
             get {
@@ -511,7 +511,7 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to only one &apos;{0}&apos; allowed.
+        ///   Looks up a localized string similar to only one {0} allowed.
         /// </summary>
         internal static string OnlyOneAllowedErrorMsg {
             get {
@@ -718,7 +718,7 @@ namespace Microsoft.Python.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to \&quot;, variable\&quot; not allowed in 3.x - use \&quot;as variable\&quot; instead..
+        ///   Looks up a localized string similar to &quot;, variable&quot; not allowed in 3.x - use &quot;as variable&quot; instead..
         /// </summary>
         internal static string VariableIn3dotXErrorMsg {
             get {

--- a/src/Parsing/Impl/Resources.resx
+++ b/src/Parsing/Impl/Resources.resx
@@ -129,7 +129,7 @@
   <data name="CantUseStarredExpErrorMsg" xml:space="preserve">
     <value>can't use starred expression here</value>
   </data>
-  <data name="ClassDecoratorsRequire2dot6ErrorMsg" xml:space="preserve">
+  <data name="ClassDecoratorsRequireTwodotSixErrorMsg" xml:space="preserve">
     <value>invalid syntax, class decorators require 2.6 or later.</value>
   </data>
   <data name="ClosingParensNotMatchFStringErrorMsg" xml:space="preserve">
@@ -148,7 +148,7 @@
     <value>default value must be specified here</value>
   </data>
   <data name="DuplicateArgsArgumentErrorMsg" xml:space="preserve">
-    <value>duplicate '{0}' args arguments</value>
+    <value>duplicate {0} args arguments</value>
   </data>
   <data name="DuplicateArgumentInFunctionDefinitionErrorMsg" xml:space="preserve">
     <value>duplicate argument '{0}' in function definition</value>
@@ -163,7 +163,7 @@
     <value>f-string: empty expression not allowed</value>
   </data>
   <data name="ExpectedCharacterErrorMsg" xml:space="preserve">
-    <value>expected ''{0}''</value>
+    <value>expected '{0}'</value>
   </data>
   <data name="ExpectedExpressionAfterDelErrorMsg" xml:space="preserve">
     <value>expected expression after del</value>
@@ -268,7 +268,7 @@
     <value>f-string expression part cannot include '#'</value>
   </data>
   <data name="OnlyOneAllowedErrorMsg" xml:space="preserve">
-    <value>only one '{0}' allowed</value>
+    <value>only one {0} allowed</value>
   </data>
   <data name="ParameterAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
     <value>invalid syntax, parameter annotations require 3.x</value>
@@ -337,7 +337,7 @@
     <value>file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present.</value>
   </data>
   <data name="VariableIn3dotXErrorMsg" xml:space="preserve">
-    <value>\", variable\" not allowed in 3.x - use \"as variable\" instead.</value>
+    <value>", variable" not allowed in 3.x - use "as variable" instead.</value>
   </data>
   <data name="YieldInsideAsyncErrorMsg" xml:space="preserve">
     <value>'yield' inside async function</value>

--- a/src/Parsing/Impl/Resources.resx
+++ b/src/Parsing/Impl/Resources.resx
@@ -117,20 +117,92 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AsRequiresPython2dot6OrlaterErrorMsg" xml:space="preserve">
+    <value>'as' requires Python 2.6 or later</value>
+  </data>
   <data name="BackslashFStringExpressionErrorMsg" xml:space="preserve">
     <value>f-string expression part cannot include a backslash</value>
+  </data>
+  <data name="BreakOustideLoopErrorMsg" xml:space="preserve">
+    <value>'break' outside loop</value>
+  </data>
+  <data name="CantUseStarredExpErrorMsg" xml:space="preserve">
+    <value>can't use starred expression here</value>
+  </data>
+  <data name="ClassDecoratorsRequire2dot6ErrorMsg" xml:space="preserve">
+    <value>invalid syntax, class decorators require 2.6 or later.</value>
   </data>
   <data name="ClosingParensNotMatchFStringErrorMsg" xml:space="preserve">
     <value>f-string: closing parenthesis '{0}' does not match opening parenthesis '{1}'</value>
   </data>
+  <data name="ContinueNotInLoopErrorMsg" xml:space="preserve">
+    <value>'continue' not properly in loop</value>
+  </data>
+  <data name="ContinueNotSupportedInsideFinallyErrorMsg" xml:space="preserve">
+    <value>'continue' not supported inside 'finally' clause</value>
+  </data>
+  <data name="DefaultExceptMustBeLastErrorMsg" xml:space="preserve">
+    <value>default 'except' must be last</value>
+  </data>
+  <data name="DefaultValueMustBeSpecifiedErrorMsg" xml:space="preserve">
+    <value>default value must be specified here</value>
+  </data>
+  <data name="DuplicateArgsArgumentErrorMsg" xml:space="preserve">
+    <value>duplicate '{0}' args arguments</value>
+  </data>
+  <data name="DuplicateArgumentInFunctionDefinitionErrorMsg" xml:space="preserve">
+    <value>duplicate argument '{0}' in function definition</value>
+  </data>
+  <data name="DuplicateArgumentInFunctionErrorMsg" xml:space="preserve">
+    <value>duplicate argument '{0}' in function definition</value>
+  </data>
+  <data name="DuplicateKeywordArgumentErrorMsg" xml:space="preserve">
+    <value>duplicate keyword argument</value>
+  </data>
   <data name="EmptyExpressionFStringErrorMsg" xml:space="preserve">
     <value>f-string: empty expression not allowed</value>
+  </data>
+  <data name="ExpectedCharacterErrorMsg" xml:space="preserve">
+    <value>expected ''{0}''</value>
+  </data>
+  <data name="ExpectedExpressionAfterDelErrorMsg" xml:space="preserve">
+    <value>expected expression after del</value>
+  </data>
+  <data name="ExpectedExpressionToBePrintedErrorMsg" xml:space="preserve">
+    <value>print statement expected expression to be printed</value>
+  </data>
+  <data name="ExpectedIndentedBlockErrorMsg" xml:space="preserve">
+    <value>expected an indented block</value>
+  </data>
+  <data name="ExpectedNameErrorMsg" xml:space="preserve">
+    <value>expected name</value>
   </data>
   <data name="ExpectingCharButFoundFStringErrorMsg" xml:space="preserve">
     <value>f-string: expecting '{0}' but found '{1}'</value>
   </data>
   <data name="ExpectingCharFStringErrorMsg" xml:space="preserve">
     <value>f-string: expecting '{0}'</value>
+  </data>
+  <data name="FromCauseNotAllowedIn2XErrorMsg" xml:space="preserve">
+    <value>invalid syntax, from cause not allowed in 2.x.</value>
+  </data>
+  <data name="FutureFeatureNotDefinedErrorMsg" xml:space="preserve">
+    <value>future feature is not defined: </value>
+  </data>
+  <data name="FutureImportsMustOccorAtBeginningOfFileErrorMsg" xml:space="preserve">
+    <value>from __future__ imports must occur at the beginning of the file</value>
+  </data>
+  <data name="FutureStatementDoesNotSupportImportErrorMsg" xml:space="preserve">
+    <value>future statement does not support import *</value>
+  </data>
+  <data name="IllegalTargetAnnotationErrorMsg" xml:space="preserve">
+    <value>illegal target for annotation</value>
+  </data>
+  <data name="ImportOnlyAllowedAtModuleErrorMsg" xml:space="preserve">
+    <value>import * only allowed at module level</value>
+  </data>
+  <data name="IncorrectStartLocationErrorMsg" xml:space="preserve">
+    <value>Start location was not set correctly</value>
   </data>
   <data name="InvalidConversionCharacterExpectedFStringErrorMsg" xml:space="preserve">
     <value>f-string: invalid conversion character: {0} expected 's', 'r', or 'a'</value>
@@ -141,14 +213,41 @@
   <data name="InvalidExpressionFStringErrorMsg" xml:space="preserve">
     <value>f-string: invalid expression</value>
   </data>
+  <data name="InvalidParameterErrorMsg" xml:space="preserve">
+    <value>invalid parameter</value>
+  </data>
+  <data name="InvalidSublistParameterErrorMsg" xml:space="preserve">
+    <value>invalid sublist parameter</value>
+  </data>
+  <data name="InvalidSyntaxAllowedInVersion3XErrorMsg" xml:space="preserve">
+    <value>invalid syntax, only exception value is allowed in 3.x.</value>
+  </data>
   <data name="InvalidSyntaxErrorMsg" xml:space="preserve">
     <value>invalid syntax</value>
+  </data>
+  <data name="IterableArgumentFollowsKeywordArgumentErrorMsg" xml:space="preserve">
+    <value>iterable argument unpacking follows keyword argument unpacking</value>
+  </data>
+  <data name="IterableUnpackingErrorMsg" xml:space="preserve">
+    <value>iterable unpacking cannot be used in comprehension</value>
+  </data>
+  <data name="KeywordsMustComeBeforeArgsErrorMsg" xml:space="preserve">
+    <value>keywords must come before ** args</value>
   </data>
   <data name="LambdaParenthesesFstringErrorMsg" xml:space="preserve">
     <value>f-string: lambda must be inside parentheses</value>
   </data>
+  <data name="MisplacedYieldErrorMsg" xml:space="preserve">
+    <value>misplaced yield</value>
+  </data>
+  <data name="MissingModuleNameErrorMsg" xml:space="preserve">
+    <value>missing module name</value>
+  </data>
   <data name="MixingBytesAndNonBytesErrorMsg" xml:space="preserve">
     <value>cannot mix bytes and nonbytes literals</value>
+  </data>
+  <data name="NamedArgumentsMustFollowBareErrorMsg" xml:space="preserve">
+    <value>named arguments must follow bare *</value>
   </data>
   <data name="NamedAssignmentWithErrorMsg" xml:space="preserve">
     <value>Cannot use named assignment with {0}</value>
@@ -156,13 +255,91 @@
   <data name="NamedExpressionCtxtErrorMsg" xml:space="preserve">
     <value>Named expression must be parenthesized in this context</value>
   </data>
+  <data name="NonKeywordArgAfterKeywordArgErrorMsg" xml:space="preserve">
+    <value>non-keyword arg after keyword arg</value>
+  </data>
+  <data name="NonLocalDeclarationAtModuleErrorMsg" xml:space="preserve">
+    <value>nonlocal declaration not allowed at module level</value>
+  </data>
+  <data name="NotAChanceErrorMsg" xml:space="preserve">
+    <value>not a chance</value>
+  </data>
   <data name="NumberSignFStringExpressionErrorMsg" xml:space="preserve">
     <value>f-string expression part cannot include '#'</value>
+  </data>
+  <data name="OnlyOneAllowedErrorMsg" xml:space="preserve">
+    <value>only one '{0}' allowed</value>
+  </data>
+  <data name="ParameterAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
+    <value>invalid syntax, parameter annotations require 3.x</value>
+  </data>
+  <data name="ParsingAlreadyStartedErrorMsg" xml:space="preserve">
+    <value>Parsing already started. Use Restart to start again.</value>
+  </data>
+  <data name="PositionalArgumentKeywardArgumentErrorMsg" xml:space="preserve">
+    <value>positional argument follows keyword argument</value>
+  </data>
+  <data name="PositionalArgumentKeywardArgumentUnpackingErrorMsg" xml:space="preserve">
+    <value>positional argument follows keyword argument unpacking</value>
+  </data>
+  <data name="PositionalParameterNotAllowedErrorMsg" xml:space="preserve">
+    <value>positional parameter after * args not allowed</value>
+  </data>
+  <data name="ReturnAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
+    <value>invalid syntax, return annotations require 3.x</value>
+  </data>
+  <data name="ReturnOutsideFunctionErrorMsg" xml:space="preserve">
+    <value>'return' outside function</value>
+  </data>
+  <data name="ReturnWithArgumentInGeneratorErrorMsg" xml:space="preserve">
+    <value>'return' with argument inside generator</value>
+  </data>
+  <data name="SetLiteralsRequirePython2dot7ErrorMsg" xml:space="preserve">
+    <value>invalid syntax, set literals require Python 2.7 or later.</value>
   </data>
   <data name="SingleClosedBraceFStringErrorMsg" xml:space="preserve">
     <value>f-string: single '}' is not allowed</value>
   </data>
+  <data name="SingleTargetCanBeAnnotatedErrorMsg" xml:space="preserve">
+    <value>only single target (not tuple) can be annotated</value>
+  </data>
+  <data name="SublistParametersNotSupported3dotXErrorMsg" xml:space="preserve">
+    <value>sublist parameters are not supported in 3.x</value>
+  </data>
+  <data name="SyntaxErrorMsg" xml:space="preserve">
+    <value>syntax error</value>
+  </data>
+  <data name="TwoStarredExpressionErrorMsg" xml:space="preserve">
+    <value>two starred expressions in assignment</value>
+  </data>
+  <data name="UnexpectedEndOfFileErrorMsg" xml:space="preserve">
+    <value>unexpected end of file</value>
+  </data>
+  <data name="UnexpectedEndOfFileWhileParsingErrorMsg" xml:space="preserve">
+    <value>unexpected EOF while parsing</value>
+  </data>
+  <data name="UnexpectedIndentErrorMsg" xml:space="preserve">
+    <value>unexpected indent</value>
+  </data>
+  <data name="UnexpectedTokenErrorMsg" xml:space="preserve">
+    <value>unexpected token '{0}'</value>
+  </data>
+  <data name="UnhandledStringTokenErrorMsg" xml:space="preserve">
+    <value>Unhandled string token</value>
+  </data>
+  <data name="UnknownEncodingErrorMsg" xml:space="preserve">
+    <value>encoding problem: unknown encoding (line {0})</value>
+  </data>
   <data name="UnmatchedFStringErrorMsg" xml:space="preserve">
     <value>f-string: unmatched '{0}'</value>
+  </data>
+  <data name="Utf8EncodingErrorMsg" xml:space="preserve">
+    <value>file has both Unicode marker and PEP-263 file encoding.  You must use \"utf-8\" as the encoding name when a BOM is present.</value>
+  </data>
+  <data name="VariableIn3dotXErrorMsg" xml:space="preserve">
+    <value>\", variable\" not allowed in 3.x - use \"as variable\" instead.</value>
+  </data>
+  <data name="YieldInsideAsyncErrorMsg" xml:space="preserve">
+    <value>'yield' inside async function</value>
   </data>
 </root>

--- a/src/Parsing/Impl/Resources.resx
+++ b/src/Parsing/Impl/Resources.resx
@@ -147,8 +147,11 @@
   <data name="DefaultValueMustBeSpecifiedErrorMsg" xml:space="preserve">
     <value>default value must be specified here</value>
   </data>
-  <data name="DuplicateArgsArgumentErrorMsg" xml:space="preserve">
-    <value>duplicate {0} args arguments</value>
+  <data name="DuplicateArgsDoubleArgumentErrorMsg" xml:space="preserve">
+    <value>duplicate ** args arguments</value>
+  </data>
+  <data name="DuplicateArgsSingleArgumentErrorMsg" xml:space="preserve">
+    <value>duplicate * args arguments</value>
   </data>
   <data name="DuplicateArgumentInFunctionDefinitionErrorMsg" xml:space="preserve">
     <value>duplicate argument '{0}' in function definition</value>
@@ -162,8 +165,8 @@
   <data name="EmptyExpressionFStringErrorMsg" xml:space="preserve">
     <value>f-string: empty expression not allowed</value>
   </data>
-  <data name="ExpectedCharacterErrorMsg" xml:space="preserve">
-    <value>expected '{0}'</value>
+  <data name="ExpectedColonErrorMsg" xml:space="preserve">
+    <value>expected ':'</value>
   </data>
   <data name="ExpectedExpressionAfterDelErrorMsg" xml:space="preserve">
     <value>expected expression after del</value>
@@ -267,8 +270,11 @@
   <data name="NumberSignFStringExpressionErrorMsg" xml:space="preserve">
     <value>f-string expression part cannot include '#'</value>
   </data>
-  <data name="OnlyOneAllowedErrorMsg" xml:space="preserve">
-    <value>only one {0} allowed</value>
+  <data name="OnlyOneAllowedDoubleErrorMsg" xml:space="preserve">
+    <value>only one ** allowed</value>
+  </data>
+  <data name="OnlyOneAllowedSingleErrorMsg" xml:space="preserve">
+    <value>only one * allowed</value>
   </data>
   <data name="ParameterAnnotationsRequire3dotXErrorMsg" xml:space="preserve">
     <value>invalid syntax, parameter annotations require 3.x</value>


### PR DESCRIPTION
Moved hard-coded error messages from Parser.cs to Resources.resx. Ran unit tests from 'Microsoft.Pythong.Parsing.Tests.ParserTests', all tests passed except for 'Microsoft.Pythong.Parsing.Tests.ParserTests.Errors.' Noted failed test <a href="https://github.com/microsoft/python-language-server/issues/647#issuecomment-497893526">here</a>. Believe test failure existed prior to my changes, reverted failing code to original state, test still failed.