### PR TITLE
Prefer type from parameter annotation to the type of default value

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             for (var i = skip; i < FunctionDefinition.Parameters.Length; i++) {
                 var p = FunctionDefinition.Parameters[i];
                 if (!string.IsNullOrEmpty(p.Name)) {
-                    var paramType = Eval.GetTypeFromAnnotation(p.Annotation, out var isGeneric);
+                    var paramType = Eval.GetTypeFromAnnotation(p.Annotation);
                     if (paramType.IsUnknown() && p.DefaultValue != null) {
                         defaultValue = Eval.GetValueFromExpression(p.DefaultValue);
                         // If parameter has default value, look for the annotation locally first

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -155,11 +155,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Declare parameters in scope
             IMember defaultValue = null;
             for (var i = skip; i < FunctionDefinition.Parameters.Length; i++) {
-                var isGeneric = false;
                 var p = FunctionDefinition.Parameters[i];
                 if (!string.IsNullOrEmpty(p.Name)) {
-                    IPythonType paramType = null;
-                    if (p.DefaultValue != null) {
+                    var paramType = Eval.GetTypeFromAnnotation(p.Annotation, out var isGeneric);
+                    if (paramType.IsUnknown() && p.DefaultValue != null) {
                         defaultValue = Eval.GetValueFromExpression(p.DefaultValue);
                         // If parameter has default value, look for the annotation locally first
                         // since outer type may be getting redefined. Consider 's = None; def f(s: s = 123): ...
@@ -171,7 +170,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                         }
                     }
                     // If all else fails, look up globally.
-                    paramType = paramType ?? Eval.GetTypeFromAnnotation(p.Annotation, out isGeneric) ?? Eval.UnknownType;
+                    paramType = paramType ?? Eval.UnknownType;
                     var pi = new ParameterInfo(Ast, p, paramType, defaultValue, isGeneric);
                     if (declareVariables) {
                         DeclareParameter(p, pi);

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
         private IPythonType TryDetermineReturnValue() {
             var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation);
-            if (annotationType.IsUnknown() || annotationType.IsTypingType("Any")) {
+            if (!annotationType.IsUnknown() && !annotationType.IsTypingType("Any")) {
                 // Annotations are typically types while actually functions return
                 // instances unless specifically annotated to a type such as Type[T].
                 var instance = annotationType.CreateInstance(annotationType.Name, ArgumentSet.Empty);

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -51,32 +51,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                        || Module.ModuleType == ModuleType.Specialized;
 
             using (Eval.OpenScope(_function.DeclaringModule, FunctionDefinition, out _)) {
-                // Process annotations.
-                var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation);
-                if (!annotationType.IsUnknown()) {
-                    // Annotations are typically types while actually functions return
-                    // instances unless specifically annotated to a type such as Type[T].
-                    var instance = annotationType.CreateInstance(annotationType.Name, ArgumentSet.Empty);
-                    _overload.SetReturnValue(instance, true);
-                } else {
-                    // Check if function is a generator
-                    var suite = FunctionDefinition.Body as SuiteStatement;
-                    var yieldExpr = suite?.Statements.OfType<ExpressionStatement>().Select(s => s.Expression as YieldExpression).ExcludeDefault().FirstOrDefault();
-                    if (yieldExpr != null) {
-                        // Function return is an iterator
-                        var yieldValue = Eval.GetValueFromExpression(yieldExpr.Expression) ?? Eval.UnknownType;
-                        var returnValue = new PythonGenerator(Eval.Interpreter, yieldValue);
-                        _overload.SetReturnValue(returnValue, true);
-                    }
-                }
-
+                var returnType = TryDetermineReturnValue();
                 DeclareParameters(!stub);
 
                 // Do process body of constructors since they may be declaring
                 // variables that are later used to determine return type of other
                 // methods and properties.
                 var ctor = _function.Name.EqualsOrdinal("__init__") || _function.Name.EqualsOrdinal("__new__");
-                if (ctor || annotationType.IsUnknown() || Module.ModuleType == ModuleType.User) {
+                if (ctor || returnType.IsUnknown() || Module.ModuleType == ModuleType.User) {
                     // Return type from the annotation is sufficient for libraries and stubs, no need to walk the body.
                     FunctionDefinition.Body?.Walk(this);
                     // For libraries remove declared local function variables to free up some memory.
@@ -124,6 +106,27 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 Eval.DeclareVariable(node.NameExpression.Name, m, VariableSource.Declaration, node.NameExpression);
             }
             return false;
+        }
+
+        private IPythonType TryDetermineReturnValue() {
+            var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation);
+            if (annotationType.IsUnknown() || annotationType.IsTypingType("Any")) {
+                // Annotations are typically types while actually functions return
+                // instances unless specifically annotated to a type such as Type[T].
+                var instance = annotationType.CreateInstance(annotationType.Name, ArgumentSet.Empty);
+                _overload.SetReturnValue(instance, true);
+            } else {
+                // Check if function is a generator
+                var suite = FunctionDefinition.Body as SuiteStatement;
+                var yieldExpr = suite?.Statements.OfType<ExpressionStatement>().Select(s => s.Expression as YieldExpression).ExcludeDefault().FirstOrDefault();
+                if (yieldExpr != null) {
+                    // Function return is an iterator
+                    var yieldValue = Eval.GetValueFromExpression(yieldExpr.Expression) ?? Eval.UnknownType;
+                    var returnValue = new PythonGenerator(Eval.Interpreter, yieldValue);
+                    _overload.SetReturnValue(returnValue, true);
+                }
+            }
+            return annotationType;
         }
 
         private void DeclareParameters(bool declareVariables) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
         private IPythonType TryDetermineReturnValue() {
             var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation);
-            if (!annotationType.IsUnknown() && !annotationType.IsTypingType("Any")) {
+            if (!annotationType.IsUnknown()) {
                 // Annotations are typically types while actually functions return
                 // instances unless specifically annotated to a type such as Type[T].
                 var instance = annotationType.CreateInstance(annotationType.Name, ArgumentSet.Empty);

--- a/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
@@ -40,8 +40,5 @@ namespace Microsoft.Python.Analysis {
 
         public static bool IsConstructor(this IPythonClassMember m)
             => m.Name.EqualsOrdinal("__init__") ||  m.Name.EqualsOrdinal("__new__");
-
-        public static bool IsTypingType(this IPythonType t) => t.DeclaringModule is TypingModule;
-        public static bool IsTypingType(this IPythonType t, string typeName) => t.IsTypingType() && t.Name.EqualsOrdinal(typeName);
     }
 }

--- a/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonTypeExtensions.cs
@@ -40,5 +40,8 @@ namespace Microsoft.Python.Analysis {
 
         public static bool IsConstructor(this IPythonClassMember m)
             => m.Name.EqualsOrdinal("__init__") ||  m.Name.EqualsOrdinal("__new__");
+
+        public static bool IsTypingType(this IPythonType t) => t.DeclaringModule is TypingModule;
+        public static bool IsTypingType(this IPythonType t, string typeName) => t.IsTypingType() && t.Name.EqualsOrdinal(typeName);
     }
 }

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -609,5 +609,20 @@ x = test()
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             analysis.Should().HaveVariable("x").OfType("Foo");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task AnnotatedParameterPriority() {
+            const string code = @"
+def func() -> int:
+    return 123
+
+def test(foo: float = func()):
+    return foo
+
+x = test()
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Float);
+        }
     }
 }

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -13,7 +13,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -588,6 +587,27 @@ class B:
             analysis.Should().NotHaveVariable("A");
             analysis.Should().NotHaveVariable("func");
             analysis.Should().HaveVariable("B").Which.Should().NotHaveMember("b");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task AnyReturnType() {
+            const string code = @"
+from typing import Any
+
+class Foo:
+    def __init__(self, name: str):
+        self.name = name
+
+def func() -> Any:
+    return Foo
+
+def test(foo: Foo = func()):
+    return foo
+
+x = test()
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x").OfType("Foo");
         }
     }
 }

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -590,15 +590,13 @@ class B:
         }
 
         [TestMethod, Priority(0)]
-        public async Task AnyReturnType() {
+        public async Task AnnotatedParameterPriority() {
             const string code = @"
-from typing import Any
-
 class Foo:
     def __init__(self, name: str):
         self.name = name
 
-def func() -> Any:
+def func() -> int:
     return Foo
 
 def test(foo: Foo = func()):
@@ -608,21 +606,6 @@ x = test()
 ";
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             analysis.Should().HaveVariable("x").OfType("Foo");
-        }
-
-        [TestMethod, Priority(0)]
-        public async Task AnnotatedParameterPriority() {
-            const string code = @"
-def func() -> int:
-    return 123
-
-def test(foo: float = func()):
-    return foo
-
-x = test()
-";
-            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
-            analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Float);
         }
     }
 }

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -1152,7 +1152,7 @@ a";
         }
 
         [TestMethod, Priority(0)]
