### PR TITLE
Bug and test fixes

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                 // TODO: warn this is not a good style per
                 // TODO: https://docs.python.org/3/faq/programming.html#what-are-the-best-practices-for-using-import-in-a-module
                 // TODO: warn this is invalid if not in the global scope.
-                HandleModuleImportStar(variableModule);
+                HandleModuleImportStar(variableModule, imports is ImplicitPackageImport);
                 return;
             }
 
@@ -75,14 +75,16 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             }
         }
 
-        private void HandleModuleImportStar(PythonVariableModule variableModule) {
+        private void HandleModuleImportStar(PythonVariableModule variableModule, bool isImplicitPackage) {
             if (variableModule.Module == Module) {
                 // from self import * won't define any new members
                 return;
             }
 
             // If __all__ is present, take it, otherwise declare all members from the module that do not begin with an underscore.
-            var memberNames = variableModule.Analysis?.StarImportMemberNames ?? variableModule.GetMemberNames().Where(s => !s.StartsWithOrdinal("_"));
+            var memberNames = isImplicitPackage 
+                ? variableModule.GetMemberNames()
+                : variableModule.Analysis.StarImportMemberNames ?? variableModule.GetMemberNames().Where(s => !s.StartsWithOrdinal("_"));
 
             foreach (var memberName in memberNames) {
                 var member = variableModule.GetMember(memberName);

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/FromImportHandler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             }
 
             // If __all__ is present, take it, otherwise declare all members from the module that do not begin with an underscore.
-            var memberNames = variableModule.Analysis.StarImportMemberNames ?? variableModule.GetMemberNames().Where(s => !s.StartsWithOrdinal("_"));
+            var memberNames = variableModule.Analysis?.StarImportMemberNames ?? variableModule.GetMemberNames().Where(s => !s.StartsWithOrdinal("_"));
 
             foreach (var memberName in memberNames) {
                 var member = variableModule.GetMember(memberName);

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
         private void LogCompleted(IDependencyChainNode<PythonAnalyzerEntry> node, IPythonModule module, Stopwatch stopWatch, TimeSpan startTime) {
             if (_log != null) {
-                var completed = node != null && module.Analysis is LibraryAnalysis ? "completed" : "completed for library";
+                var completed = node != null && module.Analysis is LibraryAnalysis ? "completed for library" : "completed ";
                 var message = node != null
                     ? $"Analysis of {module.Name}({module.ModuleType}) on depth {node.VertexDepth} {completed} in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms."
                     : $"Out of order analysis of {module.Name}({module.ModuleType}) completed in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms.";

--- a/src/Analysis/Ast/Impl/Modules/Definitions/IModuleManagement.cs
+++ b/src/Analysis/Ast/Impl/Modules/Definitions/IModuleManagement.cs
@@ -42,12 +42,6 @@ namespace Microsoft.Python.Analysis.Modules {
         bool TryAddModulePath(in string path, in bool allowNonRooted, out string fullName);
 
         /// <summary>
-        /// Sets user search paths. This changes <see cref="IModuleResolution.CurrentPathResolver"/>.
-        /// </summary>
-        /// <returns>Added roots.</returns>
-        IEnumerable<string> SetUserSearchPaths(in IEnumerable<string> searchPaths);
-
-        /// <summary>
         /// Provides ability to specialize module by replacing module import by
         /// <see cref="IPythonModule"/> implementation in code. Real module
         /// content is loaded and analyzed only for class/functions definitions

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -55,7 +55,11 @@ namespace Microsoft.Python.Analysis.Modules {
 
         private readonly DocumentBuffer _buffer = new DocumentBuffer();
         private readonly DisposeToken _disposeToken = DisposeToken.Create<PythonModule>();
+<<<<<<< HEAD
         private readonly object _syncObj = new object();
+=======
+        private readonly object _analysisLock = new object();
+>>>>>>> Multiple analysis fixes.
         private IReadOnlyList<DiagnosticsEntry> _parseErrors = Array.Empty<DiagnosticsEntry>();
         private readonly Dictionary<object, Node> _astMap = new Dictionary<object, Node>();
         private readonly IDiagnosticsService _diagnosticsService;
@@ -252,7 +256,11 @@ namespace Microsoft.Python.Analysis.Modules {
         public async Task<PythonAst> GetAstAsync(CancellationToken cancellationToken = default) {
             Task t = null;
             while (true) {
+<<<<<<< HEAD
                 lock (_syncObj) {
+=======
+                lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                     if (t == _parsingTask) {
                         break;
                     }
@@ -276,7 +284,11 @@ namespace Microsoft.Python.Analysis.Modules {
         public IEnumerable<DiagnosticsEntry> GetParseErrors() => _parseErrors.ToArray();
 
         public void Update(IEnumerable<DocumentChange> changes) {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 _parseCts?.Cancel();
                 _parseCts = new CancellationTokenSource();
 
@@ -293,7 +305,11 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         public void Reset(string content) {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 if (content != Content) {
                     ContentState = State.None;
                     InitializeContent(content, _buffer.Version + 1);
@@ -321,7 +337,11 @@ namespace Microsoft.Python.Analysis.Modules {
 
             //Log?.Log(TraceEventType.Verbose, $"Parse begins: {Name}");
 
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 version = _buffer.Version;
                 var options = new ParserOptions {
                     StubFile = FilePath != null && Path.GetExtension(FilePath).Equals(".pyi", FileSystem.StringComparison)
@@ -337,7 +357,11 @@ namespace Microsoft.Python.Analysis.Modules {
 
             //Log?.Log(TraceEventType.Verbose, $"Parse complete: {Name}");
 
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 cancellationToken.ThrowIfCancellationRequested();
                 if (version != _buffer.Version) {
                     throw new OperationCanceledException();
@@ -367,7 +391,11 @@ namespace Microsoft.Python.Analysis.Modules {
                 analyzer.EnqueueDocumentForAnalysis(this, ast, version);
             }
 
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 _parsingTask = null;
             }
         }
@@ -384,7 +412,11 @@ namespace Microsoft.Python.Analysis.Modules {
         #region IAnalyzable
 
         public void NotifyAnalysisBegins() {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 if (_updated) {
                     _updated = false;
                     // In all variables find those imported, then traverse imported modules
@@ -412,7 +444,11 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         public void NotifyAnalysisComplete(IDocumentAnalysis analysis) {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 if (analysis.Version < Analysis.Version) {
                     return;
                 }
@@ -448,20 +484,32 @@ namespace Microsoft.Python.Analysis.Modules {
 
         #region IAstNodeContainer
         public Node GetAstNode(object o) {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 return _astMap.TryGetValue(o, out var n) ? n : null;
             }
         }
 
         public void AddAstNode(object o, Node n) {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 Debug.Assert(!_astMap.ContainsKey(o) || _astMap[o] == n);
                 _astMap[o] = n;
             }
         }
 
         public void ClearContent() {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 if (ModuleType != ModuleType.User) {
                     _buffer.Reset(_buffer.Version, string.Empty);
                     _astMap.Clear();
@@ -492,7 +540,11 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         private void InitializeContent(string content, int version) {
+<<<<<<< HEAD
             lock (_syncObj) {
+=======
+            lock (_analysisLock) {
+>>>>>>> Multiple analysis fixes.
                 LoadContent(content, version);
 
                 var startParse = ContentState < State.Parsing && (_parsingTask == null || version > 0);

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -55,11 +55,7 @@ namespace Microsoft.Python.Analysis.Modules {
 
         private readonly DocumentBuffer _buffer = new DocumentBuffer();
         private readonly DisposeToken _disposeToken = DisposeToken.Create<PythonModule>();
-<<<<<<< HEAD
         private readonly object _syncObj = new object();
-=======
-        private readonly object _analysisLock = new object();
->>>>>>> Multiple analysis fixes.
         private IReadOnlyList<DiagnosticsEntry> _parseErrors = Array.Empty<DiagnosticsEntry>();
         private readonly Dictionary<object, Node> _astMap = new Dictionary<object, Node>();
         private readonly IDiagnosticsService _diagnosticsService;
@@ -256,11 +252,7 @@ namespace Microsoft.Python.Analysis.Modules {
         public async Task<PythonAst> GetAstAsync(CancellationToken cancellationToken = default) {
             Task t = null;
             while (true) {
-<<<<<<< HEAD
                 lock (_syncObj) {
-=======
-                lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                     if (t == _parsingTask) {
                         break;
                     }
@@ -284,11 +276,7 @@ namespace Microsoft.Python.Analysis.Modules {
         public IEnumerable<DiagnosticsEntry> GetParseErrors() => _parseErrors.ToArray();
 
         public void Update(IEnumerable<DocumentChange> changes) {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 _parseCts?.Cancel();
                 _parseCts = new CancellationTokenSource();
 
@@ -305,11 +293,7 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         public void Reset(string content) {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 if (content != Content) {
                     ContentState = State.None;
                     InitializeContent(content, _buffer.Version + 1);
@@ -337,11 +321,7 @@ namespace Microsoft.Python.Analysis.Modules {
 
             //Log?.Log(TraceEventType.Verbose, $"Parse begins: {Name}");
 
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 version = _buffer.Version;
                 var options = new ParserOptions {
                     StubFile = FilePath != null && Path.GetExtension(FilePath).Equals(".pyi", FileSystem.StringComparison)
@@ -357,11 +337,7 @@ namespace Microsoft.Python.Analysis.Modules {
 
             //Log?.Log(TraceEventType.Verbose, $"Parse complete: {Name}");
 
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 cancellationToken.ThrowIfCancellationRequested();
                 if (version != _buffer.Version) {
                     throw new OperationCanceledException();
@@ -391,11 +367,7 @@ namespace Microsoft.Python.Analysis.Modules {
                 analyzer.EnqueueDocumentForAnalysis(this, ast, version);
             }
 
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 _parsingTask = null;
             }
         }
@@ -412,11 +384,7 @@ namespace Microsoft.Python.Analysis.Modules {
         #region IAnalyzable
 
         public void NotifyAnalysisBegins() {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 if (_updated) {
                     _updated = false;
                     // In all variables find those imported, then traverse imported modules
@@ -444,11 +412,7 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         public void NotifyAnalysisComplete(IDocumentAnalysis analysis) {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 if (analysis.Version < Analysis.Version) {
                     return;
                 }
@@ -484,32 +448,20 @@ namespace Microsoft.Python.Analysis.Modules {
 
         #region IAstNodeContainer
         public Node GetAstNode(object o) {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 return _astMap.TryGetValue(o, out var n) ? n : null;
             }
         }
 
         public void AddAstNode(object o, Node n) {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 Debug.Assert(!_astMap.ContainsKey(o) || _astMap[o] == n);
                 _astMap[o] = n;
             }
         }
 
         public void ClearContent() {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 if (ModuleType != ModuleType.User) {
                     _buffer.Reset(_buffer.Version, string.Empty);
                     _astMap.Clear();
@@ -540,11 +492,7 @@ namespace Microsoft.Python.Analysis.Modules {
         }
 
         private void InitializeContent(string content, int version) {
-<<<<<<< HEAD
             lock (_syncObj) {
-=======
-            lock (_analysisLock) {
->>>>>>> Multiple analysis fixes.
                 LoadContent(content, version);
 
                 var startParse = ContentState < State.Parsing && (_parsingTask == null || version > 0);

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -206,12 +206,9 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
             }
 
             addedRoots.UnionWith(PathResolver.SetInterpreterSearchPaths(InterpreterPaths));
-            addedRoots.UnionWith(SetUserSearchPaths(userSearchPaths));
+            addedRoots.UnionWith(PathResolver.SetUserSearchPaths(userSearchPaths));
             ReloadModulePaths(addedRoots);
         }
-
-        public IEnumerable<string> SetUserSearchPaths(in IEnumerable<string> searchPaths) 
-            => PathResolver.SetUserSearchPaths(searchPaths);
 
         // For tests
         internal void AddUnimportableModule(string moduleName)

--- a/src/Analysis/Ast/Test/TypeshedTests.cs
+++ b/src/Analysis/Ast/Test/TypeshedTests.cs
@@ -113,7 +113,7 @@ if sys.version_info >= (2, 7):
                 }
 
                 Console.WriteLine(@"Testing with {0}", ver.InterpreterPath);
-                using (var s = await CreateServicesAsync(TestData.Root, ver)) {
+                using (var s = await CreateServicesAsync(ver)) {
                     var analysis = await GetAnalysisAsync(code, s, @"testmodule", TestData.GetTestSpecificPath(@"testmodule.pyi"));
 
                     var expected = new List<string>();

--- a/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.cs
+++ b/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Python.Analysis.Core.DependencyResolution {
             }
 
             var rootEdges = _roots.Select((r, i) => new Edge(i, r));
-            if (!lastEdge.IsEmpty && !forceAbsolute) {
+            if (!lastEdge.IsEmpty && !forceAbsolute && !lastEdge.Previous.IsFirst) {
                 rootEdges = rootEdges.Prepend(lastEdge.Previous);
             }
 
@@ -711,7 +711,7 @@ namespace Microsoft.Python.Analysis.Core.DependencyResolution {
             var rootIndex = 0;
             while (rootIndex < _roots.Count) {
                 var rootPath = _roots[rootIndex].Name;
-                if (normalizedPath.PathStartsWith(rootPath) && IsRootedPathEndsWithValidNames(normalizedPath, rootPath.Length)) {
+                if (PathUtils.PathStartsWith(normalizedPath, rootPath) && IsRootedPathEndsWithValidNames(normalizedPath, rootPath.Length)) {
                     break;
                 }
 

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
             try {
                 var output = await ps.ExecuteAndCaptureOutputAsync(startInfo, cancellationToken);
                 return output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Select(s => {
-                    if (s.PathStartsWith(tempWorkingDir)) {
+                    if (PathUtils.PathStartsWith(s, tempWorkingDir)) {
                         return null;
                     }
                     try {

--- a/src/Core/Impl/Extensions/StringExtensions.cs
+++ b/src/Core/Impl/Extensions/StringExtensions.cs
@@ -146,9 +146,6 @@ namespace Microsoft.Python.Core {
             return "\"{0}\"".FormatInvariant(arg);
         }
 
-        public static bool PathStartsWith(this string s, string prefix)
-            => s?.StartsWith(prefix, PathsStringComparison) ?? false;
-
         public static bool StartsWithOrdinal(this string s, string prefix, bool ignoreCase = false)
             => s?.StartsWith(prefix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ?? false;
 

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -716,8 +716,7 @@ x.abc()
             var module2Path = TestData.GetTestSpecificUri("package", "module2.py");
             var module3Path = TestData.GetTestSpecificUri("package", "sub_package", "module3.py");
 
-            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
-            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             var module1 = rdt.OpenDocument(module1Path, "import package.");
@@ -937,8 +936,7 @@ os.path.
             var initPyPath = TestData.GetTestSpecificUri("__init__.py");
             var module1Path = TestData.GetTestSpecificUri("module1.py");
 
-            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
-            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             rdt.OpenDocument(initPyPath, string.Empty);
@@ -959,8 +957,7 @@ os.path.
             var module2Path = TestData.GetTestSpecificUri("package", "module2.py");
             var module3Path = TestData.GetTestSpecificUri("package", "sub_package", "module3.py");
 
-            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
-            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
             var analyzer = Services.GetService<IPythonAnalyzer>();
 
@@ -983,8 +980,7 @@ os.path.
             var module1Path = TestData.GetTestSpecificUri("package", "module1.py");
             var module2Path = TestData.GetTestSpecificUri("package", "sub_package", "module2.py");
 
-            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
-            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             var module = rdt.OpenDocument(initPyPath, "answer = 42");
@@ -1009,8 +1005,7 @@ os.path.
             var module2 = TestData.GetTestSpecificUri("package", "module2.py");
             var module3 = TestData.GetTestSpecificUri("package", "sub_package", "module3.py");
 
-            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
-            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             var module = rdt.OpenDocument(module1, "from .");

--- a/src/LanguageServer/Test/GoToDefinitionTests.cs
+++ b/src/LanguageServer/Test/GoToDefinitionTests.cs
@@ -328,8 +328,8 @@ class MainClass:
     def foo(self):
         return self.bar.get_name()
 ";
-            var root = TestData.GetTestSpecificRootUri().AbsolutePath;
-            await CreateServicesAsync(root, PythonVersions.LatestAvailable3X);
+
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
             var rdt = Services.GetService<IRunningDocumentTable>();
 
             var mainPath = TestData.GetTestSpecificUri("main.py");

--- a/src/UnitTests/Core/Impl/TestData.cs
+++ b/src/UnitTests/Core/Impl/TestData.cs
@@ -86,6 +86,7 @@ namespace TestUtilities {
         public static string GetTestSpecificPath(string relativePath) => TestRunScopeAsyncLocal.Value.GetTestSpecificPath(relativePath);
         public static string GetTestSpecificPath(params string[] parts) => TestRunScopeAsyncLocal.Value.GetTestSpecificPath(Path.Combine(parts));
         public static string GetTestRelativePath(Uri uri) => TestRunScopeAsyncLocal.Value.GetTestRelativePath(uri);
+        public static string GetTestSpecificRootPath() => TestRunScopeAsyncLocal.Value.Root;
         public static string GetDefaultModulePath() => TestRunScopeAsyncLocal.Value.GetDefaultModulePath();
         public static string GetNextModulePath() => TestRunScopeAsyncLocal.Value.GetNextModulePath();
 
@@ -149,7 +150,7 @@ namespace TestUtilities {
             var path = Path.Combine(TestOutputRootLazy.Value, testDirectoryName);
 
             Directory.CreateDirectory(path);
-            TestRunScopeAsyncLocal.Value = new TestRunScope(PathUtils.EnsureEndSeparator(path));
+            TestRunScopeAsyncLocal.Value = new TestRunScope(path);
         }
 
         internal static void ClearTestRunScope() {
@@ -158,18 +159,18 @@ namespace TestUtilities {
     }
 
     internal class TestRunScope {
-        private readonly string _root;
         private int _moduleCounter;
+        public string Root { get; }
         public Uri RootUri { get; }
 
         public TestRunScope(string root) {
-            _root = root;
-            RootUri = new Uri(_root);
+            Root = root;
+            RootUri = new Uri(Root);
         }
 
         public string GetDefaultModulePath() => GetTestSpecificPath($"module.py");
         public string GetNextModulePath() => GetTestSpecificPath($"module{++_moduleCounter}.py");
-        public string GetTestSpecificPath(string relativePath) => Path.Combine(_root, relativePath);
+        public string GetTestSpecificPath(string relativePath) => Path.Combine(Root, relativePath);
         public string GetTestRelativePath(Uri uri) {
             var relativeUri = RootUri.MakeRelativeUri(uri);
             var relativePath = Uri.UnescapeDataString(relativeUri.ToString());


### PR DESCRIPTION
- Fix #1314: NRE in HandleModuleImportStar bug
- Fix #1318: PathUtils.IsNormalizedPath and PathUtils.NormalizePath work incorrectly with UNC
- Fix #1320: Incorrect relative import handling in Python 2x
- Fix #1321: If one user paths is part of the name of another, PathResolverSnapshot is built incorrectly
- Fix paths in tests
- Remove `IModuleManagement.SetUserSearchPaths`