### PR TITLE
Fix 'type name as string' conversion in scraper.

### DIFF
--- a/src/Analysis/Ast/Impl/Caching/StubCache.cs
+++ b/src/Analysis/Ast/Impl/Caching/StubCache.cs
@@ -23,7 +23,7 @@ using Microsoft.Python.Core.Logging;
 
 namespace Microsoft.Python.Analysis.Caching {
     internal sealed class StubCache : IStubCache {
-        private const int _stubCacheFormatVersion = 1;
+        private const int _stubCacheFormatVersion = 2;
 
         private readonly IFileSystem _fs;
         private readonly ILogger _log;

--- a/src/Analysis/Ast/Impl/scrape_module.py
+++ b/src/Analysis/Ast/Impl/scrape_module.py
@@ -797,7 +797,7 @@ class MemberInfo(object):
 
     def _str_from_typename(self, type_name):
         mod_name, sep, name = type_name.rpartition('.')
-        return self.name + ' = ' + safe_module_name(mod_name) + sep + name + '()'
+        return self.name + ' = ' + safe_module_name(mod_name) + sep + name
 
     def _str_from_value(self, v):
         return self.name + ' = ' + repr(v)

--- a/src/Analysis/Ast/Impl/scrape_module.py
+++ b/src/Analysis/Ast/Impl/scrape_module.py
@@ -698,6 +698,8 @@ class MemberInfo(object):
         self.signature = None
         self.documentation = getattr(value, '__doc__', None)
         self.alias = alias
+        self.instance = True
+
         if not isinstance(self.documentation, str):
             self.documentation = None
 
@@ -712,6 +714,7 @@ class MemberInfo(object):
 
         value_type = type(value)
         if issubclass(value_type, type):
+            self.instance = False
             self.need_imports, type_name = self._get_typename(value, module)
             if '.' in type_name:
                 m, s, n = type_name.rpartition('.')
@@ -797,7 +800,10 @@ class MemberInfo(object):
 
     def _str_from_typename(self, type_name):
         mod_name, sep, name = type_name.rpartition('.')
-        return self.name + ' = ' + safe_module_name(mod_name) + sep + name
+        s = self.name + ' = ' + safe_module_name(mod_name) + sep + name
+        if self.instance:
+            s = s + '()'
+        return s
 
     def _str_from_value(self, v):
         return self.name + ' = ' + repr(v)

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -634,5 +634,14 @@ class Test():
             // Test run time: typically ~ 20 sec.
             sw.ElapsedMilliseconds.Should().BeLessThan(60000); 
         }
+
+        [TestMethod, Priority(0)]
+        public async Task IOErrorBase() {
+            const string code = @"
+class A(IOError): ...
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveClass("A").Which.Should().HaveBase("OSError");
+        }
     }
 }

--- a/src/Analysis/Ast/Test/FluentAssertions/MemberAssertions.cs
+++ b/src/Analysis/Ast/Test/FluentAssertions/MemberAssertions.cs
@@ -61,6 +61,22 @@ namespace Microsoft.Python.Analysis.Tests.FluentAssertions {
             return new AndWhichConstraint<MemberAssertions, IMember>(this, Subject);
         }
 
+        public AndWhichConstraint<MemberAssertions, IPythonClassType> HaveBase(string name, string because = "", params object[] reasonArgs) {
+            NotBeNull();
+
+            var cls = Subject.GetPythonType<IPythonClassType>();
+            Execute.Assertion.ForCondition(cls != null)
+                .BecauseOf(because, reasonArgs)
+                .FailWith($"Expected {GetName(cls)} to be a class{{reason}}.");
+
+            var classBase = cls.Bases.OfType<IPythonClassType>().FirstOrDefault(b => b.Name == name);
+            Execute.Assertion.ForCondition(classBase != null)
+                .BecauseOf(because, reasonArgs)
+                .FailWith($"Expected {GetName(cls)} to have base class {name}{{reason}}.");
+
+            return new AndWhichConstraint<MemberAssertions, IPythonClassType>(this, classBase);
+        }
+
         public AndWhichConstraint<MemberAssertions, PythonFunctionType> HaveMethod(string name, string because = "", params object[] reasonArgs)
             => HaveMember<PythonFunctionType>(name, because, reasonArgs).OfMemberType(PythonMemberType.Method);
 


### PR DESCRIPTION
Closes #1403 

`type name as string` should not be adding `()` since it turns type info into an instance.
Changes version of the stub cache so it gets re-generated on user machine.