### PR TITLE
Moving location of inherit-non-class diagnostic to arguments

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 if (IsValidBase(a)) {
                     TryAddBase(bases, a);
                 } else {
-                    ReportInvalidBase(a.ToCodeString(Eval.Ast, CodeFormattingOptions.Traditional));
+                    ReportInvalidBase(a);
                 }
             }
 
@@ -196,11 +196,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             _class.AddMembers(members, false);
         }
 
-        private void ReportInvalidBase(string argVal) {
+        private void ReportInvalidBase(Arg arg) {
             Eval.ReportDiagnostics(Eval.Module.Uri,
                 new DiagnosticsEntry(
-                Resources.InheritNonClass.FormatInvariant(argVal),
-                _classDef.NameExpression.GetLocation(Eval)?.Span ?? default,
+                Resources.InheritNonClass.FormatInvariant(arg.ToCodeString(Eval.Ast, CodeFormattingOptions.Traditional)), 
+                Eval.GetLocation(arg)?.Span ?? default,
                 Diagnostics.ErrorCodes.InheritNonClass,
                 Severity.Warning,
                 DiagnosticSource.Analysis

--- a/src/Analysis/Ast/Test/LintInheritNonClassTests.cs
+++ b/src/Analysis/Ast/Test/LintInheritNonClassTests.cs
@@ -91,7 +91,7 @@ class C(5):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(2, 7, 2, 8);
+            diagnostic.SourceSpan.Should().Be(2, 9, 2, 10);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("5"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -116,12 +116,12 @@ class D(x):
             analysis.Diagnostics.Should().HaveCount(2);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(4, 7, 4, 8);
+            diagnostic.SourceSpan.Should().Be(4, 9, 4, 10);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("x"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
 
             diagnostic = analysis.Diagnostics.ElementAt(1);
-            diagnostic.SourceSpan.Should().Be(10, 7, 10, 8);
+            diagnostic.SourceSpan.Should().Be(10, 9, 10, 10);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("x"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -243,7 +243,7 @@ class C(b.test):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(12, 7, 12, 8);
+            diagnostic.SourceSpan.Should().Be(12, 9, 12, 15);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("b.test"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -270,7 +270,7 @@ class C(b.test):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(12, 7, 12, 8);
+            diagnostic.SourceSpan.Should().Be(12, 9, 12, 15);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("b.test"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -293,7 +293,7 @@ class C(b.test):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(9, 7, 9, 8);
+            diagnostic.SourceSpan.Should().Be(9, 9, 9, 15);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("b.test"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -333,7 +333,7 @@ class C(b.test):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(8, 7, 8, 8);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 15);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("b.test"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -355,7 +355,7 @@ class C(b):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(8, 7, 8, 8);
+            diagnostic.SourceSpan.Should().Be(8, 9, 8, 10);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("b"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -374,7 +374,7 @@ class C(test):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(5, 7, 5, 8);
+            diagnostic.SourceSpan.Should().Be(5, 9, 5, 13);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("test"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }
@@ -409,7 +409,7 @@ class Bar(Foo):
             analysis.Diagnostics.Should().HaveCount(1);
 
             var diagnostic = analysis.Diagnostics.ElementAt(0);
-            diagnostic.SourceSpan.Should().Be(4, 7, 4, 10);
+            diagnostic.SourceSpan.Should().Be(4, 11, 4, 12);
             diagnostic.Message.Should().Be(Resources.InheritNonClass.FormatInvariant("X"));
             diagnostic.ErrorCode.Should().Be(ErrorCodes.InheritNonClass);
         }


### PR DESCRIPTION
<img width="581" alt="inherit-non-class" src="https://user-images.githubusercontent.com/18249186/63061743-199e4a80-beab-11e9-8f4f-40002b680308.png">


Before it would have double messages on the function which can be pretty annoying. 