### PR TITLE
Allow exporting of instances from modules and prefer real types to Any

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -150,9 +150,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Add members from this file
             var members = Eval.CurrentScope.Variables.Where(v => v.Source == VariableSource.Declaration || v.Source == VariableSource.Import);
             _class.AddMembers(members, false);
-            // Add members from stub
-            var stubClass = Eval.Module.Stub?.GetMember<IPythonClassType>(_class.Name);
-            _class.AddMembers(stubClass, false);
         }
 
         // Classes and functions are walked by their respective evaluators

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Python.Analysis.Modules {
                         return true;
                     }
                     var valueType = v.Value?.GetPythonType();
-                    if (valueType is IPythonModule) {
+                    if (valueType is PythonModule) {
                         return false; // Do not re-export modules.
                     }
                     // Do not re-export types from typing

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -153,8 +153,18 @@ namespace Microsoft.Python.Analysis.Modules {
         public virtual IEnumerable<string> GetMemberNames() {
             // drop imported modules and typing.
             return Analysis.GlobalScope.Variables
-                .Where(v => !(v.Value?.GetPythonType() is PythonModule)
-                            && !(v.Value?.GetPythonType().DeclaringModule is TypingModule && !(this is TypingModule)))
+                .Where(v => {
+                    // Instances are always fine.
+                    if (v.Value is IPythonInstance) {
+                        return true;
+                    }
+                    var valueType = v.Value?.GetPythonType();
+                    if (valueType is IPythonModule) {
+                        return false; // Do not re-export modules.
+                    }
+                    // Do not re-export types from typing
+                    return !(valueType?.DeclaringModule is TypingModule) || this is TypingModule;
+                })
                 .Select(v => v.Name);
         }
         #endregion

--- a/src/Analysis/Ast/Test/ImportTests.cs
+++ b/src/Analysis/Ast/Test/ImportTests.cs
@@ -222,5 +222,14 @@ x = f()
             analysis.Diagnostics.Should().BeEmpty();
             analysis.Should().HaveFunction("print");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task PreferTypeToAny() {
+            var analysis = await GetAnalysisAsync(@"from TypingConstants import *", PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("ONE").Which.Should().HaveType("Any");
+            analysis.Should().HaveVariable("TWO").Which.Should().HaveType(BuiltinTypeId.Str);
+            var a = analysis.Should().HaveClass("A").Which;
+            a.GetMember("x").Should().HaveType(BuiltinTypeId.Int);
+        }
     }
 }

--- a/src/UnitTests/TestData/AstAnalysis/TypingConstants.py
+++ b/src/UnitTests/TestData/AstAnalysis/TypingConstants.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+ONE = ...  # type: Any
+TWO = 'a'
+
+class A:
+    x = 1
+

--- a/src/UnitTests/TestData/AstAnalysis/TypingConstants.pyi
+++ b/src/UnitTests/TestData/AstAnalysis/TypingConstants.pyi
@@ -1,0 +1,7 @@
+from typing import Any
+
+ONE = ...  # type: Any
+TWO = ...  # type: Any
+
+class A:
+    x: Any


### PR DESCRIPTION
Fixes #998 

The problem were
- Module member filtering code did not allow export of instances.
- `tkinter` stub prototypes members as `Any` while we actually have better typing from the library (`str`).

Changes
- allow instance export while still restricting re-exporting `typing` members.
- Prefer specific type we discovered in library to `Any`.