### PR TITLE
Rework search path resolution

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
                 var ps = _services.GetService<IProcessServices>();
                 var paths = await PythonLibraryPath.GetSearchPathsAsync(Configuration, fs, ps, cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
-                return paths.MaybeEnumerate().ToArray();
+                return paths.ToArray();
             } catch (InvalidOperationException ex) {
                 _log?.Log(TraceEventType.Warning, "Exception getting search paths", ex);
                 _ui?.ShowMessageAsync(Resources.ExceptionGettingSearchPaths, TraceEventType.Error);

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
     internal sealed class MainModuleResolution : ModuleResolutionBase, IModuleManagement {
         private readonly ConcurrentDictionary<string, IPythonModule> _specialized = new ConcurrentDictionary<string, IPythonModule>();
         private IRunningDocumentTable _rdt;
-        private IReadOnlyList<string> _searchPaths;
 
         public MainModuleResolution(string root, IServiceContainer services)
             : base(root, services) { }
@@ -60,29 +59,6 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
         internal async Task InitializeAsync(CancellationToken cancellationToken = default) {
             await ReloadAsync(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-        }
-
-        public async Task<IReadOnlyList<string>> GetSearchPathsAsync(CancellationToken cancellationToken = default) {
-            if (_searchPaths != null) {
-                return _searchPaths;
-            }
-
-            _searchPaths = await GetInterpreterSearchPathsAsync(cancellationToken);
-            Debug.Assert(_searchPaths != null, "Should have search paths");
-            _searchPaths = _searchPaths ?? Array.Empty<string>();
-
-            _log?.Log(TraceEventType.Verbose, "Python search paths:");
-            foreach (var s in _searchPaths) {
-                _log?.Log(TraceEventType.Verbose, $"    {s}");
-            }
-
-            var configurationSearchPaths = Configuration.SearchPaths ?? Array.Empty<string>();
-
-            _log?.Log(TraceEventType.Verbose, "Configuration search paths:");
-            foreach (var s in configurationSearchPaths) {
-                _log?.Log(TraceEventType.Verbose, $"    {s}");
-            }
-            return _searchPaths;
         }
 
         protected override IPythonModule CreateModule(string name) {
@@ -135,11 +111,11 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             return GetRdt().AddModule(mco);
         }
 
-        private async Task<IReadOnlyList<string>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
+        private async Task<IReadOnlyList<PythonLibraryPath>> GetInterpreterSearchPathsAsync(CancellationToken cancellationToken = default) {
             if (!_fs.FileExists(Configuration.InterpreterPath)) {
                 _log?.Log(TraceEventType.Warning, "Interpreter does not exist:", Configuration.InterpreterPath);
                 _ui?.ShowMessageAsync(Resources.InterpreterNotFound, TraceEventType.Error);
-                return Array.Empty<string>();
+                return Array.Empty<PythonLibraryPath>();
             }
 
             _log?.Log(TraceEventType.Information, "GetCurrentSearchPaths", Configuration.InterpreterPath);
@@ -148,11 +124,11 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
                 var ps = _services.GetService<IProcessServices>();
                 var paths = await PythonLibraryPath.GetSearchPathsAsync(Configuration, fs, ps, cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
-                return paths.MaybeEnumerate().Select(p => p.Path).ToArray();
+                return paths.MaybeEnumerate().ToArray();
             } catch (InvalidOperationException ex) {
                 _log?.Log(TraceEventType.Warning, "Exception getting search paths", ex);
                 _ui?.ShowMessageAsync(Resources.ExceptionGettingSearchPaths, TraceEventType.Error);
-                return Array.Empty<string>();
+                return Array.Empty<PythonLibraryPath>();
             }
         }
 
@@ -211,16 +187,13 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             var addedRoots = new HashSet<string>();
             addedRoots.UnionWith(PathResolver.SetRoot(Root));
 
-            InterpreterPaths = await GetSearchPathsAsync(cancellationToken);
+            var ps = _services.GetService<IProcessServices>();
 
-            IEnumerable<string> userSearchPaths = Configuration.SearchPaths;
-            InterpreterPaths = InterpreterPaths.Except(userSearchPaths, StringExtensions.PathsStringComparer).Where(p => !p.PathEquals(Root));
+            var paths = await GetInterpreterSearchPathsAsync(cancellationToken);
+            var (interpreterPaths, userPaths) = PythonLibraryPath.ClassifyPaths(Root, _fs, paths, Configuration.SearchPaths);
 
-            if (Root != null) {
-                var underRoot = userSearchPaths.ToLookup(p => _fs.IsPathUnderRoot(Root, p));
-                userSearchPaths = underRoot[true];
-                InterpreterPaths = underRoot[false].Concat(InterpreterPaths);
-            }
+            InterpreterPaths = interpreterPaths.Select(p => p.Path);
+            var userSearchPaths = userPaths.Select(p => p.Path);
 
             _log?.Log(TraceEventType.Information, "Interpreter search paths:");
             foreach (var s in InterpreterPaths) {

--- a/src/Analysis/Ast/Impl/get_search_paths.py
+++ b/src/Analysis/Ast/Impl/get_search_paths.py
@@ -45,6 +45,11 @@ def clean(path):
 BEFORE_SITE = set(clean(p) for p in BEFORE_SITE)
 AFTER_SITE = set(clean(p) for p in AFTER_SITE)
 
+try:
+    SITE_PKGS = set(clean(p) for p in site.getsitepackages())
+except AttributeError:
+    SITE_PKGS = set()
+
 for prefix in [
     sys.prefix,
     sys.exec_prefix,
@@ -69,4 +74,7 @@ for p in sys.path:
         if p in BEFORE_SITE:
             print("%s|stdlib|" % p)
         elif p in AFTER_SITE:
-            print("%s||" % p)
+            if p in SITE_PKGS:
+                print("%s|site|" % p)
+            else:
+                print("%s|pth|" % p)

--- a/src/Analysis/Ast/Test/PathClassificationTests.cs
+++ b/src/Analysis/Ast/Test/PathClassificationTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.Python.Analysis.Core.Interpreter;
+using Microsoft.Python.Core.IO;
+using Microsoft.Python.Core.OS;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+
+namespace Microsoft.Python.Analysis.Tests {
+    [TestClass]
+    public class PathClassificationTests {
+        private readonly FileSystem _fs = new FileSystem(new OSPlatform());
+
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod]
+        public void Plain() {
+            var appPath = TestData.GetTestSpecificPath("app.py");
+            var root = Path.GetDirectoryName(appPath);
+
+            var venv = Path.Combine(root, "venv");
+            var venvLib = Path.Combine(venv, "Lib");
+            var venvSitePackages = Path.Combine(venvLib, "site-packages");
+
+            var fromInterpreter = new[] {
+                new PythonLibraryPath(venvLib, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venv, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venvSitePackages, PythonLibraryPathType.Site),
+            };
+
+            var (interpreterPaths, userPaths) = PythonLibraryPath.ClassifyPaths(root, _fs, fromInterpreter, Array.Empty<string>());
+
+            interpreterPaths.Should().BeEquivalentTo(new[] {
+                new PythonLibraryPath(venvLib, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venv, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venvSitePackages, PythonLibraryPathType.Site),
+            });
+
+            userPaths.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void WithSrcDir() {
+            var appPath = TestData.GetTestSpecificPath("app.py");
+            var root = Path.GetDirectoryName(appPath);
+
+            var venv = Path.Combine(root, "venv");
+            var venvLib = Path.Combine(venv, "Lib");
+            var venvSitePackages = Path.Combine(venvLib, "site-packages");
+
+            var src = Path.Combine(root, "src");
+
+            var fromInterpreter = new[] {
+                new PythonLibraryPath(venvLib, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venv, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venvSitePackages, PythonLibraryPathType.Site),
+            };
+
+            var fromUser = new[] {
+                "./src",
+            };
+
+            var (interpreterPaths, userPaths) = PythonLibraryPath.ClassifyPaths(root, _fs, fromInterpreter, fromUser);
+
+            interpreterPaths.Should().BeEquivalentTo(new[] {
+                new PythonLibraryPath(venvLib, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venv, PythonLibraryPathType.StdLib),
+                new PythonLibraryPath(venvSitePackages, PythonLibraryPathType.Site),
+            });
+
+            userPaths.Should().BeEquivalentTo(new[] {
+                new PythonLibraryPath(src, PythonLibraryPathType.Unspecified),
+            });
+        }
+
+        [TestMethod]
+        public void NormalizeUser() {
+            var appPath = TestData.GetTestSpecificPath("app.py");
+            var root = Path.GetDirectoryName(appPath);
+
+            var src = Path.Combine(root, "src");
+
+            var fromUser = new[] {
+                "./src/",
+            };
+
+            var (interpreterPaths, userPaths) = PythonLibraryPath.ClassifyPaths(root, _fs, Array.Empty<PythonLibraryPath>(), fromUser);
+
+            interpreterPaths.Should().BeEmpty();
+
+            userPaths.Should().BeEquivalentTo(new[] {
+                new PythonLibraryPath(src, PythonLibraryPathType.Unspecified),
+            });
+        }
+
+        [TestMethod]
+        public void NestedUser() {
+            var appPath = TestData.GetTestSpecificPath("app.py");
+            var root = Path.GetDirectoryName(appPath);
+
+            var src = Path.Combine(root, "src");
+            var srcSomething = Path.Combine(src, "something");
+            var srcFoo = Path.Combine(src, "foo");
+            var srcFooBar = Path.Combine(srcFoo, "bar");
+
+            var fromUser = new[] {
+                "./src",
+                "./src/something",
+                "./src/foo",
+                "./src/foo/bar",
+            };
+
+            var (interpreterPaths, userPaths) = PythonLibraryPath.ClassifyPaths(root, _fs, Array.Empty<PythonLibraryPath>(), fromUser);
+
+            interpreterPaths.Should().BeEmpty();
+
+            userPaths.Should().BeEquivalentTo(new[] {
+                new PythonLibraryPath(srcFooBar, PythonLibraryPathType.Unspecified),
+                new PythonLibraryPath(srcFoo, PythonLibraryPathType.Unspecified),
+                new PythonLibraryPath(srcSomething, PythonLibraryPathType.Unspecified),
+                new PythonLibraryPath(src, PythonLibraryPathType.Unspecified),
+            });
+        }
+    }
+}

--- a/src/Analysis/Ast/Test/PathClassificationTests.cs
+++ b/src/Analysis/Ast/Test/PathClassificationTests.cs
@@ -23,7 +23,6 @@ using Microsoft.Python.Tests.Utilities.FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 
-
 namespace Microsoft.Python.Analysis.Tests {
     [TestClass]
     public class PathClassificationTests {

--- a/src/Analysis/Ast/Test/PathClassificationTests.cs
+++ b/src/Analysis/Ast/Test/PathClassificationTests.cs
@@ -147,6 +147,35 @@ namespace Microsoft.Python.Analysis.Tests {
         }
 
         [TestMethod]
+        public void NestedUserOrdering() {
+            var appPath = TestData.GetTestSpecificPath("app.py");
+            var root = Path.GetDirectoryName(appPath);
+
+            var src = Path.Combine(root, "src");
+            var srcSomething = Path.Combine(src, "something");
+            var srcFoo = Path.Combine(src, "foo");
+            var srcFooBar = Path.Combine(srcFoo, "bar");
+
+            var fromUser = new[] {
+                "./src/foo",
+                "./src/foo/bar",
+                "./src",
+                "./src/something",
+            };
+
+            var (interpreterPaths, userPaths) = PythonLibraryPath.ClassifyPaths(root, _fs, Array.Empty<PythonLibraryPath>(), fromUser);
+
+            interpreterPaths.Should().BeEmpty();
+
+            userPaths.Should().BeEquivalentToWithStrictOrdering(new[] {
+                new PythonLibraryPath(srcFoo, PythonLibraryPathType.Unspecified),
+                new PythonLibraryPath(srcFooBar, PythonLibraryPathType.Unspecified),
+                new PythonLibraryPath(src, PythonLibraryPathType.Unspecified),
+                new PythonLibraryPath(srcSomething, PythonLibraryPathType.Unspecified),
+            });
+        }
+
+        [TestMethod]
         public void InsideStdLib() {
             var appPath = TestData.GetTestSpecificPath("app.py");
             var root = Path.GetDirectoryName(appPath);

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -231,19 +231,16 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
 
             // Remove any interpreter paths specified in the user config so they can be reclassified.
             // The user list is usually small; List.Contains should not be too slow.
-            fromInterpreter = fromInterpreter.Where(p => !fromUserList.Contains(p.Path, PathEqualityComparer.Instance));
-
-            var stdlibLookup = fromInterpreter.ToLookup(p => p.Type == PythonLibraryPathType.StdLib);
+            fromInterpreter.Where(p => !fromUserList.Contains(p.Path, PathEqualityComparer.Instance))
+                .Split(p => p.Type == PythonLibraryPathType.StdLib, out var stdlib, out var withoutStdlib);
 
             // Pull out stdlib paths, and make them always be interpreter paths.
-            var stdlib = stdlibLookup[true].ToList();
             var interpreterPaths = new List<PythonLibraryPath>(stdlib);
-            fromInterpreter = stdlibLookup[false];
 
             var userPaths = new List<PythonLibraryPath>();
 
             var allPaths = fromUserList.Select(p => new PythonLibraryPath(p))
-                .Concat(fromInterpreter.Where(p => !p.Path.PathEquals(root)));
+                .Concat(withoutStdlib.Where(p => !p.Path.PathEquals(root)));
 
             foreach (var p in allPaths) {
                 // If path is within a stdlib path, then treat it as interpreter.

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
             // - All paths in fromInterpreter were normalised and end separator trimmed.
 
             // Clean up user configured paths.
-            // 1) Noramlize paths.
+            // 1) Normalize paths.
             // 2) If a path isn't rooted, then root it relative to the workspace root. If there is no root, just continue.
             // 3) Trim off any ending separators for consistency.
             // 4) Remove any empty paths, FS root paths (bad idea), or paths equal to the root.

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -282,10 +282,18 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
             }
         }
 
-        public bool Equals(PythonLibraryPath other) => Path.PathEquals(other.Path) && Type == other.Type && ModulePrefix == other.ModulePrefix;
+        public bool Equals(PythonLibraryPath other) {
+            if (other is null) {
+                return false;
+            }
 
-        public static bool operator ==(PythonLibraryPath left, PythonLibraryPath right) => left.Equals(right);
+            return Path.PathEquals(other.Path)
+                && Type == other.Type
+                && ModulePrefix == other.ModulePrefix;
+        }
 
-        public static bool operator !=(PythonLibraryPath left, PythonLibraryPath right) => !left.Equals(right);
+        public static bool operator ==(PythonLibraryPath left, PythonLibraryPath right) => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(PythonLibraryPath left, PythonLibraryPath right) => !(left?.Equals(right) ?? right is null);
     }
 }

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
 
     public sealed class PythonLibraryPath : IEquatable<PythonLibraryPath> {
         public PythonLibraryPath(string path, PythonLibraryPathType type = PythonLibraryPathType.Unspecified, string modulePrefix = null) {
-            Path = PathUtils.TrimEndSeparator(PathUtils.NormalizePath(path));
+            Path = PathUtils.NormalizePathAndTrim(path);
             Type = type;
             ModulePrefix = modulePrefix ?? string.Empty;
         }
@@ -210,9 +210,10 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
             IEnumerable<PythonLibraryPath> fromInterpreter,
             IEnumerable<string> fromUser
         ) {
-            // PRECONDITIONS:
-            // - root has already been normalized and had its end separator trimmed.
-            // - All paths in fromInterpreter were normalised and end separator trimmed.
+#if DEBUG
+            Debug.Assert(root == null || root.PathEquals(PathUtils.NormalizePathAndTrim(root)));
+            Debug.Assert(!fromInterpreter.Any(p => !p.Path.PathEquals(PathUtils.NormalizePathAndTrim(p.Path))));
+#endif
 
             // Clean up user configured paths.
             // 1) Normalize paths.

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -287,16 +287,12 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
 
         public static bool operator !=(PythonLibraryPath left, PythonLibraryPath right) => !left.Equals(right);
 
-        private class PathDepthComparer : IComparer, IComparer<PythonLibraryPath> {
+        private class PathDepthComparer : Comparer<PythonLibraryPath> {
             public static readonly PathDepthComparer Instance = new PathDepthComparer();
 
             private PathDepthComparer() { }
 
-            public int Compare(object x, object y) {
-                return Compare((PythonLibraryPath)x, (PythonLibraryPath)y);
-            }
-
-            public int Compare(PythonLibraryPath x, PythonLibraryPath y) {
+            public override int Compare(PythonLibraryPath x, PythonLibraryPath y) {
                 var xSeps = x.Path.Count(c => c == IOPath.DirectorySeparatorChar);
                 var ySeps = y.Path.Count(c => c == IOPath.DirectorySeparatorChar);
 

--- a/src/Core/Impl/Extensions/StringExtensions.cs
+++ b/src/Core/Impl/Extensions/StringExtensions.cs
@@ -204,6 +204,9 @@ namespace Microsoft.Python.Core {
         public static bool PathEquals(this string s, string other)
             => string.Equals(s, other, PathsStringComparison);
 
+        public static int PathCompare(this string s, string other)
+            => string.Compare(s, other, PathsStringComparison);
+
         public static bool EqualsOrdinal(this string s, int index, string other, int otherIndex, int length, bool ignoreCase = false)
             => string.Compare(s, index, other, otherIndex, length, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == 0;
         public static bool ContainsOrdinal(this string s, string value, bool ignoreCase = false)

--- a/src/Core/Impl/IO/PathUtils.cs
+++ b/src/Core/Impl/IO/PathUtils.cs
@@ -493,5 +493,7 @@ namespace Microsoft.Python.Core.IO {
             );
             return isDir ? EnsureEndSeparator(newPath) : newPath;
         }
+
+        public static string NormalizePathAndTrim(string path) => TrimEndSeparator(NormalizePath(path));
     }
 }

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -115,8 +115,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             _rootDir = @params.rootUri != null ? @params.rootUri.ToAbsolutePath() : @params.rootPath;
             if (_rootDir != null) {
-                _rootDir = PathUtils.NormalizePath(_rootDir);
-                _rootDir = PathUtils.TrimEndSeparator(_rootDir);
+                _rootDir = PathUtils.NormalizePathAndTrim(_rootDir);
             }
 
             Version.TryParse(@params.initializationOptions.interpreter.properties?.Version, out var version);

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -133,11 +133,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 // 6) Remove duplicates.
                 SearchPaths = @params.initializationOptions.searchPaths
                     .Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany()
-                    .Select(PathUtils.NormalizePath)
-                    .Select(p => _rootDir == null || Path.IsPathRooted(p) ? p : Path.GetFullPath(p, _rootDir))
-                    .Select(PathUtils.TrimEndSeparator)
-                    .Where(p => !string.IsNullOrWhiteSpace(p) && p != "/" && !p.PathEquals(_rootDir))
-                    .Distinct(PathEqualityComparer.Instance)
                     .ToList(),
                 TypeshedPath = @params.initializationOptions.typeStubSearchPaths.FirstOrDefault()
             };

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -125,12 +125,8 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 interpreterPath: @params.initializationOptions.interpreter.properties?.InterpreterPath,
                 version: version
             ) {
-                // 1) Split on ';' to support older VS Code extension versions which send paths as a single entry separated by ';'. TODO: Eventually remove.
-                // 2) Normalize paths.
-                // 3) If a path isn't rooted, then root it relative to the workspace root. If _rootDir is null, then accept the path as-is.
-                // 4) Trim off any ending separator for a consistent style.
-                // 5) Filter out any entries which are the same as the workspace root; they are redundant. Also ignore "/" to work around the extension (for now).
-                // 6) Remove duplicates.
+                // Split on ';' to support older VS Code extension versions which send paths as a single entry separated by ';'. TODO: Eventually remove.
+                // Note that the actual classification of these paths as user/library is done later in MainModuleResolution.ReloadAsync.
                 SearchPaths = @params.initializationOptions.searchPaths
                     .Select(p => p.Split(';', StringSplitOptions.RemoveEmptyEntries)).SelectMany()
                     .ToList(),


### PR DESCRIPTION
Fixes #1213.
Fixes #537. (`pth` files will be handled automatically)

This does not change the algorithm overall, just moves it to another place and makes it more consistent (running on all of the paths, and not just a subset). The `get_search_paths.py` script uses the `site` library to identify which of its package paths came from `pth` files. Paths which aren't inside a stdlib path but are likely user code can be automatically classified as such. Note that the ordering of library paths should remain the same; I don't do any sort of depth sorting at the moment, but may need to do so in the future.

As the search path classification was moved, I'm now able to write tests for it, and have done so.

A future PR will make a couple more changes to allow the interpreter paths generated in `MainModuleResolution` to be used for file watching, rather than relying only on the paths provided in the configuration.