### PR TITLE
String forward reference support

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
@@ -40,11 +40,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                         return result.GetPythonType();
                     }
                     break;
-                // Handle forward references e.g x: 'int' or x: 'Dict[int, str]'
-                // Try to get type from string 
-                case ConstantExpression constExpr when !string.IsNullOrEmpty(constExpr.GetStringValue()):
-                    Expression forwardRefExpr = TryCreateExpression(constExpr.GetStringValue());
-                    return GetTypeFromAnnotation(forwardRefExpr, out isGeneric, options);
             }
 
             // Look at specialization and typing first

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
@@ -13,9 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System.IO;
 using Microsoft.Python.Analysis.Types;
-using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
@@ -45,17 +43,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             // Look at specialization and typing first
             var ann = new TypeAnnotation(Ast.LanguageVersion, expr);
             return ann.GetValue(new TypeAnnotationConverter(this, expr, options));
-        }
-
-        private Expression TryCreateExpression(string expression) {
-            using (var sr = new StringReader($"{expression}")) {
-                var parser = Parser.CreateParser(sr, Interpreter.LanguageVersion, ParserOptions.Default);
-                var ast = parser.ParseFile();
-                if (ast.Body is SuiteStatement ste && ste.Statements.Count > 0 && ste.Statements[0] is ExpressionStatement es) {
-                    return es.Expression;
-                }
-            }
-            return null;
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return ann.GetValue(new TypeAnnotationConverter(this, expr, options));
         }
 
