### PR TITLE
Fix arg with null location

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -63,8 +63,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public LocationInfo GetLocationInfo(Node node) => node?.GetLocation(Module) ?? LocationInfo.Empty;
 
         public Location GetLocationOfName(Node node) {
-            node = node ?? throw new ArgumentNullException(nameof(node));
-            if (Module.ModuleType != ModuleType.User && Module.ModuleType != ModuleType.Library) {
+            if (node == null || (Module.ModuleType != ModuleType.User && Module.ModuleType != ModuleType.Library)) {
                 return DefaultLocation;
             }
 


### PR DESCRIPTION
Fixes #1219.

This can happen in some weird layouts. Instead of failing, just take the default location.