### PR TITLE
[WIP]: Handle inheriting from the ABC module to create abstract classes

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Core.Interpreter;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Modules.Resolution;
+using Microsoft.Python.Analysis.Specializations.Abc;
 using Microsoft.Python.Analysis.Specializations.Typing;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;

--- a/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             // Specialize typing
             TypingModule.Create(sm);
+            // Specialize abc 
             AbcModule.Create(sm);
             return pi;
         }

--- a/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
             // Specialize typing
             TypingModule.Create(sm);
+            AbcModule.Create(sm);
             return pi;
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // A class is derived from an abstract class if one of its bases is abstract or one of its bases is also derived from an abstract class
             var derivedFromAbstract = _class.Bases.OfType<PythonClassType>().Any(b => b.IsAbstract || b.IsDerivedFromAbstractClass);
             // A class is abstract if it is derived from an abstract class and has at least one abstract function
-            var isAbstract = _class.IsDerivedFromAbstractClass && _class.GetMembers<PythonFunctionType>().Any(f => f.IsAbstract);
+            var isAbstract = derivedFromAbstract && _class.GetMembers<PythonFunctionType>().Any(f => f.IsAbstract);
 
             _class.IsDerivedFromAbstractClass = derivedFromAbstract;
             _class.IsAbstract = isAbstract;

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -68,7 +68,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
                 ProcessClassBody();
 
-                // TODO do abstract check here 
                 _class.DecideAbstract();
             }
         }
@@ -119,8 +118,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Process remaining methods.
             SymbolTable.EvaluateScope(_classDef);
             UpdateClassMembers();
-
-            _class.DecideAbstract();
         }
 
         private void EvaluateConstructors(ClassDefinition cd) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 ProcessClassBody();
 
                 // TODO do abstract check here 
-                DecideAbstract();
+                _class.DecideAbstract();
             }
         }
 
@@ -119,10 +119,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Process remaining methods.
             SymbolTable.EvaluateScope(_classDef);
             UpdateClassMembers();
-        }
 
-        private void DecideAbstract() {
-            _class.SetAbstract(true);
+            _class.DecideAbstract();
         }
 
         private void EvaluateConstructors(ClassDefinition cd) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 Eval.DeclareVariable("__class__", _class, VariableSource.Declaration);
 
                 ProcessClassBody();
+
+                // TODO do abstract check here 
+                DecideAbstract();
             }
         }
 
@@ -116,6 +119,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Process remaining methods.
             SymbolTable.EvaluateScope(_classDef);
             UpdateClassMembers();
+        }
+
+        private void DecideAbstract() {
+            _class.SetAbstract(true);
         }
 
         private void EvaluateConstructors(ClassDefinition cd) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
                 ProcessClassBody();
 
-                _class.DecideAbstract();
+                DecideAbstract();
             }
         }
 
@@ -146,6 +146,19 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             foreach (var c in innerClasses) {
                 SymbolTable.Evaluate(c);
             }
+        }
+
+        /// <summary>
+        /// Decides if this class is an abstract class or not
+        /// </summary>
+        private void DecideAbstract() {
+            // A class is derived from an abstract class if one of its bases is abstract or one of its bases is also derived from an abstract class
+            var derivedFromAbstract = _class.Bases.OfType<PythonClassType>().Any(b => b.IsAbstract || b.IsDerivedFromAbstractClass);
+            // A class is abstract if it is derived from an abstract class and has at least one abstract function
+            var isAbstract = _class.IsDerivedFromAbstractClass && _class.GetMembers<PythonFunctionType>().Any(f => f.IsAbstract);
+
+            _class.IsDerivedFromAbstractClass = derivedFromAbstract;
+            _class.IsAbstract = isAbstract;
         }
 
         private void UpdateClassMembers() {

--- a/src/Analysis/Ast/Impl/Extensions/MemberContainerExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/MemberContainerExtensions.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Python.Analysis.Types {
     public static class MemberContainerExtensions {
         public static T GetMember<T>(this IMemberContainer mc, string name) where T: class, IPythonType => mc.GetMember(name) as T;
         public static IEnumerable<IMember> GetMembers(this IMemberContainer mc) => mc.GetMemberNames().Select(mc.GetMember);
+        public static IEnumerable<T> GetMembers<T>(this IMemberContainer mc) => mc.GetMemberNames().Select(mc.GetMember).OfType<T>();
     }
 }

--- a/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
@@ -60,8 +60,5 @@ namespace Microsoft.Python.Analysis {
             var unmangledName = cls.UnmangleMemberName(memberName);
             return unmangledName.StartsWithOrdinal("__") && memberName.EqualsOrdinal($"_{cls.Name}{unmangledName}");
         }
-
-        public static IReadOnlyList<T> GetMembers<T>(this IPythonClassType cls)
-            => cls.GetMemberNames().Select(cls.GetMember).OfType<T>().ToList();
     }
 }