-        public Expression TryCreateExpression(string expression) {
+        private Expression TryCreateExpression(string expression) {
             using (var sr = new StringReader($"{expression}")) {
                 var parser = Parser.CreateParser(sr, Interpreter.LanguageVersion, ParserOptions.Default);
                 var ast = parser.ParseFile();

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Annotations.cs
@@ -13,7 +13,9 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.IO;
 using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
@@ -38,11 +40,27 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                         return result.GetPythonType();
                     }
                     break;
+                // Handle forward references e.g x: 'int' or x: 'Dict[int, str]'
+                // Try to get type from string 
+                case ConstantExpression constExpr when !string.IsNullOrEmpty(constExpr.GetStringValue()):
+                    Expression forwardRefExpr = TryCreateExpression(constExpr.GetStringValue());
+                    return GetTypeFromAnnotation(forwardRefExpr, out isGeneric, options);
             }
 
             // Look at specialization and typing first
             var ann = new TypeAnnotation(Ast.LanguageVersion, expr);
             return ann.GetValue(new TypeAnnotationConverter(this, expr, options));
+        }
+
+        public Expression TryCreateExpression(string expression) {
+            using (var sr = new StringReader($"{expression}")) {
+                var parser = Parser.CreateParser(sr, Interpreter.LanguageVersion, ParserOptions.Default);
+                var ast = parser.ParseFile();
+                if (ast.Body is SuiteStatement ste && ste.Statements.Count > 0 && ste.Statements[0] is ExpressionStatement es) {
+                    return es.Expression;
+                }
+            }
+            return null;
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -138,16 +138,19 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
 
         /// <summary>
         /// Given an index argument, will try and resolve it to a forward reference, e.g
+        /// Forward references are types declared in quotes, e.g 'int' is equivalent to type int
         /// 
         /// List['str'] => List[str]
+        /// 'A[int]' => A[int]
         /// </summary>
         private IMember GetValueFromForwardRef(IMember index) {
-            index.TryGetConstant(out string memberName);
-            if (string.IsNullOrEmpty(memberName)) {
+            index.TryGetConstant(out string forwardRefStr);
+            if (string.IsNullOrEmpty(forwardRefStr)) {
                 return null;
             }
 
-            return LookupNameInScopes(memberName, out var _, out var _, LookupOptions.Normal);
+            var forwardRefExpr = TryCreateExpression(forwardRefStr);
+            return GetValueFromExpression(forwardRefExpr);
         }
 
         private IReadOnlyList<IMember> EvaluateCallArgs(CallExpression expr) {

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Specializations.Typing;
@@ -151,6 +152,17 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
 
             var forwardRefExpr = TryCreateExpression(forwardRefStr);
             return GetValueFromExpression(forwardRefExpr);
+        }
+
+        private Expression TryCreateExpression(string expression) {
+            using (var sr = new StringReader($"{expression}")) {
+                var parser = Parser.CreateParser(sr, Interpreter.LanguageVersion, ParserOptions.Default);
+                var ast = parser.ParseFile();
+                if (ast.Body is SuiteStatement ste && ste.Statements.Count > 0 && ste.Statements[0] is ExpressionStatement es) {
+                    return es.Expression;
+                }
+            }
+            return null;
         }
 
         private IReadOnlyList<IMember> EvaluateCallArgs(CallExpression expr) {

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -21,6 +21,7 @@ using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Specializations.Typing;
 using Microsoft.Python.Analysis.Specializations.Typing.Types;
 using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Analysis.Utilities;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
 using Microsoft.Python.Parsing;
@@ -150,19 +151,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 return null;
             }
 
-            var forwardRefExpr = TryCreateExpression(forwardRefStr);
+            var forwardRefExpr = AstUtilities.TryCreateExpression(forwardRefStr, Interpreter.LanguageVersion);
             return GetValueFromExpression(forwardRefExpr);
-        }
-
-        private Expression TryCreateExpression(string expression) {
-            using (var sr = new StringReader($"{expression}")) {
-                var parser = Parser.CreateParser(sr, Interpreter.LanguageVersion, ParserOptions.Default);
-                var ast = parser.ParseFile();
-                if (ast.Body is SuiteStatement ste && ste.Statements.Count > 0 && ste.Statements[0] is ExpressionStatement es) {
-                    return es.Expression;
-                }
-            }
-            return null;
         }
 
         private IReadOnlyList<IMember> EvaluateCallArgs(CallExpression expr) {

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Specializations.Typing;

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Generics.cs
@@ -141,8 +141,6 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         /// 
         /// List['str'] => List[str]
         /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
         private IMember GetValueFromForwardRef(IMember index) {
             index.TryGetConstant(out string memberName);
             if (string.IsNullOrEmpty(memberName)) {

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionOverload.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionOverload.cs
@@ -107,6 +107,12 @@ namespace Microsoft.Python.Analysis.Types {
                     return returnType.GetPythonType().Name;
                 }
             }
+            
+            // Use annotation value if it is there
+            if(_fromAnnotation && !StaticReturnValue.IsUnknown()) {
+                return StaticReturnValue.GetPythonType().Name;
+            }
+
             return _returnDocumentation;
         }
 

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionOverload.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionOverload.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Python.Analysis.Types {
         public string Documentation { get; private set; }
 
         public string GetReturnDocumentation(IPythonType self = null) {
+            // If inside a class, 
             if (self != null) {
                 var returnType = GetSpecificReturnType(self as IPythonClassType, null);
                 if (!returnType.IsUnknown()) {

--- a/src/Analysis/Ast/Impl/Types/PythonFunctionOverload.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonFunctionOverload.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Python.Analysis.Types {
         public string Documentation { get; private set; }
 
         public string GetReturnDocumentation(IPythonType self = null) {
-            // If inside a class, 
             if (self != null) {
                 var returnType = GetSpecificReturnType(self as IPythonClassType, null);
                 if (!returnType.IsUnknown()) {

--- a/src/Analysis/Ast/Impl/Utilities/AstUtilities.cs
+++ b/src/Analysis/Ast/Impl/Utilities/AstUtilities.cs
@@ -25,5 +25,16 @@ namespace Microsoft.Python.Analysis.Utilities {
                 return Parser.CreateParser(sr, PythonLanguageVersion.None).ParseFile(documentUri);
             }
         }
+
+        public static Expression TryCreateExpression(string expression, PythonLanguageVersion version) {
+            using (var sr = new StringReader(expression)) {
+                var parser = Parser.CreateParser(sr, version, ParserOptions.Default);
+                var ast = parser.ParseFile();
+                if (ast.Body is SuiteStatement ste && ste.Statements.Count > 0 && ste.Statements[0] is ExpressionStatement es) {
+                    return es.Expression;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/src/Analysis/Ast/Test/GenericsTests.cs
+++ b/src/Analysis/Ast/Test/GenericsTests.cs
@@ -1116,6 +1116,30 @@ d = Dict['float', 'str']
         }
 
         [TestMethod, Priority(0)]
+        public async Task GenericListForwardRef() {
+            const string code = @"
+from typing import List, Dict
+class A: ...
+class B: ...
+
+def test() -> 'List[A]':
+    pass
+
+def test1() -> 'Dict[A, B]':
+    pass
+
+x = test()
+y = test1()
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("x")
+                .Which.Should().HaveType("List[A]");
+            analysis.Should().HaveVariable("y")
+                        .Which.Should().HaveType("Dict[A, B]");
+        }
+
+
+        [TestMethod, Priority(0)]
         public async Task GenericClassForwardRef() {
             const string code = @"
 from typing import Generic, TypeVar

--- a/src/Analysis/Ast/Test/GenericsTests.cs
+++ b/src/Analysis/Ast/Test/GenericsTests.cs
@@ -1079,19 +1079,27 @@ y = boxedstr.get()
         public async Task GenericForwardRef() {
             const string code = @"
 from typing import List, Dict
+
+x = List['A']
+y = Dict['A', 'B']
+
 class A:
     def test(self) -> int:
         pass
 class B:
     def test(self) -> int:
         pass
-l = List['A']
-d = Dict['A', 'B']
+z = List['A']
+w = Dict['A', 'B']
 ";
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
-            analysis.Should().HaveVariable("l")
+            analysis.Should().HaveVariable("x")
                 .Which.Should().HaveType("List[A]");
-            analysis.Should().HaveVariable("d")
+            analysis.Should().HaveVariable("y")
+                           .Which.Should().HaveType("Dict[A, B]");
+            analysis.Should().HaveVariable("z")
+                .Which.Should().HaveType("List[A]");
+            analysis.Should().HaveVariable("w")
                            .Which.Should().HaveType("Dict[A, B]");
         }
 
@@ -1099,12 +1107,6 @@ d = Dict['A', 'B']
         public async Task GenericBuiltinTypeForwardRef() {
             const string code = @"
 from typing import List, Dict
-class A:
-    def test(self) -> int:
-        pass
-class B:
-    def test(self) -> int:
-        pass
 l = List['int']
 d = Dict['float', 'str']
 ";
@@ -1119,14 +1121,15 @@ d = Dict['float', 'str']
         public async Task GenericListForwardRef() {
             const string code = @"
 from typing import List, Dict
-class A: ...
-class B: ...
 
 def test() -> 'List[A]':
     pass
 
 def test1() -> 'Dict[A, B]':
     pass
+
+class A: ...
+class B: ...
 
 x = test()
 y = test1()
@@ -1147,6 +1150,45 @@ from typing import Generic, TypeVar
 T = TypeVar('T')
 K = TypeVar('K')
 
+class B(Generic[T, K]):
+    def test(self) -> T:
+        pass
+
+    def test1(self) -> K:
+        pass
+
+b = B['A', 'A']()
+y = b.test()
+z = b.test1()
+
+class A(Generic[T]):
+    def test(self) -> T:
+        pass
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            analysis.Should().HaveVariable("b")
+                          .Which.Should().HaveType("B[A, A]");
+            analysis.Should().HaveVariable("y")
+                           .Which.Should().HaveType("A");
+            analysis.Should().HaveVariable("z")
+                                      .Which.Should().HaveType("A");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task GenericClassForwardRefNestedGenerics() {
+            const string code = @"
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+K = TypeVar('K')
+
+a = A['B']()
+x = a.test()
+
+b = B['A[int]', 'A[str]']()
+y = b.test()
+z = b.test1()
+
 class A(Generic[T]):
     def test(self) -> T:
         pass
@@ -1157,13 +1199,6 @@ class B(Generic[T, K]):
 
     def test1(self) -> K:
         pass
-
-a = A['B']()
-x = a.test()
-
-b = B['A', 'A']()
-y = b.test()
-z = b.test1()
 ";
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             analysis.Should().HaveVariable("a")
@@ -1172,12 +1207,13 @@ z = b.test1()
                            .Which.Should().HaveType("B");
 
             analysis.Should().HaveVariable("b")
-                          .Which.Should().HaveType("B[A, A]");
+                          .Which.Should().HaveType("B[A[int], A[str]]");
             analysis.Should().HaveVariable("y")
-                           .Which.Should().HaveType("A");
+                           .Which.Should().HaveType("A[int]");
             analysis.Should().HaveVariable("z")
-                                      .Which.Should().HaveType("A");
+                                      .Which.Should().HaveType("A[str]");
         }
+
 
         [TestMethod, Priority(0)]
         public async Task GenericFunctionArguments() {

--- a/src/Analysis/Ast/Test/TypeshedTests.cs
+++ b/src/Analysis/Ast/Test/TypeshedTests.cs
@@ -55,7 +55,7 @@ e1, e2, e3 = sys.exc_info()
 
             f.Overloads.Should().HaveCount(1);
             f.Overloads[0].GetReturnDocumentation(null)
-                .Should().Be(@"Tuple[ (Optional[Type[BaseException]],Optional[BaseException],Optional[TracebackType])]");
+                .Should().Be(@"Tuple[Type[BaseException], BaseException, TracebackType]");
         }
 
         [TestMethod, Priority(0)]
@@ -72,7 +72,7 @@ scanner = _json.make_scanner()";
                     .And.HaveParameters("self", "string", "index")
                     .And.HaveParameterAt(1).WithName("string").WithType("str").WithNoDefaultValue()
                     .And.HaveParameterAt(2).WithName("index").WithType("int").WithNoDefaultValue()
-                    .And.HaveReturnDocumentation("Tuple[ (Any,int)]");
+                    .And.HaveReturnDocumentation("Tuple[Any, int]");
         }
 
         [TestMethod, Priority(0)]

--- a/src/LanguageServer/Test/SignatureTests.cs
+++ b/src/LanguageServer/Test/SignatureTests.cs
@@ -187,6 +187,39 @@ y = get()
             sig.signatures[0].label.Should().Be("get() -> int");
         }
 
+        [TestMethod, Priority(0)]
+        public async Task UnknownForwardRefUnboundFunction() {
+            const string code = @"
+def get() -> 'unknown_type':
+    pass
+
+y = get()
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var src = new SignatureSource(new PlainTextDocumentationSource());
+
+            var sig = src.GetSignature(analysis, new SourceLocation(5, 9));
+            sig.signatures.Should().NotBeNull();
+            sig.signatures.Length.Should().Be(1);
+            sig.signatures[0].label.Should().Be("get() -> 'unknown_type'");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task UnknownForwardRefParam() {
+            const string code = @"
+def get(v: 'tmp[unknown_type]') -> 'unknown_type':
+    pass
+
+y = get()
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var src = new SignatureSource(new PlainTextDocumentationSource());
+
+            var sig = src.GetSignature(analysis, new SourceLocation(5, 9));
+            sig.signatures.Should().NotBeNull();
+            sig.signatures.Length.Should().Be(1);
+            sig.signatures[0].label.Should().Be("get(v) -> 'unknown_type'");
+        }
 
         [TestMethod, Priority(0)]
         public async Task ForwardRefMethod() {

--- a/src/LanguageServer/Test/SignatureTests.cs
+++ b/src/LanguageServer/Test/SignatureTests.cs
@@ -243,6 +243,11 @@ y = get()
             sig.signatures.Should().NotBeNull();
             sig.signatures.Length.Should().Be(1);
             sig.signatures[0].label.Should().Be("get() -> int");
+
+            sig = src.GetSignature(analysis, new SourceLocation(12, 9));
+            sig.signatures.Should().NotBeNull();
+            sig.signatures.Length.Should().Be(1);
+            sig.signatures[0].label.Should().Be("get() -> int");
         }
 
         [TestMethod, Priority(0)]
@@ -286,6 +291,28 @@ x = boxedint.get(5)
             sig.signatures.Length.Should().Be(1);
             sig.signatures[0].label.Should().Be("get(x: Sequence[List[int]]) -> int");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task ForwardRefNestedQuotedGenericReturnValue() {
+            const string code = @"
+from typing import List, Sequence
+
+class Box():
+    def get(self, x: 'Sequence[List[int]]') -> 'Sequence[List[int]]':
+        return self.v
+
+boxedint = Box()
+x = boxedint.get(5)
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var src = new SignatureSource(new PlainTextDocumentationSource());
+
+            var sig = src.GetSignature(analysis, new SourceLocation(9, 19));
+            sig.signatures.Should().NotBeNull();
+            sig.signatures.Length.Should().Be(1);
+            sig.signatures[0].label.Should().Be("get(x: Sequence[List[int]]) -> Sequence[List[int]]");
+        }
+
 
         [TestMethod, Priority(0)]
         public async Task ForwardRefQuotedGenericTypeParameter() {


### PR DESCRIPTION
Fixes #1186.
Handles cases such as:

```
class A: ...
class Bar: ...
def tmp(v: 'List[str]') -> 'List[str]'
def tmp(v: 'Bar') -> List['Bar']
def tmp(v: 'str') -> 'A'
```

So instead of returning unknown, we try to evaluate what is inside the quotes.
* Updated the type annotation hint code to handle forward references so parameters get the correct types.
* Handled values in quotes when creating Generic types
* Handled forward reference return value hints
