### PR TITLE
Allowing classes to inherit from all specialized functions

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 // Evaluate inner classes, if any
                 EvaluateInnerClasses(_classDef);
                 _class = classInfo;
-                
+
                 var bases = ProcessBases();
                 _class.SetBases(bases);
                 // Declare __class__ variable in the scope.
@@ -131,9 +131,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 return true;
             }
 
-            // Allow any members from typing module
-            // TODO handle typing module specialization better: https://github.com/microsoft/python-language-server/issues/1367
-            if (m is ILocatedMember l && l.DeclaringModule is TypingModule) {
+            // Allow extensions from specialized functions 
+            // We specialized type to be a function even though it is a class, so this allows extension of type
+            // TODO handle module specialization better: https://github.com/microsoft/python-language-server/issues/1367
+            if (m is IPythonType t && t.IsSpecialized) {
                 return true;
             }
 

--- a/src/Analysis/Ast/Test/LintInheritNonClassTests.cs
+++ b/src/Analysis/Ast/Test/LintInheritNonClassTests.cs
@@ -436,5 +436,28 @@ class MyEntity(int):
             var analysis = await GetAnalysisAsync(code);
             analysis.Diagnostics.Should().BeEmpty();
         }
+
+        [TestMethod, Priority(0)]
+        public async Task InheritFromTypingSpecialCase() {
+            const string code = @"
+from typing import ByteString, Type, Any, SupportsInt, FrozenSet
+class Test(ByteString): 
+    mystr = 'test'
+
+class Test1(Type): 
+    mystr = 'test'
+
+class Test2(Any): 
+    mystr = 'test'
+
+class Test3(SupportsInt):
+    mystr = 'test'
+
+class Test3(FrozenSet):
+    mystr = 'test'
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
     }
 }

--- a/src/Analysis/Ast/Test/LintInheritNonClassTests.cs
+++ b/src/Analysis/Ast/Test/LintInheritNonClassTests.cs
@@ -406,12 +406,31 @@ class MyEntity(x):
             analysis.Diagnostics.Should().BeEmpty();
         }
 
-
         [TestMethod, Priority(0)]
         public async Task InheritFromUnknownInstance() {
             const string code = @"
 x = Y()
 class MyEntity(x): 
+    mystr = 'test'
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task InheritFromType() {
+            const string code = @"
+class MyEntity(type): 
+    mystr = 'test'
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task InheritFromIntType() {
+            const string code = @"
+class MyEntity(int): 
     mystr = 'test'
 ";
             var analysis = await GetAnalysisAsync(code);


### PR DESCRIPTION
I think it would be good to have a PR in the future that would add a field to `IPythonFunctionType` that allowed linting to tell if something was specialized as a function for convenience but should be treated as a class. 

Fixes #1377 