### PR TITLE
Properly add members to class rather than declaring variables

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -53,11 +53,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                     value = GetValueFromInstanceCall(pi, expr);
                     break;
                 case IPythonFunctionType ft: // Standalone function or a class method call.
-                    var instance = ft.DeclaringType != null ? new PythonInstance(ft.DeclaringType) : null;
+                    var instance = ft.DeclaringType is IPythonClassType cls1 ? new PythonInstance(cls1) : null;
                     value = GetValueFromFunctionType(ft, instance, expr);
                     break;
-                case IPythonClassType cls:
-                    value = GetValueFromClassCtor(cls, expr);
+                case IPythonClassType cls2:
+                    value = GetValueFromClassCtor(cls2, expr);
                     break;
                 case IPythonType t:
                     // Target is type (info), the call creates instance.

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -37,13 +37,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public IMember GetInScope(string name) => GetInScope(name, CurrentScope);
         public T GetInScope<T>(string name) where T : class, IMember => GetInScope<T>(name, CurrentScope);
 
-        public void DeclareVariable(string name, IMember value, VariableSource source)
-            => DeclareVariable(name, value, source, default(Location));
+        public void DeclareVariable(string name, IMember value, VariableSource source, Node location)
+            => DeclareVariable(name, value, source, GetLocationOfName(location));
 
