### PR TITLE
Fixing issue with decorators with same prefix seen as redefinition

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
@@ -241,21 +241,19 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
         private bool IsRedefinedByDecorator(FunctionDefinition fd) {
             var decorators = fd.Decorators?.Decorators ?? Array.Empty<Expression>();
             foreach (var m in decorators.OfType<MemberExpression>()) {
-                // If the decorator prefix has the same name as the function, then the function is redefined by decorator
+                // If a decorator member expression's target has the same name as the function, then the function is redefined via decorator
                 // e.g
-                // @property
-                // def x(self): ...
-                // 
                 // @x.setter
                 // def x(self): ...
+                // x.setter has the target x and the function is named x, so x is redefined via decorator
                 //
                 // But pylint only compares one level member expressions for decorators
                 // e.g 
                 // @foo.a
-                // def foo(self): ...
-                // is valid but not
+                // def foo(self): ... is a redefinition but 
+                //
                 // @foo.a.b
-                // def foo(self): ... 
+                // def foo(self): ... is not.
                 var name = (m.Target as NameExpression)?.Name ?? string.Empty;
                 if (name.Equals(fd.Name)) {
                     return true;

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             var existing = _eval.LookupNameInScopes(fd.Name, LookupOptions.Local);
 
             // lambdas have the same function name, so don't count them as redefinitions
-            if (!IsRedefinedByDecorator(fd) && !string.IsNullOrEmpty(fd.Name) && !fd.IsLambda) {
+            if (!string.IsNullOrEmpty(fd.Name) && !fd.IsLambda && !IsRedefinedByDecorator(fd)) {
                 switch (existing?.MemberType) {
                     case PythonMemberType.Method:
                     case PythonMemberType.Function:

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
@@ -101,9 +101,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             var declaringType = fd.Parent != null && _typeMap.TryGetValue(fd.Parent, out var t) ? t : null;
             var existing = _eval.LookupNameInScopes(fd.Name, LookupOptions.Local);
 
+            // Most of the time, redefinitions won't occur so if existing is null 
             // lambdas have the same function name, so don't count them as redefinitions
-            if (!string.IsNullOrEmpty(fd.Name) && !fd.IsLambda && !IsRedefinedByDecorator(fd)) {
-                switch (existing?.MemberType) {
+            if (existing != null 
+                && !fd.IsLambda 
+                && !string.IsNullOrEmpty(fd.Name) 
+                && !IsRedefinedByDecorator(fd)) {
+                switch (existing.MemberType) {
                     case PythonMemberType.Method:
                     case PythonMemberType.Function:
                     case PythonMemberType.Property:

--- a/src/Analysis/Ast/Test/LintRedefinedFunctionTests.cs
+++ b/src/Analysis/Ast/Test/LintRedefinedFunctionTests.cs
@@ -325,5 +325,138 @@ class tmp:
             diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
             diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
         }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothArePropertiesNotSamePrefix() {
+            const string code = @"
+class tmp:
+    @foo.hello
+    def foo(self):
+        return 123
+   
+    @tmp.temp
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionRedefined);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
+            diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothArePropertiesSamePrefix() {
+            const string code = @"
+class tmp:
+    @foo.hello
+    def foo(self):
+        return 123
+   
+    @foo.temp
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothArePropertiesFirstMember() {
+            const string code = @"
+class tmp:
+    @foo.a
+    def foo(self):
+        return 123
+
+    @radius
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionRedefined);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
+            diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothArePropertiesMultipleMember() {
+            const string code = @"
+class tmp:
+    @foo.a.b.c
+    def foo(self):
+        return 123
+
+    @foo.a.c.d
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionRedefined);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
+            diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothHaveSameMemberProperty() {
+            const string code = @"
+class tmp:
+    @foo.a
+    def foo(self):
+        return 123
+
+    @foo.a
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothHaveSamePropertiesMultipleMember() {
+            const string code = @"
+class tmp:
+    @foo.a.b.c
+    def foo(self):
+        return 123
+
+    @foo.a.b.c
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionRedefined);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
+            diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothPropertiesSameMethod() {
+            const string code = @"
+class tmp:
+    @foo.setter
+    def foo(self):
+        return 123
+   
+    @foo.getter
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
     }
 }

--- a/src/Analysis/Ast/Test/LintRedefinedFunctionTests.cs
+++ b/src/Analysis/Ast/Test/LintRedefinedFunctionTests.cs
@@ -458,5 +458,26 @@ class tmp:
             var analysis = await GetAnalysisAsync(code);
             analysis.Diagnostics.Should().BeEmpty();
         }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedFuncsBothPropertiesSameMethodNoMember() {
+            const string code = @"
+class tmp:
+    @foo
+    def foo(self):
+        return 123
+   
+    @foo
+    def foo(self):
+        return 123
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().HaveCount(1);
+
+            var diagnostic = analysis.Diagnostics.ElementAt(0);
+            diagnostic.ErrorCode.Should().Be(ErrorCodes.FunctionRedefined);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
+            diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
+        }
     }
 }

--- a/src/Analysis/Ast/Test/LintRedefinedFunctionTests.cs
+++ b/src/Analysis/Ast/Test/LintRedefinedFunctionTests.cs
@@ -479,5 +479,28 @@ class tmp:
             diagnostic.SourceSpan.Should().Be(8, 9, 8, 12);
             diagnostic.Message.Should().Be(Resources.FunctionRedefined.FormatInvariant(4));
         }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedLambdas() {
+            const string code = @"
+x = lambda h: h
+y = lambda c: c
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task RedefinedNoNameFunction() {
+            const string code = @"
+def (a, b, c):
+    pass
+
+def (b, c, d):
+    pass
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
     }
 }


### PR DESCRIPTION
Followed pylint's guide more closely. 