### PR TITLE
Adding diagnostic message when using duplicate arguments in function …

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         private void ValidateParameters(FunctionDefinition fd) {
             var duplicates = fd.Parameters.Where(p => !string.IsNullOrEmpty(p.Name)).GroupBy(p => p.Name).Where(g => g.Count() > 1).Select(y => y.Key);
 
-            foreach(var paramName in duplicates) {
+            foreach (var paramName in duplicates) {
                 ReportDiagnostics(Module.Uri, new DiagnosticsEntry(
                     Resources.DuplicateArgumentName.FormatInvariant(paramName),
                     GetLocation(fd.NameExpression).Span,

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         }
 
         private void ValidateParameters(FunctionDefinition fd) {
-            var duplicates = fd.Parameters.GroupBy(p => p.Name).Where(g => g.Count() > 1 && !string.IsNullOrEmpty(g.Key)).Select(y => y.Key);
+            var duplicates = fd.Parameters.Where(p => !string.IsNullOrEmpty(p.Name)).GroupBy(p => p.Name).Where(g => g.Count() > 1).Select(y => y.Key);
 
             foreach(var paramName in duplicates) {
                 ReportDiagnostics(Module.Uri, new DiagnosticsEntry(

--- a/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Python.Analysis.Diagnostics {
         public const string UnsupportedOperandType = "unsupported-operand-type";
         public const string ReturnInInit = "return-in-init";
         public const string TypingGenericArguments = "typing-generic-arguments";
+        public const string DuplicateArgumentName = "duplicate-argument-name";
     }
 }

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Duplicate argument name &apos;{0}&apos; in function definition..
+        /// </summary>
+        internal static string DuplicateArgumentName {
+            get {
+                return ResourceManager.GetString("DuplicateArgumentName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Environment variable &apos;{0}&apos; is not set, using the default cache location instead..
         /// </summary>
         internal static string EnvVariableNotSet {

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -201,4 +201,7 @@
   <data name="GenericNotAllUnique" xml:space="preserve">
     <value>Arguments to Generic must all be unique.</value>
   </data>
+  <data name="DuplicateArgumentName" xml:space="preserve">
+    <value>Duplicate argument name '{0}' in function definition.</value>
+  </data>
 </root>

--- a/src/Analysis/Ast/Test/LintDuplicateArgumentTests.cs
+++ b/src/Analysis/Ast/Test/LintDuplicateArgumentTests.cs
@@ -1,0 +1,164 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Python.Analysis.Tests.FluentAssertions;
+using Microsoft.Python.Core;
+using Microsoft.Python.Parsing.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+
+namespace Microsoft.Python.Analysis.Tests {
+
+    [TestClass]
+    public class LintDuplicateArgumentTests : AnalysisTestBase {
+
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateArgsInFunc() {
+            const string code = @"
+def test(a, a, b):
+    pass
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateArgsInNestedFunc() {
+            const string code = @"
+def test(a, a, b):
+    print('hi')
+    def test2(c, c, e):
+        pass
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(2);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+
+            diagnostic = analysis.Diagnostics.ElementAt(1);
+            diagnostic.SourceSpan.Should().Be(4, 9, 4, 14);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("c"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateNamedArgs() {
+            const string code = @"
+def test(a=1, a=2):
+    print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateNamedAndKeywordArgs() {
+            const string code = @"
+def test(a=1, **a):
+    print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateListAndKeywordArgs() {
+            const string code = @"
+def test(*a, **a):
+    print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateNamedAndListAndKeywordArgs() {
+            const string code = @"
+def test(a=1, *a, **a):
+    print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateNamedAndUnnamedArgs() {
+            const string code = @"
+def test(a, a=2):
+    print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(2, 5, 2, 9);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task DuplicateArgsInClassFunc() {
+            const string code = @"
+class Test: 
+    def test(a, a, b):
+        print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.SourceSpan.Should().Be(3, 9, 3, 13);
+            diagnostic.ErrorCode.Should().Be(Diagnostics.ErrorCodes.DuplicateArgumentName);
+            diagnostic.Message.Should().Be(Resources.DuplicateArgumentName.FormatInvariant("a"));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task NormalFuncDefinition() {
+            const string code = @"
+class Test: 
+    def test(a, b, c=1, *args, **kwargs):
+        print('hi')
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(0);
+        }
+    }
+}


### PR DESCRIPTION
…definition.

```
def test(a, a=1, *a, **a):
  pass
```

The above code gives a syntax error. Same as pylint duplicate-argument-name (E0108). 