### PR TITLE
Synchronize text buffer access

### DIFF
--- a/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
@@ -30,10 +30,7 @@ namespace Microsoft.Python.Analysis.Documents {
         public string Text {
             get {
                 lock (_lock) {
-                    if (_content == null) {
-                        _content = _sb?.ToString() ?? string.Empty;
-                    }
-                    return _content;
+                    return _content ?? (_content = _sb?.ToString() ?? string.Empty);
                 }
             }
         }

--- a/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Python.Analysis.Documents {
                 lock (_lock) {
                     if (_content == null) {
                         _content = _sb?.ToString() ?? string.Empty;
-                        _sb = null;
                     }
                     return _content;
                 }

--- a/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
@@ -21,34 +21,50 @@ using Microsoft.Python.Parsing;
 
 namespace Microsoft.Python.Analysis.Documents {
     internal sealed class DocumentBuffer {
+        private readonly object _lock = new object();
         private StringBuilder _sb;
         private string _content;
 
         public int Version { get; private set; }
-        public string Text => _content ?? (_content = _sb.ToString());
+
+        public string Text {
+            get {
+                lock (_lock) {
+                    if (_content == null) {
+                        _content = _sb.ToString();
+                        _sb = null;
+                    }
+                    return _content;
+                }
+            }
+        }
 
         public void Reset(int version, string content) {
-            Version = version;
-            _content = content ?? string.Empty;
-            _sb = null;
+            lock (_lock) {
+                Version = version;
+                _content = content ?? string.Empty;
+                _sb = null;
+            }
         }
 
         public void Update(IEnumerable<DocumentChange> changes) {
-            _sb = _sb ?? new StringBuilder(_content);
-            _content = null;
+            StringBuilder sb;
+            lock (_lock) {
+                sb = new StringBuilder(_content);
+            }
 
             var lastStart = int.MaxValue;
-            var lineLoc = SplitLines(_sb).ToArray();
+            var lineLoc = SplitLines(sb).ToArray();
 
             foreach (var change in changes) {
                 if (change.ReplaceAllText) {
-                    _sb = new StringBuilder(change.InsertedText);
+                    sb = new StringBuilder(change.InsertedText);
                     lastStart = int.MaxValue;
                     lineLoc = SplitLines(_sb).ToArray();
                     continue;
                 }
 
-                var start = NewLineLocation.LocationToIndex(lineLoc, change.ReplacedSpan.Start, _sb.Length);
+                var start = NewLineLocation.LocationToIndex(lineLoc, change.ReplacedSpan.Start, sb.Length);
                 if (start > lastStart) {
                     throw new InvalidOperationException("changes must be in reverse order of start location");
                 }
@@ -56,13 +72,18 @@ namespace Microsoft.Python.Analysis.Documents {
 
                 var end = NewLineLocation.LocationToIndex(lineLoc, change.ReplacedSpan.End, _sb.Length);
                 if (end > start) {
-                    _sb.Remove(start, end - start);
+                    sb.Remove(start, end - start);
                 }
                 if (!string.IsNullOrEmpty(change.InsertedText)) {
-                    _sb.Insert(start, change.InsertedText);
+                    sb.Insert(start, change.InsertedText);
                 }
             }
-            Version++;
+
+            lock (_lock) {
+                Version++;
+                _sb = sb;
+                _content = null;
+            }
         }
 
         private static IEnumerable<NewLineLocation> SplitLines(StringBuilder text) {


### PR DESCRIPTION
Fixes #1466
Fixes #1499
Fixes #1425
Fixes #1353 

Although text buffer updates from the same thread, it does can be read concurrently by the analysis and Reset can be called as well (although this is probably extremely rare as we do not call Reset on user files when analysis completes).

Call for content by the parser or analyzer may cause conversion of the string builder to `_content` in the middle of the string builder update yielding odd partial results.