### PR TITLE
Adding diagnostic error on binary operations with incompatible types

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -25,16 +25,6 @@ using ErrorCodes = Microsoft.Python.Analysis.Diagnostics.ErrorCodes;
 
 namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
     internal sealed partial class ExpressionEval {
-
-        private void ReportOperatorDiagnostics(Expression expr, IPythonType leftType, IPythonType rightType, PythonOperator op) {
-            ReportDiagnostics(Module.Uri, new DiagnosticsEntry(
-                Resources.UnsupporedOperandType.FormatInvariant(op.ToCodeString(), leftType.Name, rightType.Name),
-                GetLocation(expr).Span,
-                ErrorCodes.UnsupportedOperandType,
-                Severity.Error,
-                DiagnosticSource.Analysis));
-        }
-
         private IMember GetValueFromUnaryOp(UnaryExpression expr) {
             switch (expr.Op) {
                 case PythonOperator.Not:
@@ -450,5 +440,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
 
             return (null, null);
         }
+        private void ReportOperatorDiagnostics(Expression expr, IPythonType leftType, IPythonType rightType, PythonOperator op) {
+            ReportDiagnostics(Module.Uri, new DiagnosticsEntry(
+                Resources.UnsupporedOperandType.FormatInvariant(op.ToCodeString(), leftType.Name, rightType.Name),
+                GetLocation(expr).Span,
+                ErrorCodes.UnsupportedOperandType,
+                Severity.Error,
+                DiagnosticSource.Analysis));
+        }
+
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -13,16 +13,28 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
+using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Types.Collections;
 using Microsoft.Python.Analysis.Values;
+using Microsoft.Python.Core;
 using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Ast;
+using ErrorCodes = Microsoft.Python.Analysis.Diagnostics.ErrorCodes;
 
 namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
     internal sealed partial class ExpressionEval {
+
+        private void ReportOperatorDiagnostics(Expression expr, IPythonType leftType, IPythonType rightType, PythonOperator op) {
+            ReportDiagnostics(Module.Uri, new DiagnosticsEntry(
+                Resources.UnsupporedOperandType.FormatInvariant(op.ToCodeString(), leftType.Name, rightType.Name),
+                GetLocation(expr).Span,
+                ErrorCodes.UnsupportedOperandType,
+                Severity.Error,
+                DiagnosticSource.Analysis));
+        }
+
         private IMember GetValueFromUnaryOp(UnaryExpression expr) {
             switch (expr.Op) {
                 case PythonOperator.Not:
@@ -122,6 +134,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
 
             if (leftIsSupported && rightIsSupported) {
                 if (TryGetValueFromBuiltinBinaryOp(op, leftTypeId, rightTypeId, Interpreter.LanguageVersion.Is3x(), out var member)) {
+                    if (member.IsUnknown()) {
+                        ReportOperatorDiagnostics(expr, leftType, rightType, op);
+                    }
                     return member;
                 }
             }

--- a/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
@@ -25,5 +25,6 @@ namespace Microsoft.Python.Analysis.Diagnostics {
         public const string UndefinedVariable = "undefined-variable";
         public const string VariableNotDefinedGlobally= "variable-not-defined-globally";
         public const string VariableNotDefinedNonLocal = "variable-not-defined-nonlocal";
+        public const string UnsupportedOperandType = "unsupported-operand-type";
     }
 }

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unsupported operand type(s) for &apos;{0}&apos;: &apos;{1}&apos; and &apos;{2}&apos;.
+        ///   Looks up a localized string similar to Unsupported operand types for &apos;{0}&apos;: &apos;{1}&apos; and &apos;{2}&apos;.
         /// </summary>
         internal static string UnsupporedOperandType {
             get {

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -275,5 +275,14 @@ namespace Microsoft.Python.Analysis {
                 return ResourceManager.GetString("UndefinedVariable", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported operand type(s) for &apos;{0}&apos;: &apos;{1}&apos; and &apos;{2}&apos;.
+        /// </summary>
+        internal static string UnsupporedOperandType {
+            get {
+                return ResourceManager.GetString("UnsupporedOperandType", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -189,4 +189,7 @@
   <data name="UnableToDetermineCachePathException" xml:space="preserve">
     <value>Unable to determine analysis cache path. Exception: {0}. Using default '{1}'.</value>
   </data>
+  <data name="UnsupporedOperandType" xml:space="preserve">
+    <value>Unsupported operand type(s) for '{0}': '{1}' and '{2}'</value>
+  </data>
 </root>

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -190,6 +190,6 @@
     <value>Unable to determine analysis cache path. Exception: {0}. Using default '{1}'.</value>
   </data>
   <data name="UnsupporedOperandType" xml:space="preserve">
-    <value>Unsupported operand type(s) for '{0}': '{1}' and '{2}'</value>
+    <value>Unsupported operand types for '{0}': '{1}' and '{2}'</value>
   </data>
 </root>

--- a/src/Analysis/Ast/Test/LintOperatorTests.cs
+++ b/src/Analysis/Ast/Test/LintOperatorTests.cs
@@ -1,10 +1,10 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Python.Analysis.Tests.FluentAssertions;
+using Microsoft.Python.Core;
 using Microsoft.Python.Parsing.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Python.Analysis.Tests.FluentAssertions;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Python.Core;
 using TestUtilities;
 
 namespace Microsoft.Python.Analysis.Tests {

--- a/src/Analysis/Ast/Test/LintOperatorTests.cs
+++ b/src/Analysis/Ast/Test/LintOperatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.Python.Parsing.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Python.Analysis.Tests.FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Python.Core;
@@ -29,6 +30,7 @@ a = 5 + 'str'
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 14);
             diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.UnsupportedOperandType);
             diagnostic.Message.Should().Be(Resources.UnsupporedOperandType.FormatInvariant("+", "int", "str"));
         }
@@ -52,6 +54,11 @@ z = {leftType}(x) {op} {rightType}(y)
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
+
+
+            string line = $"z = {leftType}(x) {op} {rightType}(y)";
+            // source span is 1 indexed
+            diagnostic.SourceSpan.Should().Be(5, line.IndexOf(leftType) + 1, 5, line.IndexOf("(y)") + 4);
             diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.UnsupportedOperandType);
             diagnostic.Message.Should().Be(Resources.UnsupporedOperandType.FormatInvariant(op, leftType, rightType));
         }
@@ -72,7 +79,7 @@ z = {leftType}(x) {op} {rightType}(y)
 ";
 
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
-            analysis.Diagnostics.Should().HaveCount(0);
+            analysis.Diagnostics.Should().BeEmpty();
         }
     }
 

--- a/src/Analysis/Ast/Test/LintOperatorTests.cs
+++ b/src/Analysis/Ast/Test/LintOperatorTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Python.Analysis.Tests {
         public void Cleanup() => TestEnvironmentImpl.TestCleanup();
 
         [TestMethod, Priority(0)]
-        public async Task IncompatibleTypesBasic() {
+        public async Task IncompatibleTypesBinaryOpBasic() {
             var code = $@"
 a = 5 + 'str'
 ";
@@ -42,7 +42,7 @@ a = 5 + 'str'
         [DataRow("str", "float", "-")]
         [DataRow("str", "float", "*")]
         [DataTestMethod, Priority(0)]
-        public async Task IncompatibleTypes(string leftType, string rightType, string op) {
+        public async Task IncompatibleTypesBinaryOp(string leftType, string rightType, string op) {
  var code = $@"
 x = 1
 y = 2
@@ -70,7 +70,7 @@ z = {leftType}(x) {op} {rightType}(y)
         [DataRow("complex", "float", "-")]
         [DataRow("str", "int", "*")]
         [DataTestMethod, Priority(0)]
-        public async Task CompatibleTypes(string leftType, string rightType, string op) {
+        public async Task CompatibleTypesBinaryOp(string leftType, string rightType, string op) {
             var code = $@"
 x = 1
 y = 2

--- a/src/Analysis/Ast/Test/LintOperatorTests.cs
+++ b/src/Analysis/Ast/Test/LintOperatorTests.cs
@@ -1,0 +1,60 @@
+﻿using FluentAssertions;
+using Microsoft.Python.Parsing.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using System.Threading.Tasks;
+using TestUtilities;
+
+namespace Microsoft.Python.Analysis.Tests {
+    [TestClass]
+    public class LintOperatorTests : AnalysisTestBase {
+
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod, Priority(0)]
+        public async Task IncompatibleTypesBasic() {
+            var code = $@"
+a = 5 + 'str'
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.UnsupportedOperandType);
+            diagnostic.Message.Should().Be(Resources.UnsupporedOperandType);
+        }
+
+        [DataRow("str", "int", "+")]
+        [DataRow("str", "int", "-")]
+        [DataRow("str", "int", "/")]
+        [DataRow("str", "float", "+")]
+        [DataRow("str", "float", "-")]
+        [DataRow("str", "float", "*")]
+        [DataTestMethod, Priority(0)]
+        public async Task IncompatibleTypes(string leftType, string rightType, string op) {
+ var code = $@"
+x = 1
+y = 2
+
+z = {leftType}(x) {op} {rightType}(y)
+";
+
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.UnsupportedOperandType);
+            diagnostic.Message.Should().Be(Resources.UnsupporedOperandType);
+
+        }
+    }
+
+}


### PR DESCRIPTION
I basically hooked into what Jake is doing; we agreed that it is probably best to only give diagnostic error only on the builtin Python types. I structured the error message to be nearly the same as the Python interpreter's runtime error message, but that is subject to change.

For testing, I feel that a lot of the functionality is related to Jake's parsing of binary operations, so I should rely on the tests for that part of the software to prove the correctness of the diagnostic message instead of trying to recreate new tests that may or may not be duplicates of his. 