### PR TITLE
Completion presentation for private variables

### DIFF
--- a/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
@@ -17,22 +17,47 @@ using System.Linq;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Specializations.Typing;
 using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Core;
 
 namespace Microsoft.Python.Analysis {
     public static class PythonClassExtensions {
-        public static bool IsGeneric(this IPythonClassType cls) 
+        public static bool IsGeneric(this IPythonClassType cls)
             => cls.Bases != null && cls.Bases.Any(b => b is IGenericType || b is IGenericClassParameter);
 
         public static void AddMemberReference(this IPythonType type, string name, IExpressionEvaluator eval, Location location) {
             var m = type.GetMember(name);
             if (m is LocatedMember lm) {
                 lm.AddReference(location);
-            } else if(type is IPythonClassType cls) {
+            } else if (type is IPythonClassType cls) {
                 using (eval.OpenScope(cls)) {
                     eval.LookupNameInScopes(name, out _, out var v, LookupOptions.Local);
                     v?.AddReference(location);
                 }
             }
+        }
+
+        /// <summary>
+        /// Converts mangled name of a private member to its original form,
+        /// by removing private prefix, such as '_ClassName__x' to '__x'.
+        /// </summary>
+        public static string UnmangleMemberName(this IPythonClassType cls, string memberName) {
+            if (memberName.Length == 0 || (memberName.Length > 0 && memberName[0] != '_')) {
+                return memberName;
+            }
+
+            var prefix = $"_{cls.Name}__";
+            return memberName.StartsWithOrdinal(prefix)
+                ? memberName.Substring(cls.Name.Length + 1)
+                : memberName;
+        }
+
+        /// <summary>
+        /// Determines if particular member is private by checking its name to mangled form
+        /// of Python class private members, such as '_ClassName__memberName'.
+        /// </summary>
+        public static bool IsPrivateMember(this IPythonClassType cls, string memberName) {
+            var unmangledName = cls.UnmangleMemberName(memberName);
+            return unmangledName.StartsWithOrdinal("__") && memberName.EqualsOrdinal($"_{cls.Name}{unmangledName}");
         }
     }
 }

--- a/src/LanguageServer/Impl/Completion/CompletionSource.cs
+++ b/src/LanguageServer/Impl/Completion/CompletionSource.cs
@@ -16,6 +16,7 @@
 using System.Linq;
 using Microsoft.Python.Analysis;
 using Microsoft.Python.Analysis.Analyzer.Expressions;
+using Microsoft.Python.Core;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Ast;
@@ -88,7 +89,7 @@ namespace Microsoft.Python.LanguageServer.Completion {
                             return CompletionResult.Empty;
                         }
                         return result == CompletionResult.Empty ? TopLevelCompletion.GetCompletions(statement, scope, context) : result;
-                }
+                    }
             }
         }
     }

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -1150,5 +1150,27 @@ a";
             var result = cs.GetCompletions(analysis, new SourceLocation(4, 2));
             result.Completions.Select(c => c.label).Should().NotContain("aaa");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task PrivateMembers() {
+            const string code = @"
+class A:
+    def __init__(self):
+        self.__x = 123
+
+    def func(self):
+        self.
+
+A().
+";
+            var analysis = await GetAnalysisAsync(code);
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
+
+            var result = cs.GetCompletions(analysis, new SourceLocation(7, 14));
+            result.Completions.Select(c => c.label).Should().Contain("__x").And.NotContain("_A__x");
+
+            result = cs.GetCompletions(analysis, new SourceLocation(9, 5));
+            result.Completions.Select(c => c.label).Should().NotContain("_A__x").And.NotContain("__x");
+        }
     }
 }


### PR DESCRIPTION
Fixes #1154

- Unmangle name when completing on `self` in the class context.
- Hide mangled private members when completing outside of the class on the instance.