-        public void DeclareVariable(string name, IMember value, VariableSource source, Node location, bool overwrite = false)
-            => DeclareVariable(name, value, source, GetLocationOfName(location), overwrite);
-
-        private void DeclareVariable(string name, IMember value, VariableSource source, Location location, bool overwrite = false) {
+        public void DeclareVariable(string name, IMember value, VariableSource source, Location location) {
             if (source == VariableSource.Import && value is IVariable v) {
                 CurrentScope.LinkVariable(name, v, location);
                 return;

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -40,13 +40,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public void DeclareVariable(string name, IMember value, VariableSource source)
             => DeclareVariable(name, value, source, default(Location));
 
-        public void DeclareVariable(string name, IMember value, VariableSource source, IPythonModule module)
-            => DeclareVariable(name, value, source, new Location(module));
-
         public void DeclareVariable(string name, IMember value, VariableSource source, Node location, bool overwrite = false)
             => DeclareVariable(name, value, source, GetLocationOfName(location), overwrite);
 
-        public void DeclareVariable(string name, IMember value, VariableSource source, Location location, bool overwrite = false) {
+        private void DeclareVariable(string name, IMember value, VariableSource source, Location location, bool overwrite = false) {
             if (source == VariableSource.Import && value is IVariable v) {
                 CurrentScope.LinkVariable(name, v, location);
                 return;

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -197,6 +197,19 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return m;
         }
 
+        public void AssignVariable(NameExpression ne, IMember value, VariableSource source, Action<string, IMember> assignmentAction)
+            => AssignVariable(ne.Name, value, source, ne, assignmentAction);
+
+        public void AssignVariable(string name, IMember value, VariableSource source, Node expression, Action<string, IMember> assignmentAction) {
+            if (assignmentAction != null) {
+                // class A:
+                //   x: int
+                assignmentAction(name, value);
+            } else {
+                DeclareVariable(name, value, source, GetLocationOfName(expression));
+            }
+        }
+
         internal void ClearCache() => _scopeLookupCache.Clear();
 
         private IMember GetValueFromFormatSpecifier(FormatSpecifier formatSpecifier)

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                     m = GetValueFromExpression(namedExpr.Value);
                     break;
                 // indexing with nothing, e.g Generic[]
-                case ErrorExpression error:
+                case ErrorExpression _:
                     m = null;
                     break;
                 default:

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -29,6 +29,12 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
     /// <summary>
+    /// Callback for assignment of a value. Callback may decide to create
+    /// a variable or add a class member to the current class.
+    /// </summary>
+    internal delegate void AssignmentAction(string name, IMember value, Location location);
+
+    /// <summary>
     /// Helper class that provides methods for looking up variables
     /// and types in a chain of scopes during analysis.
     /// </summary>
@@ -197,14 +203,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return m;
         }
 
-        public void AssignVariable(NameExpression ne, IMember value, VariableSource source, Action<string, IMember> assignmentAction)
+        public void AssignVariable(NameExpression ne, IMember value, VariableSource source, AssignmentAction assignmentAction)
             => AssignVariable(ne.Name, value, source, ne, assignmentAction);
 
-        public void AssignVariable(string name, IMember value, VariableSource source, Node expression, Action<string, IMember> assignmentAction) {
+        public void AssignVariable(string name, IMember value, VariableSource source, Node expression, AssignmentAction assignmentAction) {
             if (assignmentAction != null) {
                 // class A:
                 //   x: int
-                assignmentAction(name, value);
+                assignmentAction(name, value, GetLocationOfName(expression));
             } else {
                 DeclareVariable(name, value, source, GetLocationOfName(expression));
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
@@ -13,9 +13,9 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
@@ -25,7 +25,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed class AssignmentHandler : StatementHandler {
         public AssignmentHandler(AnalysisWalker walker) : base(walker) { }
 
-        public void HandleAssignment(AssignmentStatement node, Action<string, IMember> assignmentAction = null) {
+        public void HandleAssignment(AssignmentStatement node, AssignmentAction assignmentAction = null) {
             if (node.Right is ErrorExpression) {
                 return;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             }
         }
 
-        public void HandleAnnotatedExpression(ExpressionWithAnnotation expr, IMember value, Action<string, IMember> assignmentAction = null) {
+        public void HandleAnnotatedExpression(ExpressionWithAnnotation expr, IMember value, AssignmentAction assignmentAction = null) {
             if (expr?.Annotation == null) {
                 return;
             }
@@ -105,7 +105,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             return false;
         }
 
-        private void HandleTypedVariable(IPythonType variableType, IMember value, Expression expr, Action<string, IMember> assignmentAction) {
+        private void HandleTypedVariable(IPythonType variableType, IMember value, Expression expr, AssignmentAction assignmentAction) {
             var instance = CreateInstance(variableType, value, expr);
 
             if (expr is NameExpression ne) {

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             // Process annotations, if any.
             foreach (var expr in node.Left.OfType<ExpressionWithAnnotation>()) {
                 // x: List[str] = [...]
-                HandleAnnotatedExpression(expr, value);
+                HandleAnnotatedExpression(expr, value, assignmentAction);
             }
 
             foreach (var ne in node.Left.OfType<NameExpression>()) {

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                 }
 
                 var source = value.IsGeneric() ? VariableSource.Generic : VariableSource.Declaration;
-                AssignVariable(ne, value ?? Module.Interpreter.UnknownType, source, assignmentAction);
+                Eval.AssignVariable(ne, value ?? Module.Interpreter.UnknownType, source, assignmentAction);
             }
         }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             var instance = CreateInstance(variableType, value, expr);
 
             if (expr is NameExpression ne) {
-                AssignVariable(ne, instance, VariableSource.Declaration, assignmentAction);
+                Eval.AssignVariable(ne, instance, VariableSource.Declaration, assignmentAction);
                 return;
             }
 
@@ -120,16 +120,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                 if (argType is PythonClassType cls && scope != null) {
                     cls.AddMember(m.Name, instance, true);
                 }
-            }
-        }
-
-        private void AssignVariable(NameExpression ne, IMember value, VariableSource source, Action<string, IMember> assignmentAction) {
-            if (assignmentAction != null) {
-                // class A:
-                //   x: int
-                assignmentAction(ne.Name, value);
-            } else {
-                Eval.DeclareVariable(ne.Name, value, source, Eval.GetLocationOfName(ne));
             }
         }
 

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Python.Analysis.Analyzer.Evaluation;
 using Microsoft.Python.Analysis.Core.DependencyResolution;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Modules;
@@ -33,7 +34,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
 
         public ImportHandler(AnalysisWalker walker) : base(walker) { }
 
-        public bool HandleImport(ImportStatement node, Action<string, IMember> assignmentAction = null) {
+        public bool HandleImport(ImportStatement node, AssignmentAction assignmentAction = null) {
             if (Module.ModuleType == ModuleType.Specialized) {
                 return false;
             }
@@ -49,7 +50,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             return false;
         }
 
-        private void HandleImport(ModuleName moduleImportExpression, NameExpression asNameExpression, bool forceAbsolute, Action<string, IMember> assignmentAction = null) {
+        private void HandleImport(ModuleName moduleImportExpression, NameExpression asNameExpression, bool forceAbsolute, AssignmentAction assignmentAction = null) {
             // "import fob.oar.baz" means
             // import_module('fob')
             // import_module('fob.oar')

--- a/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/ModuleWalker.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     case null:
                         // Nothing in sources, but there is type in the stub. Declare it.
                         if (v.Source == VariableSource.Declaration) {
-                            Eval.DeclareVariable(v.Name, v.Value, v.Source);
+                            Eval.DeclareVariable(v.Name, v.Value, v.Source, null);
                         }
                         break;
 
@@ -303,7 +303,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                             TransferDocumentationAndLocation(sourceType, stubType);
                             // TODO: choose best type between the scrape and the stub. Stub probably should always win.
                             var source = Eval.CurrentScope.Variables[v.Name]?.Source ?? v.Source;
-                            Eval.DeclareVariable(v.Name, v.Value, source);
+                            Eval.DeclareVariable(v.Name, v.Value, source, v.Location);
                         }
                         break;
                 }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 SymbolTable.Evaluate(b.ClassDefinition);
             }
 
-            var addMember = new Action<string, IMember>((n, m) => _class.AddMember(n, m, overwrite: true));
+            var addMember = new AssignmentAction((n, m, l) => _class.AddMember(n, m, overwrite: true));
             // Process imports
             foreach (var s in GetStatements<FromImportStatement>(_classDef)) {
                 ImportHandler.HandleFromImport(s, addMember);
@@ -86,9 +86,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // without self prefix and hence analysis and linter must be able to locate 
             // them without the prefix. Variables receive special source type
             // so completion source can filter them out.
-            var addMemberAndVariable = new Action<string, IMember>((n, m) => {
+            var addMemberAndVariable = new AssignmentAction((n, m, l) => {
                 _class.AddMember(n, m, overwrite: true);
-                Eval.DeclareVariable(n, m, VariableSource.ClassMember);
+                Eval.DeclareVariable(n, m, VariableSource.ClassMember, l);
             });
 
             foreach (var s in GetStatements<Statement>(_classDef)) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -13,6 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Analyzer.Evaluation;
@@ -73,12 +74,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 SymbolTable.Evaluate(b.ClassDefinition);
             }
 
+            var addMember = new Action<string,IMember>((n, m) => _class.AddMember(n, m, overwrite: true));
             // Process imports
             foreach (var s in GetStatements<FromImportStatement>(_classDef)) {
-                ImportHandler.HandleFromImport(s);
+                ImportHandler.HandleFromImport(s, addMember);
             }
             foreach (var s in GetStatements<ImportStatement>(_classDef)) {
-                ImportHandler.HandleImport(s);
+                ImportHandler.HandleImport(s, addMember);
             }
 
             // Process assignments so we get class variables declared.
@@ -90,10 +92,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             foreach (var s in GetStatements<Statement>(_classDef)) {
                 switch (s) {
                     case AssignmentStatement assignment:
-                        AssignmentHandler.HandleAssignment(assignment, (n, m) => _class.AddMember(n, m, overwrite: true));
+                        AssignmentHandler.HandleAssignment(assignment, addMember);
                         break;
                     case ExpressionStatement e:
-                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, (n, m) => _class.AddMember(n, m, overwrite: true));
+                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, addMember);
                         break;
                 }
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // them without the prefix. Variables receive special source type
             // so completion source can filter them out.
             var addMemberAndVariable = new AssignmentAction((n, m, l) => {
-                _class.AddMember(n, m, overwrite: true);
                 Eval.DeclareVariable(n, m, VariableSource.ClassMember, l);
+                _class.AddMember(n, new Variable(n, m, VariableSource.Declaration, l), overwrite: true);
             });
 
             foreach (var s in GetStatements<Statement>(_classDef)) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
 
                 var bases = ProcessBases();
                 _class.SetBases(bases);
-                
+
                 _class.AddMember("__class__", _class, overwrite: true);
                 ProcessClassBody();
             }
@@ -74,7 +74,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 SymbolTable.Evaluate(b.ClassDefinition);
             }
 
-            var addMember = new Action<string,IMember>((n, m) => _class.AddMember(n, m, overwrite: true));
+            var addMember = new Action<string, IMember>((n, m) => _class.AddMember(n, m, overwrite: true));
             // Process imports
             foreach (var s in GetStatements<FromImportStatement>(_classDef)) {
                 ImportHandler.HandleFromImport(s, addMember);
@@ -89,13 +89,18 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             //    class A:
             //      x: int
             //      x = 1
+            var addMemberAndVariable = new Action<string, IMember>((n, m) => {
+                _class.AddMember(n, m, overwrite: true);
+                Eval.DeclareVariable(n, m, VariableSource.Declaration);
+            });
+
             foreach (var s in GetStatements<Statement>(_classDef)) {
                 switch (s) {
                     case AssignmentStatement assignment:
-                        AssignmentHandler.HandleAssignment(assignment, addMember);
+                        AssignmentHandler.HandleAssignment(assignment, addMemberAndVariable);
                         break;
                     case ExpressionStatement e:
-                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, addMember);
+                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, addMemberAndVariable);
                         break;
                 }
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -81,13 +81,23 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             //    class A:
             //      x: int
             //      x = 1
+            // Here we both add class member and declare variables. 
+            // The problem is that in class scope member variables can be accessed
+            // without self prefix and hence analysis and linter must be able to locate 
+            // them without the prefix. Variables receive special source type
+            // so completion source can filter them out.
+            var addMemberAndVariable = new Action<string, IMember>((n, m) => {
+                _class.AddMember(n, m, overwrite: true);
+                Eval.DeclareVariable(n, m, VariableSource.ClassMember);
+            });
+
             foreach (var s in GetStatements<Statement>(_classDef)) {
                 switch (s) {
                     case AssignmentStatement assignment:
-                        AssignmentHandler.HandleAssignment(assignment, addMember);
+                        AssignmentHandler.HandleAssignment(assignment, addMemberAndVariable);
                         break;
                     case ExpressionStatement e:
-                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, addMember);
+                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, addMemberAndVariable);
                         break;
                 }
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -194,6 +194,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Add members from this file
             var members = Eval.CurrentScope.Variables.Where(v => v.Source == VariableSource.Declaration || v.Source == VariableSource.Import);
             _class.AddMembers(members, false);
+            Eval.CurrentScope.VariableCollection.Clear();
         }
 
         private void ReportInvalidBase(string argVal) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -64,10 +64,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 if (ctor || returnType.IsUnknown() || Module.ModuleType == ModuleType.User) {
                     // Return type from the annotation is sufficient for libraries and stubs, no need to walk the body.
                     FunctionDefinition.Body?.Walk(this);
-                    // For libraries remove declared local function variables to free up some memory.
-                    var optionsProvider = Eval.Services.GetService<IAnalysisOptionsProvider>();
-                    if (Module.ModuleType != ModuleType.User && optionsProvider?.Options.KeepLibraryLocalVariables != true) {
-                        ((VariableCollection)Eval.CurrentScope.Variables).Clear();
+                    var containsInnerTypes = Eval.CurrentScope.Variables.All(v => v.GetPythonType<IPythonClassType>() == null && v.GetPythonType<IPythonFunctionType>() == null);
+                    if (!containsInnerTypes) {
+                        // For libraries remove declared local function variables to free up some memory.
+                        var optionsProvider = Eval.Services.GetService<IAnalysisOptionsProvider>();
+                        if (Module.ModuleType != ModuleType.User && optionsProvider?.Options.KeepLibraryLocalVariables != true) {
+                            ((VariableCollection)Eval.CurrentScope.Variables).Clear();
+                        }
                     }
                 }
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/SymbolCollector.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             // Classes and functions are only declared as scope variables
             // in the global scope. Inside a class they are added as members
             // since they cannot be accessed without the 'self' or other scoping prefix.
-            if (!(_eval.CurrentScope is IGlobalScope) && _typeMap[_eval.CurrentScope.Node] is PythonClassType cls) {
+            if (_eval.CurrentScope.ScopeType != ScopeType.Global && _typeMap[_eval.CurrentScope.Node] is PythonClassType cls) {
                 cls.AddMember(name, member, overwrite: true);
             } else {
                 // The variable is transient (non-user declared) hence it does not have location.

--- a/src/Analysis/Ast/Impl/Extensions/PythonFunctionExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/PythonFunctionExtensions.cs
@@ -20,15 +20,24 @@ using Microsoft.Python.Core;
 
 namespace Microsoft.Python.Analysis.Extensions {
     public static class PythonFunctionExtensions {
-        public static bool IsUnbound(this IPythonFunctionType f) 
+        public static bool IsUnbound(this IPythonFunctionType f)
             => f.DeclaringType != null && f.MemberType == PythonMemberType.Function;
 
-        public static bool IsBound(this IPythonFunctionType f) 
+        public static bool IsBound(this IPythonFunctionType f)
             => f.DeclaringType != null && f.MemberType == PythonMemberType.Method;
 
-        public static bool HasClassFirstArgument(this IPythonClassMember m)
-            => (m is IPythonFunctionType f && !f.IsStatic && (f.IsClassMethod || f.IsBound())) ||
-               (m is IPythonPropertyType prop);
+        public static bool HasClassFirstArgument(this IPythonClassMember m) {
+            switch (m) {
+                case IPythonFunctionType f:
+                    if (!(f.DeclaringType is IPythonClassType)) {
+                        return false;
+                    }
+                    return !f.IsStatic && (f.IsClassMethod || f.IsBound());
+                case IPythonPropertyType _:
+                    return true;
+            }
+            return false;
+        }
 
         public static IScope GetScope(this IPythonFunctionType f) {
             IScope gs = f.DeclaringModule.GlobalScope;

--- a/src/Analysis/Ast/Impl/Linting/UndefinedVariables/ExpressionWalker.cs
+++ b/src/Analysis/Ast/Impl/Linting/UndefinedVariables/ExpressionWalker.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
             return false;
         }
 
+        public override bool Walk(ExpressionWithAnnotation node) => false;
+
         public override bool Walk(NameExpression node) {
             if (_localNames?.Contains(node.Name) == true) {
                 return false;

--- a/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
@@ -21,7 +21,6 @@ using System.Threading;
 using Microsoft.Python.Analysis.Caching;
 using Microsoft.Python.Analysis.Core.DependencyResolution;
 using Microsoft.Python.Analysis.Core.Interpreter;
-using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.IO;

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Python.Analysis.Types {
             Location location,
             IPythonType declaringType,
             string documentation
-        ) : base(name, location, documentation, declaringType is IPythonClassType ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
+        ) : base(name, location, documentation, declaringType?.MemberType == PythonMemberType.Class ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
             DeclaringType = declaringType;
         }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Python.Analysis.Types {
             Location location
         ) : base(fd.Name, location,
             fd.Name == "__init__" ? (declaringType?.Documentation ?? fd.GetDocumentation()) : fd.GetDocumentation(), 
-            declaringType is IPythonClassType ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
+            declaringType?.MemberType == PythonMemberType.Class ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
             DeclaringType = declaringType;
 
             location.Module.AddAstNode(this, fd);

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionType.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Python.Analysis.Types {
             Location location,
             IPythonType declaringType,
             string documentation
-        ) : base(name, location, documentation, declaringType != null ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
+        ) : base(name, location, documentation, declaringType is IPythonClassType ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
             DeclaringType = declaringType;
         }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Python.Analysis.Types {
             Location location
         ) : base(fd.Name, location,
             fd.Name == "__init__" ? (declaringType?.Documentation ?? fd.GetDocumentation()) : fd.GetDocumentation(), 
-            declaringType != null ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
+            declaringType is IPythonClassType ? BuiltinTypeId.Method : BuiltinTypeId.Function) {
             DeclaringType = declaringType;
 
             location.Module.AddAstNode(this, fd);

--- a/src/Analysis/Ast/Impl/Types/PythonType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonType.cs
@@ -111,18 +111,6 @@ namespace Microsoft.Python.Analysis.Types {
 
         internal virtual void SetDocumentation(string documentation) => Documentation = documentation;
 
-        internal void AddMembers(IEnumerable<IVariable> variables, bool overwrite) {
-            lock (_lock) {
-                if (!_readonly) {
-                    foreach (var v in variables.Where(m => overwrite || !Members.ContainsKey(m.Name))) {
-                        // If variable holds function or a class, use value as member. 
-                        // If it holds an instance, use the variable itself (i.e. it is a data member).
-                        WritableMembers[v.Name] = v.Value;
-                    }
-                }
-            }
-        }
-
         internal void AddMembers(IEnumerable<KeyValuePair<string, IMember>> members, bool overwrite) {
             lock (_lock) {
                 if (!_readonly) {

--- a/src/Analysis/Ast/Impl/Values/Definitions/IScope.cs
+++ b/src/Analysis/Ast/Impl/Values/Definitions/IScope.cs
@@ -18,6 +18,13 @@ using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Values {
+    public enum ScopeType {
+        Global,
+        Function,
+        Class,
+        Other
+    }
+
     /// <summary>
     /// Represents scope where variables can be declared.
     /// </summary>
@@ -26,6 +33,11 @@ namespace Microsoft.Python.Analysis.Values {
         /// Scope name. Typically name of the scope-defining <see cref="IScope.Node"/>
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Type of the scope.
+        /// </summary>
+        ScopeType ScopeType { get; }
 
         /// <summary>
         /// Node defining the scope. Typically <see cref="ClassDefinition"/>

--- a/src/Analysis/Ast/Impl/Values/Definitions/VariableSource.cs
+++ b/src/Analysis/Ast/Impl/Values/Definitions/VariableSource.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Python.Analysis.Values {
         /// <summary>
         /// Variable is a built-in constant such as __debug__.
         /// </summary>
-        Builtin
+        Builtin,
+
+        /// <summary>
+        /// Variable is a class member.
+        /// </summary>
+        ClassMember
     }
 }

--- a/src/Analysis/Ast/Impl/Values/Scope.cs
+++ b/src/Analysis/Ast/Impl/Values/Scope.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Python.Analysis.Values {
 
         internal void AddChildScope(Scope s) => (_childScopes ?? (_childScopes = new List<Scope>())).Add(s);
 
-        private VariableCollection VariableCollection => _variables ?? (_variables = new VariableCollection());
+        internal VariableCollection VariableCollection => _variables ?? (_variables = new VariableCollection());
 
         private void DeclareBuiltinVariables() {
             if (Node == null || Module.ModuleType != ModuleType.User || this is IGlobalScope) {

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -650,5 +650,31 @@ a = x().func()
             var analysis = await GetAnalysisAsync(code);
             analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Int);
         }
+
+        [TestMethod, Priority(0)]
+        public async Task MemberCtorAssignment() {
+            const string code = @"
+class x:
+    y: int
+    z = y
+
+a = x().z
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Int);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task AmbiguousMemberAssignment() {
+            const string code = @"
+class x:
+    x: int
+    y = x
+
+a = x().y
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveVariable("a").OfType(BuiltinTypeId.Int);
+        }
     }
 }

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Python.Analysis.Tests {
             expected = expected.Concat(o.GetMemberNames()).Distinct().ToArray();
 
             var c2 = c.GetMember("C2").Should().BeAssignableTo<IPythonClassType>().Which;
+            c2.Should().NotBeNull();
             c2.GetMemberNames().Should().OnlyContain(expected);
             c2.GetMember("k").Should().BeAssignableTo<IPythonFunctionType>();
             c2.GetMember("__class__").Should().BeAssignableTo<IPythonClassType>();

--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -606,5 +606,27 @@ x = test()
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             analysis.Should().HaveVariable("x").OfType("Foo");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task AmbiguousOptionalParameterType() {
+            const string code = @"
+from typing import Optional
+class A: ...
+
+class B:
+    def __init__(self, A: Optional[A]):
+        self.name = name
+
+    @property
+    def A(self) -> int:
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var a = analysis.Should().HaveClass("A").Which;
+            analysis.Should().HaveClass("B")
+                .Which.Should().HaveMethod("__init__")
+                .Which.Should().HaveParameterAt(1)
+                .Which.Should().HaveType("A")
+                .Which.Should().BeOfType(a.GetType());
+        }
     }
 }

--- a/src/LanguageServer/Impl/Sources/DefinitionSource.cs
+++ b/src/LanguageServer/Impl/Sources/DefinitionSource.cs
@@ -232,24 +232,11 @@ namespace Microsoft.Python.LanguageServer.Sources {
                     }
                     break;
 
-                case IPythonClassType cls:
-                    // Data members may be instances that are not tracking locations.
-                    // In this case we'll try look up the respective variable instead.
-                    using (eval.OpenScope(cls)) {
-                        eval.LookupNameInScopes(mex.Name, out _, out var v2, LookupOptions.Local);
-                        if (v2 != null) {
-                            definingMember = v2;
-                            return FromMember(v2);
-                        }
-                    }
-                    break;
-
                 default:
                     if (type?.GetMember(mex.Name) is ILocatedMember lm) {
                         definingMember = lm;
                         return FromMember(lm);
                     }
-
                     break;
             }
             return null;

--- a/src/LanguageServer/Impl/Sources/HoverSource.cs
+++ b/src/LanguageServer/Impl/Sources/HoverSource.cs
@@ -73,6 +73,13 @@ namespace Microsoft.Python.LanguageServer.Sources {
 
                         break;
                     }
+
+                case FunctionDefinition fd when node is NamedExpression && fd.Parent != fd.GlobalParent:
+                    using (eval.OpenScope(eval.Module, fd.Parent)) {
+                        eval.CurrentScope.
+                    }
+                    break;
+
             }
 
             IMember value;

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -508,10 +508,10 @@ class C(object):
             var completionInOar = cs.GetCompletions(analysis, new SourceLocation(5, 9));
             var completionForAbc = cs.GetCompletions(analysis, new SourceLocation(5, 13));
 
-            completionInD.Should().HaveLabels("C", "D", "oar")
+            completionInD.Should().HaveLabels("C", "D")
                 .And.NotContainLabels("a", "abc", "self", "x", "fob", "baz");
 
-            completionInOar.Should().HaveLabels("C", "D", "a", "oar", "abc", "self", "x")
+            completionInOar.Should().HaveLabels("C", "D", "a", "abc", "self", "x")
                 .And.NotContainLabels("fob", "baz");
 
             completionForAbc.Should().HaveLabels("baz", "fob");
@@ -851,7 +851,7 @@ pass";
         [DataTestMethod, Priority(0)]
         public async Task NoCompletionInEllipsis(bool is2x) {
             const string code = "...";
-            var analysis = await GetAnalysisAsync(code, is2x ? PythonVersions.LatestAvailable2X: PythonVersions.LatestAvailable3X);
+            var analysis = await GetAnalysisAsync(code, is2x ? PythonVersions.LatestAvailable2X : PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
             var result = cs.GetCompletions(analysis, new SourceLocation(1, 4));
@@ -1221,6 +1221,35 @@ def test(x: Foo = func()):
             print = comps.Completions.FirstOrDefault(x => x.label == "print");
             print.Should().NotBeNull();
             print.insertText.Should().Be("print");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task ClassMemberAccess() {
+            const string code = @"
+class A:
+    class B: ...
+
+    x1 = 1
+
+    def __init__(self):
+        self.x2 = 1
+
+    def method1(self):
+        return self.
+
+    def method2(self):
+        
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
+
+            var comps = cs.GetCompletions(analysis, new SourceLocation(14, 8));
+            var names = comps.Completions.Select(c => c.label);
+            names.Should().NotContain(new[] { "x1", "x2", "method1", "method2", "B" });
+
+            comps = cs.GetCompletions(analysis, new SourceLocation(11, 21));
+            names = comps.Completions.Select(c => c.label);
+            names.Should().Contain(new[] { "x1", "x2", "method1", "method2", "B" });
         }
     }
 }

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -1243,13 +1243,13 @@ class A:
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion);
 
-            var comps = cs.GetCompletions(analysis, new SourceLocation(14, 8));
+            var comps = cs.GetCompletions(analysis, new SourceLocation(11, 21));
             var names = comps.Completions.Select(c => c.label);
-            names.Should().NotContain(new[] { "x1", "x2", "method1", "method2", "B" });
-
-            comps = cs.GetCompletions(analysis, new SourceLocation(11, 21));
-            names = comps.Completions.Select(c => c.label);
             names.Should().Contain(new[] { "x1", "x2", "method1", "method2", "B" });
+
+            comps = cs.GetCompletions(analysis, new SourceLocation(14, 8));
+            names = comps.Completions.Select(c => c.label);
+            names.Should().NotContain(new[] { "x1", "x2", "method1", "method2", "B" });
         }
     }
 }


### PR DESCRIPTION
Fixes #1231 

Root cause is that class evaluator was declaring members as variables and then collected variables into members. Changes:
- introduce callback action that can decide if it wants to declare variable or add a class member.
- class variables type is added so completion can tell what to show depending on context
- class variables in class scope can be accesses without `self` while in method scopes and other places require `self`. Thus they are declared as both variables and members.