### PR TITLE
Log full exception on session failure

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
         private void LogException(IPythonModule module, Exception exception) {
             if (_log != null) {
-                _log.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) failed. Exception message: {exception.Message}.");
+                _log.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) failed. {exception}");
             }
         }
 


### PR DESCRIPTION
For #1401.

We should really have more info here than just the message, but I'm also worried that this might be _too_ much for long stack traces. Thoughts?