### PR TITLE
Fix editable installs when using extraPaths/PYTHONPATH

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -9,15 +9,10 @@ in [Filing an issue](#filing-an-issue).
 
 There are a few known issues in the current version of the language server:
 
-- Import statement handling may be too strict, leading to "unresolved import" messages and the lack of analysis.
-    - The language server considers the workspace root to be the root of user code imports. For the most part, this can be modified by adding additional folders to the `python.autoComplete.extraPaths` setting, for example, `"python.autoComplete.extraPaths": ["./src"]`, if `src` contains the user code. A `.env` file with `PYTHONPATH` set may also help.
-    - Editable installs (`pip install -e` or `setup.py develop`) are known not to work with `extraPaths` when the package is installed. (#1139, #1013, #1137, #989, others).
 - Not all `__all__` statements can be handled.
     - Some modules may have an incorrect list of exported names.
     See [#620](https://github.com/Microsoft/python-language-server/issues/620),
     [#619](https://github.com/Microsoft/python-language-server/issues/619).
-- Persistent issues with high memory consumption for users. 
-    - In some contexts, users are experiencing higher than average amounts of memory being consumed. See [#832](https://github.com/Microsoft/python-language-server/issues/832).
 
 
 ## Requirements
@@ -37,6 +32,47 @@ but may require outside libraries such as OpenSSL 1.0 or `libicu` on Linux.
 
 
 ## Common questions and issues
+
+### Unresolved import warnings
+
+If you're getting a warning about an unresolved import, first ensure that the
+package is installed into your environment if it is a library (`pip`, `pipenv`, etc).
+If the warning is about importing _your own_ code (and not a library), continue reading.
+
+The language server treats the workspace root (i.e. folder you have opened) as
+the main root of user module imports. This means that if your imports are not relative
+to this path, the language server will not be able to find them. This is common
+for users who have a `src` directory which contains their code, a directory for
+an installable package, etc.
+
+These extra roots must be specified to the language server. The easiest way to
+do this (with the VS Code Python extension) is to create a workspace configuration
+which sets `python.autoComplete.extraPaths`. For example, if a project uses a
+`src` directory, then create a file `.vscode/settings.json` in the workspace
+with the contents:
+
+
+```json
+{
+    "python.autoComplete.extraPaths": ["./src"]
+}
+```
+
+This list can be extended to other paths within the workspace (or even with
+code outside the workspace in more complicated setups). Relative paths will
+be taken as relative to the workspace root.
+
+This list may also be configured using the `PYTHONPATH` environment variable,
+either set directly, or via a `.env` file in the workspace root (if using the
+Python extension):
+
+```
+PYTHONPATH=./src
+```
+
+For more examples, see issues:
+[#1085](https://github.com/microsoft/python-language-server/issues/1085#issuecomment-492919382),
+[#1169](https://github.com/microsoft/python-language-server/issues/1169#issuecomment-499998928)
 
 ### "Server initialization failed"
 

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -213,12 +213,23 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
             InterpreterPaths = await GetSearchPathsAsync(cancellationToken);
 
-            var userSearchPaths = _interpreter.Configuration.SearchPaths.Except(InterpreterPaths, StringExtensions.PathsStringComparer);
+            IEnumerable<string> userSearchPaths = Configuration.SearchPaths;
+            InterpreterPaths = InterpreterPaths.Except(userSearchPaths, StringExtensions.PathsStringComparer);
 
             if (Root != null) {
                 var underRoot = userSearchPaths.ToLookup(p => _fs.IsPathUnderRoot(Root, p));
                 userSearchPaths = underRoot[true];
                 InterpreterPaths = underRoot[false].Concat(InterpreterPaths);
+            }
+
+            _log?.Log(TraceEventType.Information, "Interpreter search paths:");
+            foreach (var s in InterpreterPaths) {
+                _log?.Log(TraceEventType.Information, $"    {s}");
+            }
+
+            _log?.Log(TraceEventType.Information, "User search paths:");
+            foreach (var s in userSearchPaths) {
+                _log?.Log(TraceEventType.Information, $"    {s}");
             }
 
             addedRoots.UnionWith(PathResolver.SetInterpreterSearchPaths(InterpreterPaths));

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -71,16 +71,16 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             Debug.Assert(_searchPaths != null, "Should have search paths");
             _searchPaths = _searchPaths ?? Array.Empty<string>();
 
-            _log?.Log(TraceEventType.Information, "Python search paths:");
+            _log?.Log(TraceEventType.Verbose, "Python search paths:");
             foreach (var s in _searchPaths) {
-                _log?.Log(TraceEventType.Information, $"    {s}");
+                _log?.Log(TraceEventType.Verbose, $"    {s}");
             }
 
             var configurationSearchPaths = Configuration.SearchPaths ?? Array.Empty<string>();
 
-            _log?.Log(TraceEventType.Information, "Configuration search paths:");
+            _log?.Log(TraceEventType.Verbose, "Configuration search paths:");
             foreach (var s in configurationSearchPaths) {
-                _log?.Log(TraceEventType.Information, $"    {s}");
+                _log?.Log(TraceEventType.Verbose, $"    {s}");
             }
             return _searchPaths;
         }


### PR DESCRIPTION
Fixes #989.
Fixes #1013.
Closes #1085.
Closes #1099.
Fixes #1118.
Fixes #1137.
Closes #1169.

Updates #537. (The original use case should have both pth and a config file, but supporting `pth` in general needs to be reexamined.)
Updates #814. (Verify with @karthiknadig that this fixes the vendored dirs in ptvsd.)
Updates #918. (Fixes some issues in that thread, but does not add egg support; could be closed in favor of #196.)

Packages installed as editable show up in the "interpreter paths", as the interpreter's setup has been modified to show that package. Before, when we saw an item in both the interpreter and user search paths lists, the interpreter path won.

Now, if the user search paths explicitly list something, then it will first be removed from the interpreter search path (and potentially be re-added if it's found to live outside the workspace). This should mean that the old behavior of treating code outside the workspace as library code will remain the same, but editable installs will now work with extraPaths. Additionally, I've added some logging which will print the "final" search path classification, as printing it early hid the core issue from view.

After this PR, the current way to handle workspaces where the imports are not derived from the workspace root is to explicitly designate which paths are import roots, i.e.:

```json
"python.autoComplete.extraPaths": [
    "./src"
]
```

Or a more complicated:

```json
"python.autoComplete.extraPaths": [
    "./package_a",
    "./package_b",
    "./package_c"
]
```

We should look into creating distinct configuration options that allow us to distinguish this, rather than having to apply a heuristic to `initializationOptions.searchPaths`.

~~Additionally, we should be documenting this `extraPaths` recommendation somewhere.~~ (Done in this PR.) Potentially, add to the VSC extension UI, or a popup if we detect that some import _could_ be fixable with this method.

Solving this issue automatically may not be possible, however in all of the cases documented in #1169, users have opened the directive above their actual import roots; it may be possible to simply iterate through this list of things and add them as roots, but that may produce bad side effects.