--- a/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
@@ -13,7 +13,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Specializations.Typing;

--- a/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
@@ -13,6 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Specializations.Typing;
@@ -59,5 +60,8 @@ namespace Microsoft.Python.Analysis {
             var unmangledName = cls.UnmangleMemberName(memberName);
             return unmangledName.StartsWithOrdinal("__") && memberName.EqualsOrdinal($"_{cls.Name}{unmangledName}");
         }
+
+        public static IReadOnlyList<T> GetMembers<T>(this IPythonClassType cls)
+            => cls.GetMemberNames().Select(cls.GetMember).OfType<T>().ToList();
     }
 }

--- a/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
@@ -3,7 +3,7 @@ using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
 
-namespace Microsoft.Python.Analysis.Specializations.Typing {
+namespace Microsoft.Python.Analysis.Specializations.Abc {
     internal sealed class AbcModule : SpecializedModule {
         private readonly Dictionary<string, IMember> _members = new Dictionary<string, IMember>();
 

--- a/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
@@ -1,19 +1,4 @@
-﻿// Copyright(c) Microsoft Corporation
-// All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the License); you may not use
-// this file except in compliance with the License. You may obtain a copy of the
-// License at http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
-// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-// MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache Version 2.0 License for specific language governing
-// permissions and limitations under the License.
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;

--- a/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Python.Analysis.Specializations.Typing {
             _members["ABC"] = cls;
         }
 
-        private string GetMemberDocumentation(string name)
-        => base.GetMember(name)?.GetPythonType()?.Documentation;
+        private string GetMemberDocumentation(string name) => base.GetMember(name)?.GetPythonType()?.Documentation;
     }
 }

--- a/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
@@ -1,0 +1,49 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using Microsoft.Python.Analysis.Modules;
+using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Core;
+
+namespace Microsoft.Python.Analysis.Specializations.Typing {
+    internal sealed class AbcModule : SpecializedModule {
+        private readonly Dictionary<string, IMember> _members = new Dictionary<string, IMember>();
+
+        private AbcModule(string modulePath, IServiceContainer services) : base("abc", modulePath, services) { }
+
+        public static IPythonModule Create(IServiceContainer services) {
+            var interpreter = services.GetService<IPythonInterpreter>();
+            var module = interpreter.ModuleResolution
+                .SpecializeModule("abc", modulePath => new AbcModule(modulePath, services)) as AbcModule;
+            module?.SpecializeMembers();
+            return module;
+        }
+
+        #region IMemberContainer
+        public override IMember GetMember(string name) => _members.TryGetValue(name, out var m) ? m : null;
+        public override IEnumerable<string> GetMemberNames() => _members.Keys;
+        #endregion
+
+        private void SpecializeMembers() {
+            // ABC
+            var cls = PythonClassType.Specialize("abc", this, GetMemberDocumentation("abc"), isAbstract: true);
+            _members["ABC"] = cls;
+        }
+
+        private string GetMemberDocumentation(string name)
+        => base.GetMember(name)?.GetPythonType()?.Documentation;
+    }
+}

--- a/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Abc/AbcModule.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Python.Analysis.Specializations.Typing {
 
         private void SpecializeMembers() {
             // ABC
-            var cls = PythonClassType.Specialize("abc", this, GetMemberDocumentation("abc"), isAbstract: true);
+            var cls = PythonClassType.Specialize("ABC", this, GetMemberDocumentation("ABC"), isAbstract: true);
             _members["ABC"] = cls;
         }
 

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Python.Analysis.Types {
         /// <summary>
         /// If the class contains an abstract class on its inheritance chain
         /// </summary>
-        bool IsDerivedFromAbstractClass { get; }
+        bool IsDerivedFromAbstractClass { get; set;  }
 
         /// <summary>
         /// If class is created off generic template, name/type

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Python.Analysis.Types {
         /// <summary>
         /// If the class contains an abstract class on its inheritance chain
         /// </summary>
-        bool IsDerivedFromAbstract { get; }
+        bool IsDerivedFromAbstractClass { get; }
 
         /// <summary>
         /// If class is created off generic template, name/type

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonClassType.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Python.Analysis.Types {
         IReadOnlyList<IPythonType> Bases { get; }
 
         /// <summary>
+        /// If the class contains an abstract class on its inheritance chain
+        /// </summary>
+        bool IsDerivedFromAbstract { get; }
+
+        /// <summary>
         /// If class is created off generic template, name/type
         /// pairs of the generic parameter name / actual supplied type.
         /// </summary>

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Python.Analysis.Types {
     [DebuggerDisplay("Class {Name}")]
     internal class PythonClassType : PythonType, IPythonClassType, IPythonTemplateType, IEquatable<IPythonClassType> {
         private static readonly string[] _classMethods = { "mro", "__dict__", @"__weakref__" };
-        private bool _isAbstract;
-        private bool _isDerivedFromAbstractClass;
         private IPythonClassType _processing;
         private List<IPythonType> _bases;
         private IReadOnlyList<IPythonType> _mro;
@@ -57,7 +55,7 @@ namespace Microsoft.Python.Analysis.Types {
         private PythonClassType(string name, Location location, string documentation, BuiltinTypeId buildinTypeId = BuiltinTypeId.Type, bool isAbstract = false)
             : base(name, location, documentation, buildinTypeId) {
             Check.ArgumentNotNull(nameof(location), location.Module);
-            _isAbstract = isAbstract;
+            IsAbstract = isAbstract;
         }
 
         public PythonClassType(

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -40,17 +40,31 @@ namespace Microsoft.Python.Analysis.Types {
         private Dictionary<string, IPythonType> _genericParameters;
         private string _documentation;
 
+        /// <summary>
+        /// Creates function for specializations
+        /// </summary>
+        public static PythonClassType Specialize(string name, IPythonModule declaringModule, string documentation, bool isAbstract = false) {
+            return new PythonClassType(name, new Location(declaringModule, default), documentation, isAbstract: isAbstract);
+        }
+
+
         // For tests
         internal PythonClassType(string name, Location location)
             : base(name, location, string.Empty, BuiltinTypeId.Type) {
             Check.ArgumentNotNull(nameof(location), location.Module);
         }
 
+        private PythonClassType(string name, Location location, string documentation, BuiltinTypeId buildinTypeId = BuiltinTypeId.Type, bool isAbstract = false) 
+            : base(name, location, documentation, buildinTypeId) {
+            Check.ArgumentNotNull(nameof(location), location.Module);
+            _isAbstract = isAbstract;
+        }
+
         public PythonClassType(
-            ClassDefinition classDefinition,
-            Location location,
-            BuiltinTypeId builtinTypeId = BuiltinTypeId.Type
-        ) : base(classDefinition.Name, location, classDefinition.GetDocumentation(), builtinTypeId) {
+                   ClassDefinition classDefinition,
+                   Location location,
+                   BuiltinTypeId builtinTypeId = BuiltinTypeId.Type
+               ) : base(classDefinition.Name, location, classDefinition.GetDocumentation(), builtinTypeId) {
             Check.ArgumentNotNull(nameof(location), location.Module);
             location.Module.AddAstNode(this, classDefinition);
         }
@@ -93,7 +107,7 @@ namespace Microsoft.Python.Analysis.Types {
                         if (m == this) {
                             return member;
                         }
-                        member = member ?? m.GetMember(name);
+                        member = m.GetMember(name) ?? member;
                     }
                 } finally {
                     Pop();

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Python.Analysis.Types {
     internal class PythonClassType : PythonType, IPythonClassType, IPythonTemplateType, IEquatable<IPythonClassType> {
         private static readonly string[] _classMethods = { "mro", "__dict__", @"__weakref__" };
         private bool _isAbstract;
-        private bool _isDerivedFromAbstract;
+        private bool _isDerivedFromAbstractClass;
         private IPythonClassType _processing;
         private List<IPythonType> _bases;
         private IReadOnlyList<IPythonType> _mro;
@@ -54,17 +54,17 @@ namespace Microsoft.Python.Analysis.Types {
             Check.ArgumentNotNull(nameof(location), location.Module);
         }
 
-        private PythonClassType(string name, Location location, string documentation, BuiltinTypeId buildinTypeId = BuiltinTypeId.Type, bool isAbstract = false) 
+        private PythonClassType(string name, Location location, string documentation, BuiltinTypeId buildinTypeId = BuiltinTypeId.Type, bool isAbstract = false)
             : base(name, location, documentation, buildinTypeId) {
             Check.ArgumentNotNull(nameof(location), location.Module);
             _isAbstract = isAbstract;
         }
 
         public PythonClassType(
-                   ClassDefinition classDefinition,
-                   Location location,
-                   BuiltinTypeId builtinTypeId = BuiltinTypeId.Type
-               ) : base(classDefinition.Name, location, classDefinition.GetDocumentation(), builtinTypeId) {
+            ClassDefinition classDefinition,
+            Location location,
+            BuiltinTypeId builtinTypeId = BuiltinTypeId.Type
+        ) : base(classDefinition.Name, location, classDefinition.GetDocumentation(), builtinTypeId) {
             Check.ArgumentNotNull(nameof(location), location.Module);
             location.Module.AddAstNode(this, classDefinition);
         }
@@ -201,7 +201,7 @@ namespace Microsoft.Python.Analysis.Types {
         public IReadOnlyDictionary<string, IPythonType> GenericParameters
             => _genericParameters ?? EmptyDictionary<string, IPythonType>.Instance;
 
-        public bool IsDerivedFromAbstract => _isDerivedFromAbstract;
+        public bool IsDerivedFromAbstractClass => _isDerivedFromAbstractClass;
 
         #endregion
 
@@ -538,8 +538,8 @@ namespace Microsoft.Python.Analysis.Types {
         /// Decides if this class is an abstract class or not
         /// </summary>
         public void DecideAbstract() {
-            _isDerivedFromAbstract = Bases.OfType<PythonClassType>().Any(b => b.IsAbstract || b.IsDerivedFromAbstract);
-            _isAbstract = _isDerivedFromAbstract && this.GetMembers<PythonFunctionType>().Any(f => f.IsAbstract);
+            _isDerivedFromAbstractClass = Bases.OfType<PythonClassType>().Any(b => b.IsAbstract || b.IsDerivedFromAbstractClass);
+            _isAbstract = _isDerivedFromAbstractClass && this.GetMembers<PythonFunctionType>().Any(f => f.IsAbstract);
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Python.Analysis.Types {
     [DebuggerDisplay("Class {Name}")]
     internal class PythonClassType : PythonType, IPythonClassType, IPythonTemplateType, IEquatable<IPythonClassType> {
         private static readonly string[] _classMethods = { "mro", "__dict__", @"__weakref__" };
+        private bool _isAbstract;
         private IPythonClassType _processing;
         private List<IPythonType> _bases;
         private IReadOnlyList<IPythonType> _mro;
@@ -55,6 +56,8 @@ namespace Microsoft.Python.Analysis.Types {
 
         #region IPythonType
         public override PythonMemberType MemberType => PythonMemberType.Class;
+
+        public override bool IsAbstract => _isAbstract;
 
         public override IEnumerable<string> GetMemberNames() {
             var names = new HashSet<string>();
@@ -183,6 +186,10 @@ namespace Microsoft.Python.Analysis.Types {
         public IReadOnlyDictionary<string, IPythonType> GenericParameters
             => _genericParameters ?? EmptyDictionary<string, IPythonType>.Instance;
         #endregion
+
+        internal void SetAbstract(bool isAbstract) {
+            _isAbstract = isAbstract;
+        }
 
         internal void SetBases(IEnumerable<IPythonType> bases) {
             if (_bases != null) {

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Python.Analysis.Types {
         #region IPythonType
         public override PythonMemberType MemberType => PythonMemberType.Class;
 
-        public override bool IsAbstract => _isAbstract;
+        public override bool IsAbstract { get; set; }
 
         public override IEnumerable<string> GetMemberNames() {
             var names = new HashSet<string>();
@@ -201,7 +201,7 @@ namespace Microsoft.Python.Analysis.Types {
         public IReadOnlyDictionary<string, IPythonType> GenericParameters
             => _genericParameters ?? EmptyDictionary<string, IPythonType>.Instance;
 
-        public bool IsDerivedFromAbstractClass => _isDerivedFromAbstractClass;
+        public bool IsDerivedFromAbstractClass { get; set; }
 
         #endregion
 
@@ -532,14 +532,6 @@ namespace Microsoft.Python.Analysis.Types {
                         }
                 }
             }
-        }
-
-        /// <summary>
-        /// Decides if this class is an abstract class or not
-        /// </summary>
-        public void DecideAbstract() {
-            _isDerivedFromAbstractClass = Bases.OfType<PythonClassType>().Any(b => b.IsAbstract || b.IsDerivedFromAbstractClass);
-            _isAbstract = _isDerivedFromAbstractClass && this.GetMembers<PythonFunctionType>().Any(f => f.IsAbstract);
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Python.Analysis.Types {
             IPythonType declaringType,
             Location location
         ) : base(fd.Name, location,
-            fd.Name == "__init__" ? (declaringType?.Documentation ?? fd.GetDocumentation()) : fd.GetDocumentation(), 
+            fd.Name == "__init__" ? (declaringType?.Documentation ?? fd.GetDocumentation()) : fd.GetDocumentation(),
             declaringType != null ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
             DeclaringType = declaringType;
 
@@ -118,34 +118,45 @@ namespace Microsoft.Python.Analysis.Types {
         internal IPythonFunctionType ToUnbound() => new PythonUnboundMethod(this);
 
         private void ProcessDecorators(FunctionDefinition fd) {
-            foreach (var dec in (fd.Decorators?.Decorators).MaybeEnumerate().OfType<NameExpression>()) {
-                // TODO: warn about incompatible combinations.
-                switch (dec.Name) {
-                    case @"staticmethod":
-                        IsStatic = true;
+            // TODO: warn about incompatible combinations.
+            foreach (var dec in (fd.Decorators?.Decorators).MaybeEnumerate()) {
+                switch (dec) {
+                    case NameExpression n:
+                        ProcessDecorator(n.Name);
                         break;
-                    case @"classmethod":
-                        IsClassMethod = true;
-                        break;
-                    case @"abstractmethod":
-                        _isAbstract = true;
-                        break;
-                    case @"abstractstaticmethod":
-                        IsStatic = true;
-                        _isAbstract = true;
-                        break;
-                    case @"abstractclassmethod":
-                        IsClassMethod = true;
-                        _isAbstract = true;
-                        break;
-                    case @"overload":
-                        IsOverload = true;
-                        break;
-                    case @"property":
-                    case @"abstractproperty":
-                        Debug.Assert(false, "Found property attribute while processing function. Properties should be handled in the respective class.");
+                    case MemberExpression m:
+                        ProcessDecorator(m.Name);
                         break;
                 }
+            }
+        }
+
+        private void ProcessDecorator(string decorator) {
+            switch (decorator) {
+                case @"staticmethod":
+                    IsStatic = true;
+                    break;
+                case @"classmethod":
+                    IsClassMethod = true;
+                    break;
+                case @"abstractmethod":
+                    _isAbstract = true;
+                    break;
+                case @"abstractstaticmethod":
+                    IsStatic = true;
+                    _isAbstract = true;
+                    break;
+                case @"abstractclassmethod":
+                    IsClassMethod = true;
+                    _isAbstract = true;
+                    break;
+                case @"overload":
+                    IsOverload = true;
+                    break;
+                case @"property":
+                case @"abstractproperty":
+                    Debug.Assert(false, "Found property attribute while processing function. Properties should be handled in the respective class.");
+                    break;
             }
         }
 

--- a/src/Analysis/Ast/Impl/Types/PythonPropertyType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonPropertyType.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Python.Analysis.Types {
 
         #region IPythonPropertyType
         public FunctionDefinition FunctionDefinition => DeclaringModule.GetAstNode<FunctionDefinition>(this);
-        public override bool IsAbstract { get; }
+        public override bool IsAbstract { get; set; }
         public bool IsReadOnly => true;
         public IPythonType DeclaringType { get; }
         public string Description 

--- a/src/Analysis/Ast/Impl/Types/PythonType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonType.cs
@@ -59,7 +59,10 @@ namespace Microsoft.Python.Analysis.Types {
         public virtual string Documentation { get; private set; }
         public virtual BuiltinTypeId TypeId => _typeId;
         public bool IsBuiltin => DeclaringModule == null || DeclaringModule is IBuiltinsPythonModule;
-        public virtual bool IsAbstract => false;
+        public virtual bool IsAbstract {
+            get => false;
+            set => IsAbstract = value;
+        }
         public virtual bool IsSpecialized => false;
 
         /// <summary>

--- a/src/Analysis/Ast/Test/AbstractClassTests.cs
+++ b/src/Analysis/Ast/Test/AbstractClassTests.cs
@@ -327,5 +327,22 @@ class C(B):
             cls.IsAbstract.Should().BeFalse();
             cls.Should().HaveMethod("method").Which.IsAbstract.Should().BeFalse();
         }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritsABCImportReference() {
+            const string code = @"
+import abc
+
+class A(abc.ABC):
+    @abc.abstractmethod
+    def method(self):
+        return 1
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var gParent = analysis.Should().HaveClass("A").Which;
+            gParent.Should().HaveMethod("method").Which.IsAbstract.Should().BeTrue();
+            gParent.IsAbstract.Should().BeTrue();
+        }
     }
 }

--- a/src/Analysis/Ast/Test/AbstractClassTests.cs
+++ b/src/Analysis/Ast/Test/AbstractClassTests.cs
@@ -1,0 +1,259 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Python.Analysis.Tests.FluentAssertions;
+using Microsoft.Python.Parsing.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Microsoft.Python.Analysis.Tests {
+    [TestClass]
+    public class AbstractClassTests : AnalysisTestBase {
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritABC() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class C(ABC):
+    @abstractmethod
+    def method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            cls.IsAbstract.Should().BeTrue();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritMultiple() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class B:
+    def test(self):
+        return 5
+
+class C(ABC, B):
+    @abstractmethod
+    def method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            cls.IsAbstract.Should().BeTrue();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleBasesOneHasAbstractMethods() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class B:
+    @abstractmethod
+    def test(self):
+        return 5
+
+class C(ABC, B):
+    def method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            cls.IsAbstract.Should().BeFalse();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritABCNoMethods() {
+            const string code = @"
+from abc import ABC
+
+class C(ABC):
+    def method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            // because there are no methods on the abstract class, treat it as a normal class
+            cls.IsAbstract.Should().BeFalse();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassWithAbstractMethodsNoABC() {
+            const string code = @"
+from abc import abstractmethod
+
+class C():
+    @abstractmethod
+    def method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            // because there are no methods on the abstract class, treat it as a normal class
+            cls.IsAbstract.Should().BeFalse();
+        }
+
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritsAbstract() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @abstractmethod
+    def method(self):
+        return 4
+
+class B(A):
+    def not_impl(self):
+        return 2
+";
+            // note to Cameron - when implementing a method in the base class, it overwrites the abstract
+            // method in the superclass, so when implementing, all you need to do is check the immediate parents 
+            // to see if they have any abstract methods
+            var analysis = await GetAnalysisAsync(code);
+
+            var clsBase = analysis.Should().HaveClass("A").Which;
+            var absFunc = clsBase.Should().HaveMethod("method").Which;
+            absFunc.IsAbstract.Should().BeTrue();
+
+            var cls = analysis.Should().HaveClass("B").Which;
+            clsBase.IsAbstract.Should().BeTrue();
+            cls.IsAbstract.Should().BeTrue();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritsAbstractImplementsAllMethods() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @abstractmethod
+    def method(self):
+        return 4
+
+class B(A):
+    def method(self):
+        return 10
+
+    def not_impl(self):
+        return 2
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            var clsBase = analysis.Should().HaveClass("A").Which;
+            var absFunc = clsBase.Should().HaveFunction("method").Which;
+            absFunc.IsAbstract.Should().BeTrue();
+
+            var cls = analysis.Should().HaveClass("B").Which;
+            var clsFunc = cls.Should().HaveFunction("method").Which;
+            clsFunc.IsAbstract.Should().BeFalse();
+
+            clsBase.IsAbstract.Should().BeTrue();
+            cls.IsAbstract.Should().BeFalse();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritsAbstractAddMoreAbstractMethods() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @abstractmethod
+    def method(self):
+        return 1
+
+class B(A):
+    @abstractmethod
+    def not_impl(self):
+        return 3
+
+class C(B):
+    def new_method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            analysis.Should().HaveClass("A").Which.Should().HaveFunction("method").Which
+                .IsAbstract.Should().BeTrue();
+
+            var gParent = analysis.Should().HaveClass("B").Which;
+            gParent.IsAbstract.Should().BeTrue();
+            gParent.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
+
+            var parent = analysis.Should().HaveClass("C").Which;
+            parent.IsAbstract.Should().BeTrue();
+            parent.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
+            parent.Should().HaveFunction("not_impl").Which.IsAbstract.Should().BeTrue();
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            cls.IsAbstract.Should().BeTrue();
+            cls.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
+            cls.Should().HaveFunction("not_impl").Which.IsAbstract.Should().BeTrue();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassInheritsPassesAbstractMethods() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @abstractmethod
+    def method(self):
+        return 1
+
+class B(A):
+    def not_impl(self):
+        return 3
+
+class C(B):
+    def method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            analysis.Should().HaveClass("A").Which.Should().HaveFunction("method").Which
+                .IsAbstract.Should().BeTrue();
+
+            var gParent = analysis.Should().HaveClass("B").Which;
+            gParent.IsAbstract.Should().BeTrue();
+            gParent.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
+
+            var parent = analysis.Should().HaveClass("C").Which;
+            parent.IsAbstract.Should().BeTrue();
+            parent.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            cls.IsAbstract.Should().BeTrue();
+            cls.Should().HaveFunction("method").Which.IsAbstract.Should().BeFalse();
+        }
+    }
+}

--- a/src/Analysis/Ast/Test/AbstractClassTests.cs
+++ b/src/Analysis/Ast/Test/AbstractClassTests.cs
@@ -253,7 +253,6 @@ class C(B):
             var cls = analysis.Should().HaveClass("C").Which;
             cls.IsAbstract.Should().BeFalse();
 
-            var tmp = cls.GetMembers<PythonFunctionType>();
             cls.Should().HaveMethod("method").Which.IsAbstract.Should().BeFalse();
             cls.Should().HaveMethod("new_method").Which.IsAbstract.Should().BeFalse();
         }

--- a/src/Analysis/Ast/Test/AbstractClassTests.cs
+++ b/src/Analysis/Ast/Test/AbstractClassTests.cs
@@ -218,6 +218,45 @@ class C(B):
             cls.IsAbstract.Should().BeTrue();
             cls.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
             cls.Should().HaveFunction("not_impl").Which.IsAbstract.Should().BeTrue();
+            cls.Should().HaveFunction("new_method").Which.IsAbstract.Should().BeFalse();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassDerivedFromAbstractAddMoreAbstractMethods() {
+            const string code = @"
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @abstractmethod
+    def method(self):
+        return 1
+
+class B(A):
+    def method(self):
+        return 3
+
+class C(B):
+    @abstractmethod
+    def new_method(self):
+        return 4
+";
+            var analysis = await GetAnalysisAsync(code);
+
+            analysis.Should().HaveClass("A").Which.Should().HaveFunction("method").Which
+                .IsAbstract.Should().BeTrue();
+
+            var gParent = analysis.Should().HaveClass("B").Which;
+            gParent.IsAbstract.Should().BeTrue();
+            gParent.Should().HaveFunction("method").Which.IsAbstract.Should().BeTrue();
+
+            var parent = analysis.Should().HaveClass("C").Which;
+            parent.IsAbstract.Should().BeTrue();
+            parent.Should().HaveFunction("method").Which.IsAbstract.Should().BeFalse();
+
+            var cls = analysis.Should().HaveClass("C").Which;
+            cls.IsAbstract.Should().BeTrue();
+            cls.Should().HaveFunction("method").Which.IsAbstract.Should().BeFalse();
+            cls.Should().HaveFunction("new_method").Which.IsAbstract.Should().BeTrue();
         }
 
         [TestMethod, Priority(0)]

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -325,6 +325,9 @@ class cls(object):
     
     @abstractclassmethod
     def e(cls): pass
+
+    @abstractmethod
+    def f(self): pass
 ";
 
             var analysis = await GetAnalysisAsync(code);
@@ -351,6 +354,11 @@ class cls(object):
             e.IsAbstract.Should().BeTrue();
             e.IsStatic.Should().BeFalse();
             e.IsClassMethod.Should().BeTrue();
+
+            var f = cls.Should().HaveMethod("f").Which;
+            f.IsAbstract.Should().BeTrue();
+            f.IsStatic.Should().BeFalse();
+            f.IsClassMethod.Should().BeFalse();
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Does not handle metadata=ABCMetadata, will probably try that later. 

IsAbstract is now set correctly for abstract classes. 

Basically a class is abstract if it derives from an abstract class and has abstract methods.

A class derives from an abstract class if any of its bases derive from abstract classes or are abstract classes.

A class is abstract if it extends ABC from package abc. 