### PR TITLE
ArgumentNullException to use nameof in Parser project Issue #228

### DIFF
--- a/src/Parsing/Impl/LiteralParser.cs
+++ b/src/Parsing/Impl/LiteralParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Python.Parsing {
         public static string ParseString(char[] text, int start, int length, bool isRaw, bool isUni, 
             bool normalizeLineEndings, bool allowTrailingBackslash = false) {
             if (text == null) {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             if (isRaw && !isUni && !normalizeLineEndings) {

--- a/src/Parsing/Impl/Parser.cs
+++ b/src/Parsing/Impl/Parser.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Python.Parsing {
 
         public static Parser CreateParser(TextReader reader, PythonLanguageVersion version, ParserOptions parserOptions) {
             if (reader == null) {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(reader));
             }
 
             var options = parserOptions ?? ParserOptions.Default;
@@ -120,7 +120,7 @@ namespace Microsoft.Python.Parsing {
 
         public static Parser CreateParser(Stream stream, PythonLanguageVersion version) {
             if (stream == null) {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
             return CreateParser(stream, version, null);


### PR DESCRIPTION
This pull request updated the literal strings in the "throw new ArgumentNullException" to use thrownameof() instead of string literals.