### PR TITLE
Multiple analysis fixes

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IAnalyzable.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IAnalyzable.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         /// <summary>
         /// Notifies document that its analysis is now complete.
         /// </summary>
-        void NotifyAnalysisComplete(int version, ModuleWalker walker, bool isFinalPass);
+        /// <param name="analysis">Document analysis</param>
+        void NotifyAnalysisComplete(IDocumentAnalysis analysis);
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core.Collections;
+using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     public interface IPythonAnalyzer {
@@ -27,7 +28,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         /// <summary>
         /// Schedules module for analysis. Module will be scheduled if version of AST is greater than the one used to get previous analysis
         /// </summary>
-        void EnqueueDocumentForAnalysis(IPythonModule module, int version);
+        void EnqueueDocumentForAnalysis(IPythonModule module, PythonAst ast, int version);
 
         /// <summary>
         /// Schedules module for analysis for its existing AST, but with new dependencies.

--- a/src/Analysis/Ast/Impl/Analyzer/EmptyAnalysis.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/EmptyAnalysis.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             Document = document ?? throw new ArgumentNullException(nameof(document));
             GlobalScope = new EmptyGlobalScope(document);
             Ast = AstUtilities.MakeEmptyAst(document.Uri);
-            ExpressionEvaluator = new ExpressionEval(services, document);
+            ExpressionEvaluator = new ExpressionEval(services, document, Ast);
         }
 
         public IDocument Document { get; }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             var init = cls.GetMember<IPythonFunctionType>(@"__init__");
             if (init != null) {
                 using (OpenScope(cls.DeclaringModule, cls.ClassDefinition, out _)) {
-                    var a = new ArgumentSet(init, 0, new PythonInstance(cls), expr, Module, this);
+                    var a = new ArgumentSet(init, 0, new PythonInstance(cls), expr, this);
                     if (a.Errors.Count > 0) {
                         // AddDiagnostics(Module.Uri, a.Errors);
                     }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             => DeclareVariable(name, value, source, default(Location));
 
         public void DeclareVariable(string name, IMember value, VariableSource source, IPythonModule module)
-            => DeclareVariable(name, value, source, new Location(module, default));
+            => DeclareVariable(name, value, source, new Location(module));
 
         public void DeclareVariable(string name, IMember value, VariableSource source, Node location, bool overwrite = false)
             => DeclareVariable(name, value, source, GetLocationOfName(location), overwrite);

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -38,15 +38,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         private readonly object _lock = new object();
         private readonly List<DiagnosticsEntry> _diagnostics = new List<DiagnosticsEntry>();
 
-        public ExpressionEval(IServiceContainer services, IPythonModule module)
-            : this(services, module, new GlobalScope(module)) { }
-
-        public ExpressionEval(IServiceContainer services, IPythonModule module, GlobalScope gs) {
+        public ExpressionEval(IServiceContainer services, IPythonModule module, PythonAst ast) {
             Services = services ?? throw new ArgumentNullException(nameof(services));
             Module = module ?? throw new ArgumentNullException(nameof(module));
-            Ast = module.GetAst();
+            Ast = ast ?? throw new ArgumentNullException(nameof(ast));
 
-            GlobalScope = gs;
+            GlobalScope = new GlobalScope(module, ast);
             CurrentScope = GlobalScope;
             DefaultLocation = new Location(module);
             //Log = services.GetService<ILogger>();
@@ -60,7 +57,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public IPythonType UnknownType => Interpreter.UnknownType;
         public Location DefaultLocation { get; }
 
-        public LocationInfo GetLocationInfo(Node node) => node?.GetLocation(Module) ?? LocationInfo.Empty;
+        public LocationInfo GetLocationInfo(Node node) => node?.GetLocation(this) ?? LocationInfo.Empty;
 
         public Location GetLocationOfName(Node node) {
             if (node == null || (Module.ModuleType != ModuleType.User && Module.ModuleType != ModuleType.Library)) {
@@ -103,7 +100,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public IServiceContainer Services { get; }
         IScope IExpressionEvaluator.CurrentScope => CurrentScope;
         IGlobalScope IExpressionEvaluator.GlobalScope => GlobalScope;
-        public LocationInfo GetLocation(Node node) => node?.GetLocation(Module) ?? LocationInfo.Empty;
+        public LocationInfo GetLocation(Node node) => node?.GetLocation(this) ?? LocationInfo.Empty;
         public IEnumerable<DiagnosticsEntry> Diagnostics => _diagnostics;
 
         public void ReportDiagnostics(Uri documentUri, DiagnosticsEntry entry) {

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
@@ -125,8 +125,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
 
             var printNameExpression = node.Names.FirstOrDefault(n => n?.Name == "print_function");
             if (printNameExpression != null) {
-                var fn = new PythonFunctionType("print", new Location(Module, default), null, string.Empty);
-                var o = new PythonFunctionOverload(fn.Name, new Location(Module, default));
+                var fn = new PythonFunctionType("print", new Location(Module), null, string.Empty);
+                var o = new PythonFunctionOverload(fn.Name, new Location(Module));
                 var parameters = new List<ParameterInfo> {
                     new ParameterInfo("*values", Interpreter.GetBuiltinType(BuiltinTypeId.Object), ParameterKind.List, null),
                     new ParameterInfo("sep", Interpreter.GetBuiltinType(BuiltinTypeId.Str), ParameterKind.KeywordOnly, null),

--- a/src/Analysis/Ast/Impl/Analyzer/LibraryAnalysis.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/LibraryAnalysis.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
     /// Analysis of a library code.
     /// </summary>
     internal sealed class LibraryAnalysis : IDocumentAnalysis {
-        public LibraryAnalysis(IDocument document, int version, IServiceContainer services, GlobalScope globalScope, IReadOnlyList<string> starImportMemberNames) {
+        public LibraryAnalysis(IDocument document, int version, IGlobalScope globalScope, IExpressionEvaluator eval, IReadOnlyList<string> starImportMemberNames) {
             Check.ArgumentNotNull(nameof(document), document);
             Check.ArgumentNotNull(nameof(globalScope), globalScope);
 
@@ -37,14 +37,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             Version = version;
             GlobalScope = globalScope;
 
-            var ast = Document.GetAst();
-            ast.Reduce(x => x is ImportStatement || x is FromImportStatement);
-            var c = (IAstNodeContainer)Document;
-            c.ClearContent();
-            c.ClearAst();
-            c.AddAstNode(document, ast);
-
-            ExpressionEvaluator = new ExpressionEval(services, document, globalScope);
+            ExpressionEvaluator = eval;
             StarImportMemberNames = starImportMemberNames;
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private int _allReferencesCount;
         private bool _allIsUsable = true;
 
-        public ModuleWalker(IServiceContainer services, IPythonModule module)
-            : base(new ExpressionEval(services, module)) {
+        public ModuleWalker(IServiceContainer services, IPythonModule module, PythonAst ast)
+            : base(new ExpressionEval(services, module, ast)) {
             _stubAnalysis = Module.Stub is IDocument doc ? doc.GetAnyAnalysis() : null;
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Caching;
@@ -31,6 +32,7 @@ using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Core.Disposables;
 using Microsoft.Python.Core.Logging;
 using Microsoft.Python.Core.Services;
+using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     public sealed class PythonAnalyzer : IPythonAnalyzer, IDisposable {
@@ -68,9 +70,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
             => _analysisCompleteEvent.WaitAsync(cancellationToken);
 
         public async Task<IDocumentAnalysis> GetAnalysisAsync(IPythonModule module, int waitTime, CancellationToken cancellationToken) {
-            var key = new AnalysisModuleKey(module);
             PythonAnalyzerEntry entry;
             lock (_syncObj) {
+                var key = new AnalysisModuleKey(module);
                 if (!_analysisEntries.TryGetValue(key, out entry)) {
                     var emptyAnalysis = new EmptyAnalysis(_services, (IDocument)module);
                     entry = new PythonAnalyzerEntry(emptyAnalysis);
@@ -120,11 +122,13 @@ namespace Microsoft.Python.Analysis.Analyzer {
         }
 
         public void RemoveAnalysis(IPythonModule module) {
+            AnalysisModuleKey key;
             lock (_syncObj) {
-                _analysisEntries.Remove(new AnalysisModuleKey(module));
+                key = new AnalysisModuleKey(module);
+                _analysisEntries.Remove(key);
             }
 
-            _dependencyResolver.Remove(new AnalysisModuleKey(module));
+            _dependencyResolver.Remove(key);
         }
 
         public void EnqueueDocumentForAnalysis(IPythonModule module, ImmutableArray<IPythonModule> analysisDependencies) {
@@ -144,16 +148,28 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        public void EnqueueDocumentForAnalysis(IPythonModule module, int bufferVersion) {
-            var key = new AnalysisModuleKey(module);
+        public void EnqueueDocumentForAnalysis(IPythonModule module, PythonAst ast, int bufferVersion) {
             PythonAnalyzerEntry entry;
+            AnalysisModuleKey key;
             int version;
+
             lock (_syncObj) {
+                key = new AnalysisModuleKey(module);
                 version = _version + 1;
                 if (_analysisEntries.TryGetValue(key, out entry)) {
                     if (entry.BufferVersion >= bufferVersion) {
                         return;
                     }
+
+                    // It is possible that parsing request for the library has been started when document is open,
+                    // but it is closed at the moment of analysis and then become open again.
+                    // In this case, we still need to analyze the document, but using correct entry.
+                    var libraryAsDocumentKey = key.GetLibraryAsDocumentKey();
+                    if (entry.PreviousAnalysis is LibraryAnalysis && _analysisEntries.TryGetValue(libraryAsDocumentKey, out var documentEntry)) {
+                        key = libraryAsDocumentKey;
+                        entry = documentEntry;
+                    }
+
                 } else {
                     entry = new PythonAnalyzerEntry(new EmptyAnalysis(_services, (IDocument)module));
                     _analysisEntries[key] = entry;
@@ -161,7 +177,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 }
             }
 
-            if (entry.Invalidate(module, bufferVersion, version, out var dependencies)) {
+            if (entry.Invalidate(module, ast, bufferVersion, version, out var dependencies)) {
                 AnalyzeDocument(key, entry, dependencies);
             }
         }
@@ -205,12 +221,12 @@ namespace Microsoft.Python.Analysis.Analyzer {
         internal void RaiseAnalysisComplete(int moduleCount, double msElapsed) 
             => AnalysisComplete?.Invoke(this, new AnalysisCompleteEventArgs(moduleCount, msElapsed));
 
-        private void AnalyzeDocument(AnalysisModuleKey key, PythonAnalyzerEntry entry, ImmutableArray<AnalysisModuleKey> dependencies) {
+        private void AnalyzeDocument(in AnalysisModuleKey key, in PythonAnalyzerEntry entry, in ImmutableArray<AnalysisModuleKey> dependencies) {
             _analysisCompleteEvent.Reset();
             ActivityTracker.StartTracking();
             _log?.Log(TraceEventType.Verbose, $"Analysis of {entry.Module.Name}({entry.Module.ModuleType}) queued");
 
-            var graphVersion = _dependencyResolver.ChangeValue(key, entry, entry.IsUserModule, dependencies);
+            var graphVersion = _dependencyResolver.ChangeValue(key, entry, entry.IsUserOrBuiltin || key.IsLibraryAsDocument, dependencies);
 
             lock (_syncObj) {
                 if (_version > graphVersion) {
@@ -226,7 +242,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
         
-        private bool TryCreateSession(int graphVersion, PythonAnalyzerEntry entry, out PythonAnalyzerSession session) {
+        private bool TryCreateSession(in int graphVersion, in PythonAnalyzerEntry entry, out PythonAnalyzerSession session) {
             var analyzeUserModuleOutOfOrder = false;
             lock (_syncObj) {
                 if (_currentSession != null) {
@@ -244,11 +260,6 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
 
             if (!_dependencyResolver.TryCreateWalker(graphVersion, 2, out var walker)) {
-                if (entry.Module.ModuleType == ModuleType.Builtins) {
-                    session = CreateSession(null, entry);
-                    return true;
-                }
-
                 session = null;
                 return false;
             }
@@ -290,7 +301,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             session.Start(false);
         }
 
-        private PythonAnalyzerSession CreateSession(IDependencyChainWalker<AnalysisModuleKey, PythonAnalyzerEntry> walker, PythonAnalyzerEntry entry) 
+        private PythonAnalyzerSession CreateSession(in IDependencyChainWalker<AnalysisModuleKey, PythonAnalyzerEntry> walker, in PythonAnalyzerEntry entry) 
             => new PythonAnalyzerSession(_services, _progress, _analysisCompleteEvent, _startNextSession, _disposeToken.CancellationToken, walker, _version, entry);
 
         private void LoadMissingDocuments(IPythonInterpreter interpreter, ImmutableArray<AnalysisModuleKey> missingKeys) {

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerEntry.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerEntry.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis.Core.DependencyResolution;
+using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
@@ -32,13 +33,13 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private readonly object _syncObj = new object();
         private TaskCompletionSource<IDocumentAnalysis> _analysisTcs;
         private IPythonModule _module;
-        private bool _isUserModule;
+        private ModuleType _moduleType;
+        private PythonAst _ast;
         private IDocumentAnalysis _previousAnalysis;
         private HashSet<AnalysisModuleKey> _parserDependencies;
         private HashSet<AnalysisModuleKey> _analysisDependencies;
         private int _bufferVersion;
         private int _analysisVersion;
-        private int _depth;
 
         public IPythonModule Module {
             get {
@@ -48,10 +49,18 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
+        public bool IsUserOrBuiltin {
+            get {
+                lock (_syncObj) {
+                    return _moduleType == ModuleType.User || _moduleType == ModuleType.Builtins;
+                }
+            }
+        }
+
         public bool IsUserModule {
             get {
                 lock (_syncObj) {
-                    return _isUserModule;
+                    return _moduleType == ModuleType.User;
                 }
             }
         }
@@ -74,21 +83,12 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        public int Depth {
-            get {
-                lock (_syncObj) {
-                    return _depth;
-                }
-            }
-        }
-
         public bool NotAnalyzed => PreviousAnalysis is EmptyAnalysis;
         
         public PythonAnalyzerEntry(EmptyAnalysis emptyAnalysis) {
             _previousAnalysis = emptyAnalysis;
             _module = emptyAnalysis.Document;
-            _isUserModule = emptyAnalysis.Document.ModuleType == ModuleType.User;
-            _depth = _isUserModule ? 0 : -1;
+            _moduleType = _module.ModuleType;
 
             _bufferVersion = -1;
             _analysisVersion = 0;
@@ -101,12 +101,18 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public bool IsValidVersion(int version, out IPythonModule module, out PythonAst ast) {
             lock (_syncObj) {
                 module = _module;
-                ast = module.GetAst();
-                if (ast == null || module == null) {
+                ast = _ast;
+
+                if (module == null) {
                     return false;
                 }
 
-                return _previousAnalysis is EmptyAnalysis || _isUserModule || _analysisVersion <= version;
+                if (ast == null) {
+                    Debug.Assert(!(_previousAnalysis is LibraryAnalysis), $"Library module {module.Name} of type {module.ModuleType} has been analyzed already!");
+                    return false;
+                }
+
+                return _previousAnalysis is EmptyAnalysis || _moduleType == ModuleType.User || _analysisVersion <= version;
             }
         }
 
@@ -118,6 +124,11 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
                 if (_analysisVersion > version) {
                     return;
+                }
+
+                if (analysis is LibraryAnalysis) {
+                    _ast = null;
+                    _parserDependencies = null;
                 }
 
                 _analysisDependencies = null;
@@ -209,20 +220,21 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        public bool Invalidate(IPythonModule module, int bufferVersion, int analysisVersion, out ImmutableArray<AnalysisModuleKey> dependencies) {
+        public bool Invalidate(IPythonModule module, PythonAst ast, int bufferVersion, int analysisVersion, out ImmutableArray<AnalysisModuleKey> dependencies) {
             dependencies = ImmutableArray<AnalysisModuleKey>.Empty;
             if (_bufferVersion >= bufferVersion) {
                 return false;
             }
 
-            var dependenciesHashSet = FindDependencies(module, bufferVersion);
+            var dependenciesHashSet = FindDependencies(module, ast, bufferVersion);
             lock (_syncObj) {
                 if (_analysisVersion >= analysisVersion && _bufferVersion >= bufferVersion) {
                     return false;
                 }
 
+                _ast = ast;
                 _module = module;
-                _isUserModule = module.ModuleType == ModuleType.User;
+                _moduleType = module.ModuleType;
                 _parserDependencies = dependenciesHashSet;
 
                 Interlocked.Exchange(ref _bufferVersion, bufferVersion);
@@ -234,13 +246,13 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        private HashSet<AnalysisModuleKey> FindDependencies(IPythonModule module,  int bufferVersion) {
+        private HashSet<AnalysisModuleKey> FindDependencies(IPythonModule module, PythonAst ast, int bufferVersion) {
             if (_bufferVersion > bufferVersion) {
                 return new HashSet<AnalysisModuleKey>();
             }
 
             var walker = new DependencyWalker(module);
-            module.GetAst().Walk(walker);
+            ast.Walk(walker);
             var dependencies = walker.Dependencies;
             dependencies.Remove(new AnalysisModuleKey(module));
             return dependencies;
@@ -285,8 +297,14 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
 
             public override bool Walk(ImportStatement import) {
+                var forceAbsolute = import.ForceAbsolute;
                 foreach (var moduleName in import.Names) {
-                    HandleSearchResults(_pathResolver.FindImports(_module.FilePath, moduleName, import.ForceAbsolute));
+                    var importNames = ImmutableArray<string>.Empty;
+                    foreach (var nameExpression in moduleName.Names) {
+                        importNames = importNames.Add(nameExpression.Name);
+                        var imports = _pathResolver.GetImportsFromAbsoluteName(_module.FilePath, importNames, forceAbsolute);
+                        HandleSearchResults(imports);
+                    }
                 }
 
                 return false;

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -19,13 +19,16 @@ using System.Linq;
 using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Dependencies;
 using Microsoft.Python.Analysis.Diagnostics;
+using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.Logging;
 using Microsoft.Python.Core.Services;
+using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     internal sealed class PythonAnalyzerSession {
@@ -146,9 +149,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 if (!isCanceled) {
                     _progress.ReportRemaining(remaining);
                     if (isFinal) {
-                        ActivityTracker.EndTracking();
-                        (_analyzer as PythonAnalyzer)?.RaiseAnalysisComplete(ActivityTracker.ModuleCount, ActivityTracker.MillisecondsElapsed);
-                        _log?.Log(TraceEventType.Verbose, $"Analysis complete: {ActivityTracker.ModuleCount} modules in { ActivityTracker.MillisecondsElapsed} ms.");
+                        var (modulesCount, totalMilliseconds) = ActivityTracker.EndTracking();
+                        (_analyzer as PythonAnalyzer)?.RaiseAnalysisComplete(modulesCount, totalMilliseconds);
+                        _log?.Log(TraceEventType.Verbose, $"Analysis complete: {modulesCount} modules in {totalMilliseconds} ms.");
                     }
                 }
             }
@@ -193,7 +196,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
                 if (isCanceled && !node.Value.NotAnalyzed) {
                     remaining++;
-                    node.Skip();
+                    node.MoveNext();
                     continue;
                 }
 
@@ -246,25 +249,23 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     }
 
                     _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) canceled.");
-                    node.Skip();
                     return;
                 }
 
                 var startTime = stopWatch.Elapsed;
-                AnalyzeEntry(entry, module, _walker.Version, node.IsComplete);
-                node.Commit();
-                ActivityTracker.OnModuleAnalysisComplete(node.Value.Module.FilePath);
+                AnalyzeEntry(node, entry, module, ast, _walker.Version);
 
-                LogCompleted(module, stopWatch, startTime);
+                LogCompleted(node, module, stopWatch, startTime);
             } catch (OperationCanceledException oce) {
                 node.Value.TryCancel(oce, _walker.Version);
-                node.Skip();
                 LogCanceled(node.Value.Module);
             } catch (Exception exception) {
                 node.Value.TrySetException(exception, _walker.Version);
-                node.Commit();
+                node.MarkWalked();
                 LogException(node.Value.Module, exception);
             } finally {
+                node.MoveNext();
+
                 bool isCanceled;
                 lock (_syncObj) {
                     isCanceled = _isCanceled;
@@ -293,9 +294,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
                 var startTime = stopWatch?.Elapsed ?? TimeSpan.Zero;
 
-                AnalyzeEntry(_entry, module, Version, true);
+                AnalyzeEntry(null, _entry, module, ast, Version);
 
-                LogCompleted(module, stopWatch, startTime);
+                LogCompleted(null, module, stopWatch, startTime);
             } catch (OperationCanceledException oce) {
                 _entry.TryCancel(oce, Version);
                 LogCanceled(_entry.Module);
@@ -308,7 +309,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        private void AnalyzeEntry(PythonAnalyzerEntry entry, IPythonModule module, int version, bool isFinalPass) {
+        private void AnalyzeEntry(IDependencyChainNode<PythonAnalyzerEntry> node, PythonAnalyzerEntry entry, IPythonModule module, PythonAst ast, int version) {
             if (entry.PreviousAnalysis is LibraryAnalysis) {
                 _log?.Log(TraceEventType.Verbose, $"Request to re-analyze finalized {module.Name}.");
             }
@@ -317,8 +318,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
             var analyzable = module as IAnalyzable;
             analyzable?.NotifyAnalysisBegins();
 
-            var ast = module.GetAst();
-            var walker = new ModuleWalker(_services, module);
+            var walker = new ModuleWalker(_services, module, ast);
             ast.Walk(walker);
 
             _analyzerCancellationToken.ThrowIfCancellationRequested();
@@ -326,7 +326,18 @@ namespace Microsoft.Python.Analysis.Analyzer {
             walker.Complete();
             _analyzerCancellationToken.ThrowIfCancellationRequested();
 
-            analyzable?.NotifyAnalysisComplete(version, walker, isFinalPass);
+            bool isCanceled;
+            lock (_syncObj) {
+                isCanceled = _isCanceled;
+            }
+
+            if (!isCanceled) {
+                node?.MarkWalked();
+            }
+
+            var analysis = CreateAnalysis(node, (IDocument)module, ast, version, walker, isCanceled);
+
+            analyzable?.NotifyAnalysisComplete(analysis);
             entry.TrySetAnalysis(module.Analysis, version);
 
             if (module.ModuleType == ModuleType.User) {
@@ -335,9 +346,13 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        private void LogCompleted(IPythonModule module, Stopwatch stopWatch, TimeSpan startTime) {
+        private void LogCompleted(IDependencyChainNode<PythonAnalyzerEntry> node, IPythonModule module, Stopwatch stopWatch, TimeSpan startTime) {
             if (_log != null) {
-                _log.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) completed in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms.");
+                var completed = node != null && module.Analysis is LibraryAnalysis ? "completed" : "completed for library";
+                var message = node != null
+                    ? $"Analysis of {module.Name}({module.ModuleType}) on depth {node.VertexDepth} {completed} in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms."
+                    : $"Out of order analysis of {module.Name}({module.ModuleType}) completed in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms.";
+                _log.Log(TraceEventType.Verbose, message);
             }
         }
 
@@ -351,6 +366,25 @@ namespace Microsoft.Python.Analysis.Analyzer {
             if (_log != null) {
                 _log.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) failed. Exception message: {exception.Message}.");
             }
+        }
+
+        private IDocumentAnalysis CreateAnalysis(IDependencyChainNode<PythonAnalyzerEntry> node, IDocument document, PythonAst ast, int version, ModuleWalker walker, bool isCanceled) {
+            var createLibraryAnalysis = !isCanceled &&
+                node != null &&
+                !node.HasMissingDependencies &&
+                document.ModuleType == ModuleType.Library &&
+                !document.IsOpen &&
+                node.HasOnlyWalkedDependencies &&
+                node.IsValidVersion;
+
+            if (!createLibraryAnalysis) {
+                return new DocumentAnalysis(document, version, walker.GlobalScope, walker.Eval, walker.StarImportMemberNames);
+            }
+
+            ast.Reduce(x => x is ImportStatement || x is FromImportStatement);
+            document.SetAst(ast);
+            var eval = new ExpressionEval(walker.Eval.Services, document, ast);
+            return new LibraryAnalysis(document, version, walker.GlobalScope, eval, walker.StarImportMemberNames);
         }
 
         private enum State {

--- a/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonInterpreter.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
             lock (_lock) {
                 var builtinModule = _moduleResolution.CreateBuiltinsModule();
                 _builtinTypes[BuiltinTypeId.NoneType]
-                    = new PythonType("NoneType", new Location(builtinModule, default), string.Empty, BuiltinTypeId.NoneType);
+                    = new PythonType("NoneType", new Location(builtinModule), string.Empty, BuiltinTypeId.NoneType);
                 _builtinTypes[BuiltinTypeId.Unknown]
-                    = UnknownType = new PythonType("Unknown", new Location(builtinModule, default), string.Empty);
+                    = UnknownType = new PythonType("Unknown", new Location(builtinModule), string.Empty);
             }
             await _moduleResolution.InitializeAsync(cancellationToken);
 

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
                     Eval.ReportDiagnostics(Module.Uri, new Diagnostics.DiagnosticsEntry(
                             Resources.ReturnInInit,
-                            node.GetLocation(Module).Span,
+                            node.GetLocation(Eval).Span,
                             ErrorCodes.ReturnInInit,
                             Severity.Warning,
                             DiagnosticSource.Analysis));

--- a/src/Analysis/Ast/Impl/Dependencies/DependencyVertex.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/DependencyVertex.cs
@@ -13,7 +13,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/src/Analysis/Ast/Impl/Dependencies/IDependencyChainNode.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/IDependencyChainNode.cs
@@ -18,12 +18,19 @@ namespace Microsoft.Python.Analysis.Dependencies {
         int VertexDepth { get; }
 
         /// <summary>
-        /// Shows if node has any direct or indirect dependencies that aren't added to the graph
+        /// Returns true if node has any direct or indirect dependencies that aren't added to the graph, otherwise false
         /// </summary>
         bool HasMissingDependencies { get; }
+        /// <summary>
+        /// Returns true if node has only direct and indirect dependencies that have been walked at least once, otherwise false
+        /// </summary>
+        bool HasOnlyWalkedDependencies { get; }
+        /// <summary>
+        /// Returns true if node version matches version of the walked graph
+        /// </summary>
+        bool IsValidVersion { get; }
         TValue Value { get; }
-        void Commit();
-        void Skip();
-        bool IsComplete { get; }
+        void MarkWalked();
+        void MoveNext();
     }
 }

--- a/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/IDependencyResolver.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Python.Analysis.Dependencies {
     /// concurrently.
     /// </summary>
     internal interface IDependencyResolver<TKey, TValue> {
-        int TryAddValue(TKey key, TValue value, bool isRoot, ImmutableArray<TKey> incomingKeys);
-        int ChangeValue(TKey key, TValue value, bool isRoot, ImmutableArray<TKey> incomingKeys);
-        int Remove(TKey key);
-        int RemoveKeys(ImmutableArray<TKey> keys);
+        int TryAddValue(in TKey key, in TValue value, in bool isRoot, in ImmutableArray<TKey> incomingKeys);
+        int ChangeValue(in TKey key, in TValue value, in bool isRoot, in ImmutableArray<TKey> incomingKeys);
+        int Remove(in TKey key);
+        int RemoveKeys(in ImmutableArray<TKey> keys);
 
         IDependencyChainWalker<TKey, TValue> CreateWalker();
-        bool TryCreateWalker(int version, int walkerDepthLimit, out IDependencyChainWalker<TKey, TValue> walker);
+        bool TryCreateWalker(in int version, in int walkerDepthLimit, out IDependencyChainWalker<TKey, TValue> walker);
     }
 }

--- a/src/Analysis/Ast/Impl/Documents/Definitions/IDocument.cs
+++ b/src/Analysis/Ast/Impl/Documents/Definitions/IDocument.cs
@@ -52,11 +52,6 @@ namespace Microsoft.Python.Analysis.Documents {
         Task<IDocumentAnalysis> GetAnalysisAsync(int waitTime = 200, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Returns last known document AST. The AST may be out of date or null.
-        /// </summary>
-        PythonAst GetAnyAst();
-
-        /// <summary>
         /// Returns last known document analysis. The analysis may be out of date.
         /// </summary>
         IDocumentAnalysis GetAnyAnalysis();

--- a/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Python.Analysis.Documents {
 
             if (justOpened) {
                 Opened?.Invoke(this, new DocumentEventArgs(document));
-                _services.GetService<IPythonAnalyzer>().InvalidateAnalysis(document);
             }
 
             return document;
@@ -248,8 +247,8 @@ namespace Microsoft.Python.Analysis.Documents {
 
         private bool TryOpenDocument(DocumentEntry entry, string content) {
             if (!entry.Document.IsOpen) {
-                entry.Document.Reset(content);
                 entry.Document.IsOpen = true;
+                entry.Document.Reset(content);
                 entry.LockCount++;
                 return true;
             }

--- a/src/Analysis/Ast/Impl/Extensions/NodeExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/NodeExtensions.cs
@@ -13,19 +13,32 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis {
     public static class NodeExtensions {
-        public static LocationInfo GetLocation(this Node node, IPythonModule module) {
+        public static LocationInfo GetLocation(this Node node, IExpressionEvaluator eval) {
             if (node == null || node.StartIndex >= node.EndIndex) {
                 return LocationInfo.Empty;
             }
 
-            var start = node.GetStart(module.GetAst());
-            var end = node.GetEnd(module.GetAst());
-            return new LocationInfo(module.FilePath, module.Uri, start.Line, start.Column, end.Line, end.Column);
+            return GetLocation(node, eval.Ast, eval.Module);
+        }
+
+        public static LocationInfo GetLocation(this Node node, IDocumentAnalysis analysis) {
+            if (node == null || node.StartIndex >= node.EndIndex) {
+                return LocationInfo.Empty;
+            }
+
+            return GetLocation(node, analysis.Ast, analysis.Document);
+        }
+
+        private static LocationInfo GetLocation(Node node, PythonAst ast, IPythonFile pythonFile) {
+            var start = node.GetStart(ast);
+            var end = node.GetEnd(ast);
+            return new LocationInfo(pythonFile.FilePath, pythonFile.Uri, start.Line, start.Column, end.Line, end.Column);
         }
 
         public static Expression RemoveParenthesis(this Expression e) {

--- a/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonClassExtensions.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Python.Analysis {
                     eval.LookupNameInScopes(name, out _, out var v, LookupOptions.Local);
                     v?.AddReference(location);
                 }
+            } else if (type is IPythonModule module && module.GlobalScope != null && module.GlobalScope.Variables.TryGetVariable(name, out var variable)) {
+                variable.AddReference(location);
             }
         }
 

--- a/src/Analysis/Ast/Impl/Extensions/PythonModuleExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonModuleExtensions.cs
@@ -20,10 +20,16 @@ using Microsoft.Python.Parsing.Ast;
 namespace Microsoft.Python.Analysis {
     public static class PythonModuleExtensions {
         internal static PythonAst GetAst(this IPythonModule module)
-            => ((IAstNodeContainer)module).GetAstNode<PythonAst>(module);
+            => (PythonAst)((IAstNodeContainer)module).GetAstNode(module);
+
+        internal static void SetAst(this IPythonModule module, PythonAst ast) {
+            var contained = (IAstNodeContainer)module;
+            contained.ClearContent();
+            contained.AddAstNode(module, ast);
+        }
 
         internal static T GetAstNode<T>(this IPythonModule module, object o) where T : Node
-            => ((IAstNodeContainer)module).GetAstNode<T>(o);
+            => (T)((IAstNodeContainer)module).GetAstNode(o);
         internal static void AddAstNode(this IPythonModule module, object o, Node n)
             => ((IAstNodeContainer)module).AddAstNode(o, n);
     }

--- a/src/Analysis/Ast/Impl/Linting/UndefinedVariables/ExpressionWalker.cs
+++ b/src/Analysis/Ast/Impl/Linting/UndefinedVariables/ExpressionWalker.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
             //    y = x
             //    x = 1
             var variableDefinitionSpan = v.Definition.Span;
-            var nameUseLocation = node.GetLocation(analysis.Document);
+            var nameUseLocation = node.GetLocation(analysis);
 
             // Make sure we are in the same scope in order to avoid
             //    def func():

--- a/src/Analysis/Ast/Impl/Modules/BuiltinsPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/BuiltinsPythonModule.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Python.Analysis.Modules {
 
             _hiddenNames.Add("__builtin_module_names__");
 
-            var location = new Location(this, default);
+            var location = new Location(this);
             if (_boolType != null) {
                 Analysis.GlobalScope.DeclareVariable("True", _boolType, VariableSource.Builtin, location);
                 Analysis.GlobalScope.DeclareVariable("False", _boolType, VariableSource.Builtin, location);

--- a/src/Analysis/Ast/Impl/Modules/Definitions/IAstNodeContainer.cs
+++ b/src/Analysis/Ast/Impl/Modules/Definitions/IAstNodeContainer.cs
@@ -24,17 +24,12 @@ namespace Microsoft.Python.Analysis.Modules {
         /// Nodes are not available for library modules as AST is not retained
         /// in libraries in order to conserve memory.
         /// </summary>
-        T GetAstNode<T>(object o) where T : Node;
+        Node GetAstNode(object o);
 
         /// <summary>
         /// Associated AST node with the object.
         /// </summary>
         void AddAstNode(object o, Node n);
-
-        /// <summary>
-        /// Removes all AST node associations.
-        /// </summary>
-        void ClearAst();
 
         void ClearContent();
     }

--- a/src/Analysis/Ast/Impl/Specializations/BuiltinsSpecializations.cs
+++ b/src/Analysis/Ast/Impl/Specializations/BuiltinsSpecializations.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Python.Analysis.Specializations {
         }
 
         public static IMember __iter__(IPythonInterpreter interpreter, BuiltinTypeId contentTypeId) {
-            var location = new Location(interpreter.ModuleResolution.BuiltinsModule, default);
+            var location = new Location(interpreter.ModuleResolution.BuiltinsModule);
             var fn = new PythonFunctionType(@"__iter__", location, null, string.Empty);
             var o = new PythonFunctionOverload(fn.Name, location);
             o.AddReturnValue(PythonTypeIterator.FromTypeId(interpreter, contentTypeId));

--- a/src/Analysis/Ast/Impl/Specializations/Typing/TypingModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Typing/TypingModule.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Python.Analysis.Specializations.Typing {
                 eval.ReportDiagnostics(
                     eval.Module?.Uri,
                     new DiagnosticsEntry(Resources.NewTypeFirstArgNotString.FormatInvariant(firstArgType), 
-                        expression?.GetLocation(eval.Module)?.Span ?? default, 
+                        expression?.GetLocation(eval)?.Span ?? default, 
                         Diagnostics.ErrorCodes.TypingNewTypeArguments,
                         Severity.Error, DiagnosticSource.Analysis)
                 );

--- a/src/Analysis/Ast/Impl/Specializations/Typing/TypingModule.cs
+++ b/src/Analysis/Ast/Impl/Specializations/Typing/TypingModule.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Python.Analysis.Specializations.Typing {
         #endregion
 
         private void SpecializeMembers() {
-            var location = new Location(this, default);
+            var location = new Location(this);
 
             // TypeVar
             var fn = PythonFunctionType.Specialize("TypeVar", this, GetMemberDocumentation("TypeVar"));

--- a/src/Analysis/Ast/Impl/Types/ArgumentSet.cs
+++ b/src/Analysis/Ast/Impl/Types/ArgumentSet.cs
@@ -19,7 +19,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Python.Analysis.Analyzer;
-using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Extensions;
 using Microsoft.Python.Analysis.Values;
@@ -82,8 +81,6 @@ namespace Microsoft.Python.Analysis.Types {
 
             _evaluated = true;
         }
-        public ArgumentSet(IPythonFunctionType fn, int overloadIndex, IPythonInstance instance, CallExpression callExpr, ExpressionEval eval) :
-            this(fn, overloadIndex, instance, callExpr, eval.Module, eval) { }
 
         /// <summary>
         /// Creates set of arguments for a function call based on the call expression
@@ -95,9 +92,8 @@ namespace Microsoft.Python.Analysis.Types {
         /// <param name="overloadIndex">Function overload to call.</param>
         /// <param name="instance">Type instance the function is bound to. For derived classes it is different from the declared type.</param>
         /// <param name="callExpr">Call expression that invokes the function.</param>
-        /// <param name="module">Module that contains the call expression.</param>
         /// <param name="eval">Evaluator that can calculate values of arguments from their respective expressions.</param>
-        public ArgumentSet(IPythonFunctionType fn, int overloadIndex, IPythonInstance instance, CallExpression callExpr, IPythonModule module, IExpressionEvaluator eval) {
+        public ArgumentSet(IPythonFunctionType fn, int overloadIndex, IPythonInstance instance, CallExpression callExpr, IExpressionEvaluator eval) {
             Eval = eval;
             OverloadIndex = overloadIndex;
             DeclaringModule = fn.DeclaringModule;
@@ -129,7 +125,7 @@ namespace Microsoft.Python.Analysis.Types {
                 return;
             }
 
-            var callLocation = callExpr.GetLocation(module);
+            var callLocation = callExpr.GetLocation(eval);
 
             // https://www.python.org/dev/peps/pep-3102/#id5
             // For each formal parameter, there is a slot which will be used to contain
@@ -180,7 +176,7 @@ namespace Microsoft.Python.Analysis.Types {
                     if (formalParamIndex >= overload.Parameters.Count) {
                         // We ran out of formal parameters and yet haven't seen
                         // any sequence or dictionary ones. This looks like an error.
-                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyFunctionArguments, arg.GetLocation(module).Span,
+                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyFunctionArguments, arg.GetLocation(eval).Span,
                             ErrorCodes.TooManyFunctionArguments, Severity.Warning, DiagnosticSource.Analysis));
                         return;
                     }
@@ -189,7 +185,7 @@ namespace Microsoft.Python.Analysis.Types {
                     if (formalParam.Kind == ParameterKind.List) {
                         if (string.IsNullOrEmpty(formalParam.Name)) {
                             // If the next unfilled slot is a vararg slot, and it does not have a name, then it is an error.
-                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyPositionalArgumentBeforeStar, arg.GetLocation(module).Span,
+                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyPositionalArgumentBeforeStar, arg.GetLocation(eval).Span,
                                 ErrorCodes.TooManyPositionalArgumentsBeforeStar, Severity.Warning, DiagnosticSource.Analysis));
                             return;
                         }
@@ -197,7 +193,7 @@ namespace Microsoft.Python.Analysis.Types {
                         // If the next unfilled slot is a vararg slot then all remaining
                         // non-keyword arguments are placed into the vararg slot.
                         if (_listArgument == null) {
-                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyFunctionArguments, arg.GetLocation(module).Span,
+                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyFunctionArguments, arg.GetLocation(eval).Span,
                                 ErrorCodes.TooManyFunctionArguments, Severity.Warning, DiagnosticSource.Analysis));
                             return;
                         }
@@ -217,7 +213,7 @@ namespace Microsoft.Python.Analysis.Types {
 
                     if (formalParam.Kind == ParameterKind.Dictionary) {
                         // Next slot is a dictionary slot, but we have positional arguments still.
-                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyPositionalArgumentBeforeStar, arg.GetLocation(module).Span,
+                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_TooManyPositionalArgumentBeforeStar, arg.GetLocation(eval).Span,
                             ErrorCodes.TooManyPositionalArgumentsBeforeStar, Severity.Warning, DiagnosticSource.Analysis));
                         return;
                     }
@@ -231,7 +227,7 @@ namespace Microsoft.Python.Analysis.Types {
                     var arg = callExpr.Args[callParamIndex];
 
                     if (string.IsNullOrEmpty(arg.Name)) {
-                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_PositionalArgumentAfterKeyword, arg.GetLocation(module).Span,
+                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_PositionalArgumentAfterKeyword, arg.GetLocation(eval).Span,
                             ErrorCodes.PositionalArgumentAfterKeyword, Severity.Warning, DiagnosticSource.Analysis));
                         return;
                     }
@@ -243,13 +239,13 @@ namespace Microsoft.Python.Analysis.Types {
                         // to the dictionary using the keyword name as the dictionary key,
                         // unless there is already an entry with that key, in which case it is an error.
                         if (_dictArgument == null) {
-                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_UnknownParameterName, arg.GetLocation(module).Span,
+                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_UnknownParameterName, arg.GetLocation(eval).Span,
                                 ErrorCodes.UnknownParameterName, Severity.Warning, DiagnosticSource.Analysis));
                             return;
                         }
 
                         if (_dictArgument.Arguments.ContainsKey(arg.Name)) {
-                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_ParameterAlreadySpecified.FormatUI(arg.Name), arg.GetLocation(module).Span,
+                            _errors.Add(new DiagnosticsEntry(Resources.Analysis_ParameterAlreadySpecified.FormatUI(arg.Name), arg.GetLocation(eval).Span,
                                 ErrorCodes.ParameterAlreadySpecified, Severity.Warning, DiagnosticSource.Analysis));
                             return;
                         }
@@ -260,7 +256,7 @@ namespace Microsoft.Python.Analysis.Types {
 
                     if (nvp.ValueExpression != null || nvp.Value != null) {
                         // Slot is already filled.
-                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_ParameterAlreadySpecified.FormatUI(arg.Name), arg.GetLocation(module).Span,
+                        _errors.Add(new DiagnosticsEntry(Resources.Analysis_ParameterAlreadySpecified.FormatUI(arg.Name), arg.GetLocation(eval).Span,
                             ErrorCodes.ParameterAlreadySpecified, Severity.Warning, DiagnosticSource.Analysis));
                         return;
                     }

--- a/src/Analysis/Ast/Impl/Types/LocatedMember.cs
+++ b/src/Analysis/Ast/Impl/Types/LocatedMember.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Python.Analysis.Types {
     internal abstract class LocatedMember : ILocatedMember {
         private HashSet<Location> _references;
 
-        protected LocatedMember(IPythonModule module) : this(new Location(module, default)) { }
+        protected LocatedMember(IPythonModule module) : this(new Location(module)) { }
 
         protected LocatedMember(Location location) {
             Location = location;

--- a/src/Analysis/Ast/Impl/Types/Location.cs
+++ b/src/Analysis/Ast/Impl/Types/Location.cs
@@ -17,7 +17,7 @@ using Microsoft.Python.Core.Text;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Types {
-    public struct Location {
+    public readonly struct Location {
         public Location(IPythonModule module) : this(module, default) { }
 
         public Location(IPythonModule module, IndexSpan indexSpan) {

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Python.Analysis.Types {
         /// Creates function for specializations
         /// </summary>
         public static PythonFunctionType Specialize(string name, IPythonModule declaringModule, string documentation)
-            => new PythonFunctionType(name, new Location(declaringModule, default), documentation, true);
+            => new PythonFunctionType(name, new Location(declaringModule), documentation, true);
 
         private PythonFunctionType(string name, Location location, string documentation, bool isSpecialized = false) :
             base(name, location, documentation ?? string.Empty, BuiltinTypeId.Function) {

--- a/src/Analysis/Ast/Impl/Values/GlobalScope.cs
+++ b/src/Analysis/Ast/Impl/Values/GlobalScope.cs
@@ -19,18 +19,21 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Values {
     internal sealed class GlobalScope: Scope, IGlobalScope {
-        public GlobalScope(IPythonModule module): base(null, null, module) {
+        private readonly PythonAst _ast;
+
+        public GlobalScope(IPythonModule module, PythonAst ast): base(null, null, module) {
+            _ast = ast;
             DeclareBuiltinVariables();
         }
 
-        public override ScopeStatement Node => Module.GetAst();
+        public override ScopeStatement Node => _ast;
 
         private void DeclareBuiltinVariables() {
             if (Module.ModuleType != ModuleType.User) {
                 return;
             }
 
-            var location = new Location(Module, default);
+            var location = new Location(Module);
 
             var boolType = Module.Interpreter.GetBuiltinType(BuiltinTypeId.Bool);
             var strType = Module.Interpreter.GetBuiltinType(BuiltinTypeId.Str);

--- a/src/Analysis/Ast/Impl/Values/Scope.cs
+++ b/src/Analysis/Ast/Impl/Values/Scope.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Python.Analysis.Values {
                 return;
             }
 
-            var location = new Location(Module, default);
+            var location = new Location(Module);
             var strType = Module.Interpreter.GetBuiltinType(BuiltinTypeId.Str);
             var objType = Module.Interpreter.GetBuiltinType(BuiltinTypeId.Object);
 

--- a/src/Analysis/Ast/Test/ArgumentSetTests.cs
+++ b/src/Analysis/Ast/Test/ArgumentSetTests.cs
@@ -370,14 +370,14 @@ def func(a = A()): ...
             var analysis = await GetAnalysisAsync(code);
             var f = analysis.Should().HaveFunction(funcName).Which;
             var call = GetCall(analysis.Ast);
-            return new ArgumentSet(f, 0, null, call, analysis.Document, analysis.ExpressionEvaluator);
+            return new ArgumentSet(f, 0, null, call, analysis.ExpressionEvaluator);
         }
 
         private async Task<ArgumentSet> GetUnboundArgSetAsync(string code, string funcName = "f") {
             var analysis = await GetAnalysisAsync(code);
             var f = analysis.Should().HaveVariable(funcName).Which;
             var call = GetCall(analysis.Ast);
-            return new ArgumentSet(f.Value.GetPythonType<IPythonFunctionType>(), 0, null, call, analysis.Document, analysis.ExpressionEvaluator);
+            return new ArgumentSet(f.Value.GetPythonType<IPythonFunctionType>(), 0, null, call, analysis.ExpressionEvaluator);
         }
 
         private async Task<ArgumentSet> GetClassArgSetAsync(string code, string className = "A", string funcName = "f") {
@@ -385,7 +385,7 @@ def func(a = A()): ...
             var cls = analysis.Should().HaveClass(className).Which;
             var f = cls.Should().HaveMethod(funcName).Which;
             var call = GetCall(analysis.Ast);
-            return new ArgumentSet(f, 0, new PythonInstance(cls), call, analysis.Document, analysis.ExpressionEvaluator);
+            return new ArgumentSet(f, 0, new PythonInstance(cls), call, analysis.ExpressionEvaluator);
         }
 
         private CallExpression GetCall(PythonAst ast) {

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Python.Analysis.Tests {
                 var o = interpreter.GetBuiltinType(BuiltinTypeId.Object);
                 var m = new SentinelModule("test", s);
 
-                var location = new Location(m, default);
+                var location = new Location(m);
                 var O = new PythonClassType("O", location);
                 var A = new PythonClassType("A", location);
                 var B = new PythonClassType("B", location);

--- a/src/Analysis/Ast/Test/DependencyResolverTests.cs
+++ b/src/Analysis/Ast/Test/DependencyResolverTests.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Python.Analysis.Tests {
         [DataRow("A:C|C:B|B:A|D:AF|F:CE|E:BD", "ABCABCDEFDEF", "F")]
         [DataRow("A:BC|B:AC|C:BA|D:BC", "ACBACBD", "D")]
         [DataRow("A|B|C|D:AB|E:BC", "[ABC][DE]", "D|E")]
-        [DataRow("A:CE|B:A|C:B|D:BC|E|F:C", "[CE]ABCAB[DF]", "F")]
-        [DataRow("A:D|B:E|C:F|D:E|E:F|F:D", "DFEDFE[ABC]", "A")]
+        [DataRow("A:CE|B:A|C:B|D:BC|E|F:C", "[CE]ABCAB[DF]", "D|F")]
+        [DataRow("A:D|B:E|C:F|D:E|E:F|F:D", "DFEDFE[ABC]", "A|B|C")]
         // ReSharper restore StringLiteralTypo
         [DataTestMethod]
         public void ChangeValue(string input, string output, string root) {
@@ -71,7 +71,8 @@ namespace Microsoft.Python.Analysis.Tests {
 
                     foreach (var task in tasks) {
                         result.Append(task.Result.Value[0]);
-                        task.Result.Commit();
+                        task.Result.MarkWalked();
+                        task.Result.MoveNext();
                     }
 
                     if (tasks.Count > 1) {
@@ -87,7 +88,7 @@ namespace Microsoft.Python.Analysis.Tests {
         }
         
         [TestMethod]
-        public async Task ChangeValue_RepeatedChange() {
+        public async Task ChangeValue_ChangeToIdentical() {
             var resolver = new DependencyResolver<string, string>();
             resolver.ChangeValue("A", "A:B", true, "B");
             resolver.ChangeValue("B", "B:C", false, "C");
@@ -98,7 +99,9 @@ namespace Microsoft.Python.Analysis.Tests {
             while (walker.Remaining > 0) {
                 var node = await walker.GetNextAsync(default);
                 result.Append(node.Value[0]);
-                node.Commit();
+                node.HasOnlyWalkedDependencies.Should().BeTrue();
+                node.MarkWalked();
+                node.MoveNext();
             }
 
             result.ToString().Should().Be("CBA");
@@ -110,14 +113,16 @@ namespace Microsoft.Python.Analysis.Tests {
             while (walker.Remaining > 0) {
                 var node = await walker.GetNextAsync(default);
                 result.Append(node.Value[0]);
-                node.Commit();
+                node.HasOnlyWalkedDependencies.Should().BeTrue();
+                node.MarkWalked();
+                node.MoveNext();
             }
 
             result.ToString().Should().Be("BA");
         }
 
         [TestMethod]
-        public async Task ChangeValue_RepeatedChange2() {
+        public async Task ChangeValue_TwoChanges() {
             var resolver = new DependencyResolver<string, string>();
             resolver.ChangeValue("A", "A:B", true, "B");
             resolver.ChangeValue("B", "B", true);
@@ -129,7 +134,9 @@ namespace Microsoft.Python.Analysis.Tests {
             while (walker.Remaining > 0) {
                 var node = await walker.GetNextAsync(default);
                 result.Append(node.Value[0]);
-                node.Commit();
+                node.HasOnlyWalkedDependencies.Should().BeTrue();
+                node.MarkWalked();
+                node.MoveNext();
             }
 
             result.ToString().Should().Be("BDAC");
@@ -142,7 +149,9 @@ namespace Microsoft.Python.Analysis.Tests {
             while (walker.Remaining > 0) {
                 var node = await walker.GetNextAsync(default);
                 result.Append(node.Value[0]);
-                node.Commit();
+                node.HasOnlyWalkedDependencies.Should().BeTrue();
+                node.MarkWalked();
+                node.MoveNext();
             }
 
             result.ToString().Should().Be("DCBA");
@@ -159,12 +168,16 @@ namespace Microsoft.Python.Analysis.Tests {
             var result = new StringBuilder();
             var node = await walker.GetNextAsync(default);
             result.Append(node.Value[0]);
-            node.Commit();
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default);
             result.Append(node.Value[0]);
-            node.Commit();
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             walker.MissingKeys.Should().Equal("D");
             result.ToString().Should().Be("BC");
 
@@ -189,10 +202,13 @@ namespace Microsoft.Python.Analysis.Tests {
             var node = await walker.GetNextAsync(default);
             node.Value.Should().Be("A:BD");
             node.HasMissingDependencies.Should().BeTrue();
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             walker.Remaining.Should().Be(0);
-            
+
+            // Add B
             resolver.ChangeValue("B", "B", false);
             walker = resolver.CreateWalker();       
             walker.MissingKeys.Should().Equal("D");
@@ -200,15 +216,20 @@ namespace Microsoft.Python.Analysis.Tests {
             node = await walker.GetNextAsync(default); 
             node.Value.Should().Be("B");
             node.HasMissingDependencies.Should().BeFalse();
-            node.Commit();                             
-                                                       
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default); 
             node.Value.Should().Be("A:BD");
             node.HasMissingDependencies.Should().BeTrue();
-            node.Commit();  
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             walker.Remaining.Should().Be(0); 
             
+            // Add D
             resolver.ChangeValue("D", "D:C", false, "C");
             walker = resolver.CreateWalker();       
             walker.MissingKeys.Should().BeEmpty();
@@ -216,18 +237,104 @@ namespace Microsoft.Python.Analysis.Tests {
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("C");
             node.HasMissingDependencies.Should().BeFalse();
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             node = await walker.GetNextAsync(default); 
             node.Value.Should().Be("D:C");
             node.HasMissingDependencies.Should().BeFalse();
-            node.Commit();                             
-                                                       
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default); 
             node.Value.Should().Be("A:BD");
             node.HasMissingDependencies.Should().BeFalse();
-            node.Commit();  
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            walker.Remaining.Should().Be(0);
+        }
+
+        [TestMethod]
+        public async Task ChangeValue_Add_ParallelWalkers() {
+            var resolver = new DependencyResolver<string, string>();
+            resolver.ChangeValue("A", "A:BD", true, "B", "D");
+            resolver.ChangeValue("B", "B:C", false, "C");
+            resolver.ChangeValue("C", "C", false);
+
+            var walker = resolver.CreateWalker();
+            walker.MissingKeys.Should().Equal("D");
+
+            var node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("C");
+            node.HasMissingDependencies.Should().BeFalse();
+            node.IsValidVersion.Should().BeTrue();
+
+            // Add D
+            resolver.ChangeValue("D", "D:C", false, "C");
+            var newWalker = resolver.CreateWalker();
+            newWalker.MissingKeys.Should().BeEmpty();
+
+            // MarkWalked node from old walker
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeFalse();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("B:C");
+            node.HasMissingDependencies.Should().BeFalse();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeFalse();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("A:BD");
+            node.HasMissingDependencies.Should().BeTrue();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeFalse();
+            node.MarkWalked();
+            node.MoveNext();
+
+            walker.Remaining.Should().Be(0);
+
+            // Walk new walker
+            node = await newWalker.GetNextAsync(default);
+            node.Value.Should().Be("C");
+            node.HasMissingDependencies.Should().BeFalse();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await newWalker.GetNextAsync(default);
+            node.Value.Should().Be("B:C");
+            node.HasMissingDependencies.Should().BeFalse();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await newWalker.GetNextAsync(default);
+            node.Value.Should().Be("D:C");
+            node.HasMissingDependencies.Should().BeFalse();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await newWalker.GetNextAsync(default);
+            node.Value.Should().Be("A:BD");
+            node.HasMissingDependencies.Should().BeFalse();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.IsValidVersion.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             walker.Remaining.Should().Be(0);
         }
 
@@ -242,15 +349,21 @@ namespace Microsoft.Python.Analysis.Tests {
             walker.MissingKeys.Should().BeEmpty();
             var node = await walker.GetNextAsync(default);
             node.Value.Should().Be("C");
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("B:C");
-            node.Commit();
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("A:BC");
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             resolver.Remove("B");
             walker = resolver.CreateWalker();
@@ -258,7 +371,106 @@ namespace Microsoft.Python.Analysis.Tests {
 
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("A:BC");
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            walker.Remaining.Should().Be(0);
+        }
+
+        [TestMethod]
+        public async Task ChangeValue_ChangeChangeRemove() {
+            var resolver = new DependencyResolver<string, string>();
+            resolver.ChangeValue("A", "A:B", true, "B");
+            resolver.ChangeValue("B", "B:C", true, "C");
+            resolver.ChangeValue("C", "C:AD", true, "A", "D");
+
+            var walker = resolver.CreateWalker();
+            walker.MissingKeys.Should().Equal("D");
+            walker.AffectedValues.Should().Equal("A:B", "B:C", "C:AD");
+            walker.Remaining.Should().Be(6);
+
+            //resolver.ChangeValue("D", "D:B", true, "B");
+            resolver.ChangeValue("A", "A", true);
+            resolver.ChangeValue("B", "B", true);
+            resolver.Remove("B");
+
+            walker = resolver.CreateWalker();
+            walker.MissingKeys.Should().Equal("D");
+            walker.Remaining.Should().Be(2);
+
+            var node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("A");
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("C:AD");
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            walker.Remaining.Should().Be(0);
+        }
+
+        [TestMethod]
+        public async Task ChangeValue_RemoveFromLoop() {
+            var resolver = new DependencyResolver<string, string>();
+            resolver.ChangeValue("A", "A:B", true, "B");
+            resolver.ChangeValue("B", "B:C", false, "C");
+            resolver.ChangeValue("C", "C:A", false, "A");
+
+            var walker = resolver.CreateWalker();
+            walker.MissingKeys.Should().BeEmpty();
+
+            var node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("A:B");
+            node.HasOnlyWalkedDependencies.Should().BeFalse();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("C:A");
+            node.HasOnlyWalkedDependencies.Should().BeFalse();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("B:C");
+            node.HasOnlyWalkedDependencies.Should().BeFalse();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("A:B");
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("C:A");
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("B:C");
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
+            walker.Remaining.Should().Be(0);
+
+            resolver.Remove("B");
+            walker = resolver.CreateWalker();
+            walker.MissingKeys.Should().Equal("B");
+
+            node = await walker.GetNextAsync(default);
+            node.Value.Should().Be("A:B");
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             walker.Remaining.Should().Be(0);
         }
@@ -275,19 +487,27 @@ namespace Microsoft.Python.Analysis.Tests {
             walker.MissingKeys.Should().BeEmpty();
             var node = await walker.GetNextAsync(default);
             node.Value.Should().Be("D");
-            node.Commit();
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("C:D");
-            node.Commit();
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("B:C");
-            node.Commit();
-            
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
+
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("A:BC");
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             resolver.RemoveKeys("B", "D");
             walker = resolver.CreateWalker();
@@ -295,11 +515,15 @@ namespace Microsoft.Python.Analysis.Tests {
 
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("C:D");
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             node = await walker.GetNextAsync(default);
             node.Value.Should().Be("A:BC");
-            node.Commit();
+            node.HasOnlyWalkedDependencies.Should().BeTrue();
+            node.MarkWalked();
+            node.MoveNext();
 
             walker.Remaining.Should().Be(0);
         }
@@ -316,11 +540,11 @@ namespace Microsoft.Python.Analysis.Tests {
             var result = new StringBuilder();
             var node = await walker.GetNextAsync(default);
             result.Append(node.Value[0]);
-            node.Skip();
+            node.MoveNext();
             
             node = await walker.GetNextAsync(default);
             result.Append(node.Value[0]);
-            node.Skip();
+            node.MoveNext();
             
             result.ToString().Should().Be("BD");
 

--- a/src/Analysis/Core/Impl/DependencyResolution/AstUtilities.cs
+++ b/src/Analysis/Core/Impl/DependencyResolution/AstUtilities.cs
@@ -18,9 +18,6 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Core.DependencyResolution {
     public static class AstUtilities {
-        public static IImportSearchResult FindImports(this PathResolverSnapshot pathResolver, string modulePath, ModuleName importName, bool forceAbsolute) 
-            => pathResolver.GetImportsFromAbsoluteName(modulePath, importName.Names.Select(n => n.Name), forceAbsolute);
-
         public static IImportSearchResult FindImports(this PathResolverSnapshot pathResolver, string modulePath, FromImportStatement fromImportStatement) {
             var rootNames = fromImportStatement.Root.Names.Select(n => n.Name);
             return fromImportStatement.Root is RelativeModuleName relativeName

--- a/src/LanguageServer/Impl/Implementation/Server.Symbols.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Symbols.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             var path = @params.textDocument.uri.AbsolutePath;
             var symbols = await _indexManager.HierarchicalDocumentSymbolsAsync(path, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            return symbols.Select(hSym => MakeDocumentSymbol(hSym)).ToArray();
+            return symbols.Select(MakeDocumentSymbol).ToArray();
         }
 
         private static SymbolInformation MakeSymbolInfo(FlatSymbol s) {

--- a/src/LanguageServer/Impl/Indexing/MostRecentDocumentSymbols.cs
+++ b/src/LanguageServer/Impl/Indexing/MostRecentDocumentSymbols.cs
@@ -119,8 +119,7 @@ namespace Microsoft.Python.LanguageServer.Indexing {
             }
         }
 
-        private async Task<IReadOnlyList<HierarchicalSymbol>> IndexAsync(IDocument doc,
-            CancellationToken indexCt) {
+        private async Task<IReadOnlyList<HierarchicalSymbol>> IndexAsync(IDocument doc, CancellationToken indexCt) {
             var ast = await doc.GetAstAsync(indexCt);
             indexCt.ThrowIfCancellationRequested();
             var walker = new SymbolIndexWalker(ast);

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 return item.Task;
             }
 
-            private struct QueueItem {
+            private readonly struct QueueItem {
                 private readonly TaskCompletionSource<IDisposable> _tcs;
                 public Task<IDisposable> Task => _tcs.Task;
                 public bool IsAwaitable { get; }

--- a/src/LanguageServer/Test/ImportsTests.cs
+++ b/src/LanguageServer/Test/ImportsTests.cs
@@ -229,8 +229,8 @@ module2.";
 
         [TestMethod, Priority(0)]
         public async Task UserSearchPathsInsideWorkspace() {
-            var folder1 = TestData.GetTestSpecificPath("folder1");
-            var folder2 = TestData.GetTestSpecificPath("folder2");
+            var folder2 = TestData.GetTestSpecificPath("src");
+            var folder1 = TestData.GetTestSpecificPath("src", "virtualenv");
             var packageInFolder1 = Path.Combine(folder1, "package");
             var packageInFolder2 = Path.Combine(folder2, "package");
             var module1Path = Path.Combine(packageInFolder1, "module1.py");


### PR DESCRIPTION
- Fixes #1151: Reliable way to determine final analysis of a module
- Fixes #1201: NRE in SymbolCollector.AddProperty
- Fixes #1228: NRE in TryFindMissingDependencies
- Fixes #1294: Handle valid case for reloading AST
- Fixes #1295: FindReferences doesn't work on package init members
- Fixes #1296: DependencyResolver graph misses intermediate imports
- Part of the fix for #1174: All references are not listed when using ms language server (bug isn't fully fixed).
