### PR TITLE
No diagnostic message when Generic is called with no args

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -125,7 +125,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 }
             } else {
                 var index = GetValueFromExpression(expr.Index);
-                indices.Add(index ?? UnknownType);
+                // Don't count null indexes as arguments
+                if(index != null) {
+                    indices.Add(index);
+                }
             }
             return indices;
         }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             } else {
                 var index = GetValueFromExpression(expr.Index);
                 // Don't count null indexes as arguments
-                if(index != null) {
+                if (index != null) {
                     indices.Add(index);
                 }
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -184,6 +184,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 case NamedExpression namedExpr:
                     m = GetValueFromExpression(namedExpr.Value);
                     break;
+                // indexing with nothing, e.g Generic[]
+                case ErrorExpression error:
+                    m = null;
+                    break;
                 default:
                     m = GetValueFromBinaryOp(expr) ?? GetConstantFromLiteral(expr, options);
                     break;

--- a/src/Analysis/Ast/Test/LintGenericTests.cs
+++ b/src/Analysis/Ast/Test/LintGenericTests.cs
@@ -80,7 +80,26 @@ _T = _X
         public async Task GenericArgumentsNoDiagnosticOnValid(string decl) {
             string code = GenericSetup + decl;
             var analysis = await GetAnalysisAsync(code);
-            analysis.Diagnostics.Should().HaveCount(0);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task GenericNoArgumentsNoDiagnostic() {
+            string code = GenericSetup + @"
+x = Generic[]
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+
+        [TestMethod, Priority(0)]
+        public async Task GenericArgumentSpaceNoDiagnostic() {
+            string code = GenericSetup + @"
+x = Generic[  ]
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
         }
     }
 }


### PR DESCRIPTION
This is a fix for the issue I talked about in our meeting. The issue was that when in an index expression, if you do:
```
A = [1,2,3]

A[]
```

We would get an error expression for the inside part, but we would fall into the default case in evaluating it and return Unknown type for the arguments when there are actually no arguments and we should (in my opinion) return null.