### PR TITLE
Handle library analysis better

### DIFF
--- a/src/Analysis/Ast/Impl/Values/Scope.cs
+++ b/src/Analysis/Ast/Impl/Values/Scope.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Python.Analysis.Values {
 
         #region IScope
         public string Name => Node?.Name ?? "<global>";
-        public virtual ScopeStatement Node => Module.GetAstNode<ScopeStatement>(this);
+        public virtual ScopeStatement Node => Module.GetAstNode<ScopeStatement>(this) ?? Module.GetAst();
         public IScope OuterScope { get; }
         public IPythonModule Module { get; }
 


### PR DESCRIPTION
Not entirely sure how completions ended up there since they are supposed to be suppressed, but if AST is dropped, scope does can lose its node and then should just use the empty AST.