### PR TITLE
No completions on ellipsis

### DIFF
--- a/src/LanguageServer/Impl/Completion/CompletionSource.cs
+++ b/src/LanguageServer/Impl/Completion/CompletionSource.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Python.LanguageServer.Completion {
                 case ConstantExpression ce2 when ce2.Value is string:
                 case ConstantExpression ce3 when ce3.Value is AsciiString:
                 // no completions in strings
+                case ConstantExpression ce4 when ce4.Value is Ellipsis:
+                // no completions in ellipsis
                 case null when context.Ast.IsInsideComment(context.Location):
                 case null when context.Ast.IsInsideString(context.Location):
                     return CompletionResult.Empty;

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -850,6 +850,19 @@ pass";
         [DataRow(true)]
         [DataRow(false)]
         [DataTestMethod, Priority(0)]
+        public async Task NoCompletionInEllipsis(bool is2x) {
+            const string code = "...";
+            var analysis = await GetAnalysisAsync(code, is2x ? PythonVersions.LatestAvailable2X: PythonVersions.LatestAvailable3X);
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
+
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 4));
+            result.Should().HaveNoCompletion();
+        }
+
+
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataTestMethod, Priority(0)]
         public async Task NoCompletionInString(bool is2x) {
             var analysis = await GetAnalysisAsync("\"str.\"", is2x ? PythonVersions.LatestAvailable2X : PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);


### PR DESCRIPTION
It will give completions for 
```
....
```
So I'm not sure what the intended behavior for that is, but on regular ellipsis it doesn't give completions. 