### PR TITLE
Adding diagnostic when doing comparisons with callables

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -123,9 +123,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 ReportDiagnostics(
                     Module.Uri,
                     new DiagnosticsEntry(
-                        Resources.ComparisonWithCallable,
+                        Resources.FunctionComparison,
                         GetLocation(expr).Span,
-                        ErrorCodes.ComparisonWithCallable,
+                        ErrorCodes.FunctionComparison,
                         Severity.Warning,
                         DiagnosticSource.Analysis
                 ));

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return Interpreter.GetBuiltinType(leftTypeId);
             }
 
-            if ((left is PythonFunctionType || right is PythonFunctionType) && op.IsComparison()) {
+            if ((left is IPythonFunctionType || right is IPythonFunctionType) && op.IsComparison()) {
                 ReportDiagnostics(
                     Module.Uri,
                     new DiagnosticsEntry(

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Operators.cs
@@ -119,6 +119,18 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return Interpreter.GetBuiltinType(leftTypeId);
             }
 
+            if ((left is PythonFunctionType || right is PythonFunctionType) && op.IsComparison()) {
+                ReportDiagnostics(
+                    Module.Uri,
+                    new DiagnosticsEntry(
+                        Resources.ComparisonWithCallable,
+                        GetLocation(expr).Span,
+                        ErrorCodes.ComparisonWithCallable,
+                        Severity.Warning,
+                        DiagnosticSource.Analysis
+                ));
+            }
+
             var leftIsSupported = IsSupportedBinopBuiltin(leftTypeId);
             var rightIsSupported = IsSupportedBinopBuiltin(rightTypeId);
 

--- a/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Python.Analysis.Diagnostics {
         public const string ReturnInInit = "return-in-init";
         public const string TypingNewTypeArguments = "typing-newtype-arguments";
         public const string TypingGenericArguments = "typing-generic-arguments";
-    }
-}
+        public const string ComparisonWithCallable = "comparison-with-callable";
+    } }

--- a/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
@@ -23,11 +23,12 @@ namespace Microsoft.Python.Analysis.Diagnostics {
         public const string ParameterMissing = "parameter-missing";
         public const string UnresolvedImport = "unresolved-import";
         public const string UndefinedVariable = "undefined-variable";
-        public const string VariableNotDefinedGlobally= "variable-not-defined-globally";
+        public const string VariableNotDefinedGlobally = "variable-not-defined-globally";
         public const string VariableNotDefinedNonLocal = "variable-not-defined-nonlocal";
         public const string UnsupportedOperandType = "unsupported-operand-type";
         public const string ReturnInInit = "return-in-init";
         public const string TypingNewTypeArguments = "typing-newtype-arguments";
         public const string TypingGenericArguments = "typing-generic-arguments";
-        public const string ComparisonWithCallable = "comparison-with-callable";
-    } }
+        public const string FunctionComparison = "function-comparison";
+    }
+}

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comparing against a callable, did you omit the parenthesis?.
+        /// </summary>
+        internal static string ComparisonWithCallable {
+            get {
+                return ResourceManager.GetString("ComparisonWithCallable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Environment variable &apos;{0}&apos; is not set, using the default cache location instead..
         /// </summary>
         internal static string EnvVariableNotSet {

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -133,15 +133,6 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comparing against a callable, did you omit the parenthesis?.
-        /// </summary>
-        internal static string ComparisonWithCallable {
-            get {
-                return ResourceManager.GetString("ComparisonWithCallable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Environment variable &apos;{0}&apos; is not set, using the default cache location instead..
         /// </summary>
         internal static string EnvVariableNotSet {
@@ -228,6 +219,15 @@ namespace Microsoft.Python.Analysis {
         internal static string ExceptionGettingSearchPaths {
             get {
                 return ResourceManager.GetString("ExceptionGettingSearchPaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Functions are not comparable..
+        /// </summary>
+        internal static string FunctionComparison {
+            get {
+                return ResourceManager.GetString("FunctionComparison", resourceCulture);
             }
         }
         

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -204,4 +204,7 @@
   <data name="GenericNotAllUnique" xml:space="preserve">
     <value>Arguments to Generic must all be unique.</value>
   </data>
+  <data name="ComparisonWithCallable" xml:space="preserve">
+    <value>Comparing against a callable, did you omit the parenthesis?</value>
+  </data>
 </root>

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -204,7 +204,7 @@
   <data name="GenericNotAllUnique" xml:space="preserve">
     <value>Arguments to Generic must all be unique.</value>
   </data>
-  <data name="ComparisonWithCallable" xml:space="preserve">
-    <value>Comparing against a callable, did you omit the parenthesis?</value>
+  <data name="FunctionComparison" xml:space="preserve">
+    <value>Functions are not comparable.</value>
   </data>
 </root>

--- a/src/Analysis/Ast/Test/LintOperatorTests.cs
+++ b/src/Analysis/Ast/Test/LintOperatorTests.cs
@@ -110,7 +110,7 @@ def test():
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
             diagnostic.Severity.Should().Be(Severity.Warning);
-            diagnostic.ErrorCode.Should().Be(ErrorCodes.ComparisonWithCallable);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionComparison);
             diagnostic.Message.Should().Be(Resources.ComparisonWithCallable);
             diagnostic.SourceSpan.Should().Be(7, 5, 7, decl.Length + 1);
         }
@@ -155,7 +155,7 @@ x = C.hello < 5
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
             diagnostic.Severity.Should().Be(Severity.Warning);
-            diagnostic.ErrorCode.Should().Be(ErrorCodes.ComparisonWithCallable);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionComparison);
             diagnostic.Message.Should().Be(Resources.ComparisonWithCallable);
             diagnostic.SourceSpan.Should().Be(8, 5, 8, 16);
         }

--- a/src/Analysis/Ast/Test/LintOperatorTests.cs
+++ b/src/Analysis/Ast/Test/LintOperatorTests.cs
@@ -111,7 +111,7 @@ def test():
             var diagnostic = analysis.Diagnostics.ElementAt(0);
             diagnostic.Severity.Should().Be(Severity.Warning);
             diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionComparison);
-            diagnostic.Message.Should().Be(Resources.ComparisonWithCallable);
+            diagnostic.Message.Should().Be(Resources.FunctionComparison);
             diagnostic.SourceSpan.Should().Be(7, 5, 7, decl.Length + 1);
         }
 
@@ -156,7 +156,7 @@ x = C.hello < 5
             var diagnostic = analysis.Diagnostics.ElementAt(0);
             diagnostic.Severity.Should().Be(Severity.Warning);
             diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionComparison);
-            diagnostic.Message.Should().Be(Resources.ComparisonWithCallable);
+            diagnostic.Message.Should().Be(Resources.FunctionComparison);
             diagnostic.SourceSpan.Should().Be(8, 5, 8, 16);
         }
 


### PR DESCRIPTION
Same as pylint comparison-with-callables. It's a warning that shows up when you do:

```
def test():
  pass

x = 5 < test
```

Doing ```test``` instead of ```test()```