### PR TITLE
Lock document content 

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -235,7 +235,14 @@ namespace Microsoft.Python.Analysis.Modules {
         /// <summary>
         /// Returns module content (code).
         /// </summary>
-        public string Content => _buffer.Text;
+        public string Content {
+            get {
+                lock (AnalysisLock) {
+                    return _buffer.Text;
+                }
+            }
+        }
+
         #endregion
 
         #region Parsing


### PR DESCRIPTION
Since it is locked in other cases when we are resetting or reloading.