### PR TITLE
Add RDT count to the analysis_complete event

### DIFF
--- a/src/Analysis/Ast/Impl/Documents/Definitions/IRunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/Definitions/IRunningDocumentTable.cs
@@ -94,6 +94,6 @@ namespace Microsoft.Python.Analysis.Documents {
         /// <summary>
         /// Gets the number of documents in the table.
         /// </summary>
-        int Count();
+        int DocumentCount { get; }
     }
 }

--- a/src/Analysis/Ast/Impl/Documents/Definitions/IRunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/Definitions/IRunningDocumentTable.cs
@@ -90,5 +90,10 @@ namespace Microsoft.Python.Analysis.Documents {
         /// Fires when document is removed.
         /// </summary>
         event EventHandler<DocumentEventArgs> Removed;
+
+        /// <summary>
+        /// Gets the number of documents in the table.
+        /// </summary>
+        int Count();
     }
 }

--- a/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
@@ -69,6 +69,12 @@ namespace Microsoft.Python.Analysis.Documents {
             }
         }
 
+        public int Count() {
+            lock (_lock) {
+                return _documentsByUri.Count;
+            }
+        }
+
         /// <summary>
         /// Adds file to the list of available documents.
         /// </summary>

--- a/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
@@ -69,9 +69,11 @@ namespace Microsoft.Python.Analysis.Documents {
             }
         }
 
-        public int Count() {
-            lock (_lock) {
-                return _documentsByUri.Count;
+        public int DocumentCount {
+            get {
+                lock (_lock) {
+                    return _documentsByUri.Count;
+                }
             }
         }
 

--- a/src/LanguageServer/Impl/Implementation/Server.Telemetry.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Telemetry.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             te.Measurements["workingMB"] = workingMB;
             te.Measurements["elapsedMs"] = e.MillisecondsElapsed;
             te.Measurements["moduleCount"] = e.ModuleCount;
+            te.Measurements["rdtCount"] = _rdt.Count();
 
             telemetry.SendTelemetryAsync(te).DoNotWait();
         }

--- a/src/LanguageServer/Impl/Implementation/Server.Telemetry.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.Telemetry.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             te.Measurements["workingMB"] = workingMB;
             te.Measurements["elapsedMs"] = e.MillisecondsElapsed;
             te.Measurements["moduleCount"] = e.ModuleCount;
-            te.Measurements["rdtCount"] = _rdt.Count();
+            te.Measurements["rdtCount"] = _rdt.DocumentCount;
 
             telemetry.SendTelemetryAsync(te).DoNotWait();
         }


### PR DESCRIPTION
Fixes #1379.

Can't use `GetDocuments().Count` as it collects the entire list under lock.