### PR TITLE
Fallback to function when property's declaringType is unknown

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
@@ -150,6 +150,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
         }
 
         private bool TryAddProperty(FunctionDefinition node, IPythonType declaringType) {
+            // We can't add a property to an unknown type. Fallback to a regular function for now.
+            // TOOD: Decouple declaring types from the property.
+            if (declaringType.IsUnknown()) {
+                return false;
+            }
+
             var dec = node.Decorators?.Decorators;
             var decorators = dec != null ? dec.ExcludeDefault().ToArray() : Array.Empty<Expression>();
 

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -143,7 +143,9 @@ namespace Microsoft.Python.Analysis.Types {
                         break;
                     case @"property":
                     case @"abstractproperty":
-                        Debug.Assert(false, "Found property attribute while processing function. Properties should be handled in the respective class.");
+                        // Ignore property decorators if the declaring type is unknown.
+                        // TODO: Restore this to a hard failure once property can handle not having a declaring type.
+                        Debug.Assert(DeclaringType.IsUnknown(), "Found property attribute while processing function. Properties should be handled in the respective class.");
                         break;
                 }
             }

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -634,5 +634,21 @@ class Test():
             // Test run time: typically ~ 20 sec.
             sw.ElapsedMilliseconds.Should().BeLessThan(60000); 
         }
+
+        [TestMethod, Priority(0)]
+        public async Task NestedProperty() {
+            const string code = @"
+class x(object):
+    def func(self):
+        @property
+        def foo(*args, **kwargs):
+            pass
+        return 42
+
+a = x().func()
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Int);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1335, for now.

This could stand to be improved by somehow allowing the declaring type to be null, but that is a more complicated fix, and just falling back to a function provides some usability and stops the NREs.