### PR TITLE
Actually populate buffer when reloading Ast

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Python.Analysis.Modules {
         private PythonAst RecreateAst() {
             lock (AnalysisLock) {
                 ContentState = State.None;
-                LoadContent();
+                LoadContent(null, _buffer.Version);
                 var parser = Parser.CreateParser(new StringReader(_buffer.Text), Interpreter.LanguageVersion, ParserOptions.Default);
                 var ast = parser.ParseFile(Uri);
                 ContentState = State.Parsed;


### PR DESCRIPTION
Fixes #1202.

`LoadContent()` gets the content, but does nothing with it. The other overload is the one with side effects, so call it instead.

There are probably other fixups that could be done in this area (the LibraryAnalysis constructor having side effects and clearing out things it's passed makes things complicated), but this is the minimal change until the double-final-analysis thing is fixed.