### PR TITLE
Do not allow workspace root to be an interpreter/library path

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             InterpreterPaths = await GetSearchPathsAsync(cancellationToken);
 
             IEnumerable<string> userSearchPaths = Configuration.SearchPaths;
-            InterpreterPaths = InterpreterPaths.Except(userSearchPaths, StringExtensions.PathsStringComparer);
+            InterpreterPaths = InterpreterPaths.Except(userSearchPaths, StringExtensions.PathsStringComparer).Where(p => p.PathEquals(Root));
 
             if (Root != null) {
                 var underRoot = userSearchPaths.ToLookup(p => _fs.IsPathUnderRoot(Root, p));

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             InterpreterPaths = await GetSearchPathsAsync(cancellationToken);
 
             IEnumerable<string> userSearchPaths = Configuration.SearchPaths;
-            InterpreterPaths = InterpreterPaths.Except(userSearchPaths, StringExtensions.PathsStringComparer).Where(p => p.PathEquals(Root));
+            InterpreterPaths = InterpreterPaths.Except(userSearchPaths, StringExtensions.PathsStringComparer).Where(p => !p.PathEquals(Root));
 
             if (Root != null) {
                 var underRoot = userSearchPaths.ToLookup(p => _fs.IsPathUnderRoot(Root, p));


### PR DESCRIPTION
Fixes #1175.
Fixes #1209.
Updates #537.

If the workspace root is allowed to be an interpreter path, the analysis hangs. This only happens with editable installs, which modify the interpreter via pth files.