-        public async Task ParameterDefaultAny() {
+        public async Task ParameterAnnotatedDefault() {
             const string code = @"
 from typing import Any
 
@@ -1162,28 +1162,6 @@ class Foo:
         self.name = name
 
 def func() -> Any:
-    return Foo
-
-def test(x = func()):
-    x.
-";
-            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
-            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
-            var comps = cs.GetCompletions(analysis, new SourceLocation(13, 7));
-            comps.Should().HaveLabels("name", "z");
-        }
-
-        [TestMethod, Priority(0)]
-        public async Task ParameterAnnotatedDefaultAny() {
-            const string code = @"
-from typing import Any
-
-class Foo:
-    z: int
-    def __init__(self, name: str):
-        self.name = name
-
-def func() -> int:
     return 123
 
 def test(x: Foo = func()):

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -1150,5 +1150,49 @@ a";
             var result = cs.GetCompletions(analysis, new SourceLocation(4, 2));
             result.Completions.Select(c => c.label).Should().NotContain("aaa");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task ParameterDefaultAny() {
+            const string code = @"
+from typing import Any
+
+class Foo:
+    z: int
+    def __init__(self, name: str):
+        self.name = name
+
+def func() -> Any:
+    return Foo
+
+def test(x = func()):
+    x.
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
+            var comps = cs.GetCompletions(analysis, new SourceLocation(13, 7));
+            comps.Should().HaveLabels("name", "z");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ParameterAnnotatedDefaultAny() {
+            const string code = @"
+from typing import Any
+
+class Foo:
+    z: int
+    def __init__(self, name: str):
+        self.name = name
+
+def func() -> int:
+    return 123
+
+def test(x: Foo = func()):
+    x.
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
+            var comps = cs.GetCompletions(analysis, new SourceLocation(13, 7));
+            comps.Should().HaveLabels("name", "z");
+        }
     }
 }


### PR DESCRIPTION
Fixes #1155

Treat `Any` function return as unknown so we will evaluate it with arguments and figure out proper return type.