### PR TITLE
Improve handling of circular and imported class bases

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Scopes.cs
@@ -49,6 +49,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public void DeclareVariable(string name, IMember value, VariableSource source, Location location, bool overwrite = true) {
             var member = GetInScope(name);
             if (member != null && !overwrite) {
+                if (source == VariableSource.Import) {
+                    // Duplicate declaration so if variable gets overwritten it can still be retrieved. Consider:
+                    //    from X import A
+                    //    class A(A): ...
+                    CurrentScope.DeclareImported(name, value, location);
+                }
                 return;
             }
             if (source == VariableSource.Import && value is IVariable v) {

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
@@ -80,16 +80,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             TryHandleClassVariable(node, value);
         }
 
-        private bool IsValidAssignment(string name, Location loc) {
-            if (Eval.GetInScope(name) is ILocatedMember m) {
-                // Class and function definition are processed first, so only override
-                // if assignment happens after declaration
-                if (loc.IndexSpan.Start < m.Location.IndexSpan.Start) {
-                    return false;
-                }
-            }
-            return true;
-        }
+        private bool IsValidAssignment(string name, Location loc) => !Eval.GetInScope(name).IsDeclaredAfter(loc);
 
         public void HandleAnnotatedExpression(ExpressionWithAnnotation expr, IMember value) {
             if (expr?.Annotation == null) {

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -361,9 +361,9 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
         private void LogCompleted(IDependencyChainNode<PythonAnalyzerEntry> node, IPythonModule module, Stopwatch stopWatch, TimeSpan startTime) {
             if (_log != null) {
-                var completed = node != null && module.Analysis is LibraryAnalysis ? "completed for library" : "completed ";
+                var completed = node != null && module.Analysis is LibraryAnalysis ? "completed for library" : "completed";
                 var message = node != null
-                    ? $"Analysis of {module.Name}({module.ModuleType}) on depth {node.VertexDepth} {completed} in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms."
+                    ? $"Analysis of {module.Name} ({module.ModuleType}) on depth {node.VertexDepth} {completed} in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms."
                     : $"Out of order analysis of {module.Name}({module.ModuleType}) completed in {(stopWatch.Elapsed - startTime).TotalMilliseconds} ms.";
                 _log.Log(TraceEventType.Verbose, message);
             }

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 _class = classInfo;
 
                 var bases = ProcessBases();
-                _class.SetBases(bases, Eval);
+                _class.SetBases(bases, Eval.CurrentScope);
                 _class.DecideGeneric();
                 // Declare __class__ variable in the scope.
                 Eval.DeclareVariable("__class__", _class, VariableSource.Declaration);

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 _class = classInfo;
 
                 var bases = ProcessBases();
-                _class.SetBases(bases);
+                _class.SetBases(bases, Eval);
                 _class.DecideGeneric();
                 // Declare __class__ variable in the scope.
                 Eval.DeclareVariable("__class__", _class, VariableSource.Declaration);

--- a/src/Analysis/Ast/Impl/Extensions/EvaluatorExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/EvaluatorExtensions.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Python.Analysis {
 
         public static IMember LookupImportedNameInScopes(this IExpressionEvaluator eval, string name, out IScope scope) {
             scope = null;
-            foreach(var s in eval.CurrentScope.EnumerateTowardsGlobal) {
+            foreach (var s in eval.CurrentScope.EnumerateTowardsGlobal) {
                 var v = s.Imported[name];
-                if(v != null) {
+                if (v != null) {
                     scope = s;
                     return v.Value;
                 }

--- a/src/Analysis/Ast/Impl/Extensions/EvaluatorExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/EvaluatorExtensions.cs
@@ -25,18 +25,6 @@ namespace Microsoft.Python.Analysis {
         public static IMember LookupNameInScopes(this IExpressionEvaluator eval, string name, LookupOptions options = LookupOptions.Normal)
             => eval.LookupNameInScopes(name, out _, out _, options);
 
-        public static IMember LookupImportedNameInScopes(this IExpressionEvaluator eval, string name, out IScope scope) {
-            scope = null;
-            foreach (var s in eval.CurrentScope.EnumerateTowardsGlobal) {
-                var v = s.Imported[name];
-                if (v != null) {
-                    scope = s;
-                    return v.Value;
-                }
-            }
-            return null;
-        }
-
         public static IDisposable OpenScope(this IExpressionEvaluator eval, IPythonClassType cls)
          => eval.OpenScope(cls.DeclaringModule, cls.ClassDefinition);
         public static IDisposable OpenScope(this IExpressionEvaluator eval, IPythonFunctionType ft)

--- a/src/Analysis/Ast/Impl/Extensions/EvaluatorExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/EvaluatorExtensions.cs
@@ -24,6 +24,19 @@ namespace Microsoft.Python.Analysis {
             => eval.LookupNameInScopes(name, out scope, out _, options);
         public static IMember LookupNameInScopes(this IExpressionEvaluator eval, string name, LookupOptions options = LookupOptions.Normal)
             => eval.LookupNameInScopes(name, out _, out _, options);
+
+        public static IMember LookupImportedNameInScopes(this IExpressionEvaluator eval, string name, out IScope scope) {
+            scope = null;
+            foreach(var s in eval.CurrentScope.EnumerateTowardsGlobal) {
+                var v = s.Imported[name];
+                if(v != null) {
+                    scope = s;
+                    return v.Value;
+                }
+            }
+            return null;
+        }
+
         public static IDisposable OpenScope(this IExpressionEvaluator eval, IPythonClassType cls)
          => eval.OpenScope(cls.DeclaringModule, cls.ClassDefinition);
         public static IDisposable OpenScope(this IExpressionEvaluator eval, IPythonFunctionType ft)

--- a/src/Analysis/Ast/Impl/Extensions/MemberExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/MemberExtensions.cs
@@ -112,5 +112,9 @@ namespace Microsoft.Python.Analysis {
             => lm.IsDeclaredAfter(other.Location);
         public static bool IsDeclaredAfter(this ILocatedMember lm, Location loc)
             => lm.Location.IndexSpan.Start > loc.IndexSpan.Start;
+        public static bool IsDeclaredAfterOrAt(this ILocatedMember lm, ILocatedMember other)
+            => lm.IsDeclaredAfterOrAt(other.Location);
+        public static bool IsDeclaredAfterOrAt(this ILocatedMember lm, Location loc)
+            => lm.Location.IndexSpan.Start >= loc.IndexSpan.Start;
     }
 }

--- a/src/Analysis/Ast/Impl/Extensions/MemberExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/MemberExtensions.cs
@@ -14,7 +14,6 @@
 // permissions and limitations under the License.
 
 using System.Diagnostics;
-using Microsoft.Python.Analysis.Specializations.Typing;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
 
@@ -106,5 +105,12 @@ namespace Microsoft.Python.Analysis {
             return parent;
         }
 
+        public static bool IsDeclaredAfter(this IMember m, Location loc)
+            => m is ILocatedMember lm && lm.IsDeclaredAfter(loc);
+
+        public static bool IsDeclaredAfter(this ILocatedMember lm, ILocatedMember other)
+            => lm.IsDeclaredAfter(other.Location);
+        public static bool IsDeclaredAfter(this ILocatedMember lm, Location loc)
+            => lm.Location.IndexSpan.Start > loc.IndexSpan.Start;
     }
 }

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Python.Analysis.Types {
                     }
 
                     // Set specific class bases 
-                    classType.SetBases(specificBases.Concat(newBases), args.Eval);
+                    classType.SetBases(specificBases.Concat(newBases), args.Eval.CurrentScope);
                     // Now that parameters are set, check if class is generic
                     classType._parameters = classType._genericParameters.Values.Distinct().OfType<IGenericTypeParameter>().ToList();
                     classType.DecideGeneric();

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
@@ -61,23 +61,19 @@ namespace Microsoft.Python.Analysis.Types {
         /// </summary>
         public IPythonType CreateSpecificType(IArgumentSet args) {
             lock (_genericParameterLock) {
-                var genericTypeParameters = GetTypeParameters();
+                var newGenericTypeParameters = GetTypeParameters();
                 var newBases = new List<IPythonType>();
 
                 // Get map of generic type parameter to specific type - fill in what type goes to what
                 // type parameter T -> int, U -> str, etc.
-                var genericTypeToSpecificType = GetSpecificTypes(args, genericTypeParameters, newBases);
+                var genericTypeToSpecificType = GetSpecificTypes(args, newGenericTypeParameters, newBases);
 
                 var classType = new PythonClassType(BaseName, new Location(DeclaringModule));
                 // Storing generic parameters allows methods returning generic types 
                 // to know what type parameter returns what specific type
-                classType.StoreGenericParameters(genericTypeParameters, genericTypeToSpecificType);
+                classType.StoreGenericParameters(GenericParameters, newGenericTypeParameters, genericTypeToSpecificType);
 
                 // Set generic name
-                if (!classType._genericParameters.IsNullOrEmpty()) {
-                    classType._genericName = CodeFormatter.FormatSequence(BaseName, '[', classType._genericParameters.Values);
-                }
-
                 // Locking so threads can only access class after it's been initialized
                 // Store generic parameters first so name updates correctly, then check if class type has been cached
                 _specificTypeCache = _specificTypeCache ?? new Dictionary<string, PythonClassType>();
@@ -106,8 +102,8 @@ namespace Microsoft.Python.Analysis.Types {
                     // Get list of bases that are generic but not generic class parameters, e.g A[T], B[T] but not Generic[T1, T2]
                     var genericTypeBases = bases.Except(genericClassParameters).OfType<IGenericType>().Where(g => g.IsGeneric).ToArray();
 
-                    // Removing all generic bases, and will only specialize genericTypeBases, remove generic class paramters entirely
-                    // We remove generic class paramters entirely because the type information is now stored in GenericParameters field
+                    // Removing all generic bases, and will only specialize genericTypeBases, remove generic class parameters entirely
+                    // We remove generic class parameters entirely because the type information is now stored in GenericParameters field
                     // We still need generic bases so we can specialize them 
                     var specificBases = bases.Except(genericTypeBases).Except(genericClassParameters).ToList();
 
@@ -215,7 +211,7 @@ namespace Microsoft.Python.Analysis.Types {
                     // for the copy constructor. Consider 'class A(Generic[K, V], Mapping[K, V])'
                     // constructed as 'd = {1:'a', 2:'b'}; A(d)'. Here we look through bases
                     // and see if any matches the builtin type id. For example, Mapping or Dict
-                    // will have BultinTypeId.Dict and we can figure out specific types from
+                    // will have BuiltinTypeId.Dict and we can figure out specific types from
                     // the content of the collection.
                     var b = _bases.OfType<IGenericType>().Where(g => g.IsGeneric).FirstOrDefault(x => x.TypeId == type.TypeId);
                     if (b != null && !b.Parameters.IsNullOrEmpty()) {
@@ -260,20 +256,24 @@ namespace Microsoft.Python.Analysis.Types {
         /// Points the generic type parameter in class type to their corresponding specific type (or a generic
         /// type parameter if no specific type was provided)
         /// </summary>
-        private void StoreGenericParameters(IGenericTypeParameter[] genericParameters, IReadOnlyDictionary<IGenericTypeParameter, IPythonType> genericToSpecificTypes) {
+        private void StoreGenericParameters(
+            IReadOnlyDictionary<IGenericTypeParameter, IPythonType> currentGenericParameters,
+            IEnumerable<IGenericTypeParameter> newGenericParameters,
+            IReadOnlyDictionary<IGenericTypeParameter, IPythonType> genericToSpecificTypes) {
+
             // copy original generic parameters over and try to fill them in
-            _genericParameters = new Dictionary<IGenericTypeParameter, IPythonType>(GenericParameters.ToDictionary(k => k.Key, k => k.Value));
+            _genericParameters = currentGenericParameters.ToDictionary(k => k.Key, k => k.Value);
 
             // Case when creating a new specific class type
             if (Parameters.Count == 0) {
                 // Assign class type generic type parameters to specific types 
-                foreach (var gb in genericParameters) {
+                foreach (var gb in newGenericParameters) {
                     _genericParameters[gb] = genericToSpecificTypes.TryGetValue(gb, out var v) ? v : null;
                 }
             } else {
                 // When Parameters field is not empty then need to update generic parameters field
-                foreach (var gp in GenericParameters.Keys) {
-                    if (GenericParameters[gp] is IGenericTypeParameter specificType) {
+                foreach (var gp in currentGenericParameters.Keys) {
+                    if (currentGenericParameters[gp] is IGenericTypeParameter specificType) {
                         // Get unfilled type parameter or type parameter that was filled with another type parameter
                         // and try to fill it in
                         // e.g 
@@ -283,6 +283,10 @@ namespace Microsoft.Python.Analysis.Types {
                         _genericParameters[gp] = genericToSpecificTypes.TryGetValue(specificType, out var v) ? v : null;
                     }
                 }
+            }
+
+            if (!_genericParameters.IsNullOrEmpty()) {
+                _genericName = CodeFormatter.FormatSequence(BaseName, '[', _genericParameters.Values);
             }
         }
 

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Python.Analysis.Types {
                     classType._parameters = classType._genericParameters.Values.Distinct().OfType<IGenericTypeParameter>().ToList();
                     classType.DecideGeneric();
                     // Transfer members from generic to specific type.
-                    classType.SetClassMembers(args);
+                    classType.SetClassMembers(this, args);
                 }
                 return classType;
             }
@@ -335,11 +335,11 @@ namespace Microsoft.Python.Analysis.Types {
         /// Transfers members from generic class to the specific class type
         /// while instantiating specific types for the members.
         /// </summary>
-        private void SetClassMembers(IArgumentSet args) {
-            // Add members from the template class (this one).
+        private void SetClassMembers(IPythonClassType templateClass, IArgumentSet args) {
+            // Add members from the template class.
             // Members must be clones rather than references since
             // we are going to set specific types on them.
-            AddMembers(this, true);
+            AddMembers(templateClass, true);
 
             // Resolve return types of methods, if any were annotated as generics
             var members = GetMemberNames()

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.Generics.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Python.Analysis.Types {
                 var classType = new PythonClassType(BaseName, new Location(DeclaringModule));
                 // Storing generic parameters allows methods returning generic types 
                 // to know what type parameter returns what specific type
-                classType.StoreGenericParameters(GenericParameters, newGenericTypeParameters, genericTypeToSpecificType);
+                classType.StoreGenericParameters(this, newGenericTypeParameters, genericTypeToSpecificType);
 
                 // Set generic name
                 // Locking so threads can only access class after it's been initialized
@@ -257,23 +257,23 @@ namespace Microsoft.Python.Analysis.Types {
         /// type parameter if no specific type was provided)
         /// </summary>
         private void StoreGenericParameters(
-            IReadOnlyDictionary<IGenericTypeParameter, IPythonType> currentGenericParameters,
+            IPythonClassType templateClass,
             IEnumerable<IGenericTypeParameter> newGenericParameters,
             IReadOnlyDictionary<IGenericTypeParameter, IPythonType> genericToSpecificTypes) {
 
             // copy original generic parameters over and try to fill them in
-            _genericParameters = currentGenericParameters.ToDictionary(k => k.Key, k => k.Value);
+            _genericParameters = templateClass.GenericParameters.ToDictionary(k => k.Key, k => k.Value);
 
             // Case when creating a new specific class type
-            if (Parameters.Count == 0) {
+            if (templateClass.Parameters.Count == 0) {
                 // Assign class type generic type parameters to specific types 
                 foreach (var gb in newGenericParameters) {
                     _genericParameters[gb] = genericToSpecificTypes.TryGetValue(gb, out var v) ? v : null;
                 }
             } else {
                 // When Parameters field is not empty then need to update generic parameters field
-                foreach (var gp in currentGenericParameters.Keys) {
-                    if (currentGenericParameters[gp] is IGenericTypeParameter specificType) {
+                foreach (var gp in templateClass.GenericParameters.Keys) {
+                    if (templateClass.GenericParameters[gp] is IGenericTypeParameter specificType) {
                         // Get unfilled type parameter or type parameter that was filled with another type parameter
                         // and try to fill it in
                         // e.g 

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Python.Analysis.Types {
                     var declared = eval.LookupNameInScopes(b.Name, out var scope);
                     if (declared != null && scope != null) {
                         var v = scope.Variables[b.Name];
-                        if (v.Source != VariableSource.Import && v.Value is IPythonClassType cls && cls.Location.IndexSpan.Start >= Location.IndexSpan.Start) {
+                        if (v.Source != VariableSource.Import && v.Value is IPythonClassType cls && cls.IsDeclaredAfter(Location)) {
                             // There is a declaration with the same name, but it appears later in the module. Use the import.
                             if (!importedType.IsUnknown()) {
                                 newBases.Add(importedType);

--- a/src/Analysis/Ast/Impl/Types/PythonClassType.cs
+++ b/src/Analysis/Ast/Impl/Types/PythonClassType.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Python.Analysis.Types {
 
         private IEnumerable<IPythonType> DisambiguateBases(IEnumerable<IPythonType> bases, IExpressionEvaluator eval) {
             if (bases == null) {
-                return Array.Empty<IPythonType>();
+                return Enumerable.Empty<IPythonType>();
             }
 
             if (eval == null) {

--- a/src/Analysis/Ast/Impl/Values/Definitions/IScope.cs
+++ b/src/Analysis/Ast/Impl/Values/Definitions/IScope.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Python.Analysis.Values {
         IVariableCollection Globals { get; }
 
         /// <summary>
+        /// Collection of variables imported from other modules.
+        /// </summary>
+        IVariableCollection Imported { get; }
+
+        /// <summary>
         /// Module the scope belongs to.
         /// </summary>
         IPythonModule Module { get; }

--- a/src/Analysis/Ast/Impl/Values/EmptyGlobalScope.cs
+++ b/src/Analysis/Ast/Impl/Values/EmptyGlobalScope.cs
@@ -1,0 +1,45 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Parsing.Ast;
+
+namespace Microsoft.Python.Analysis.Values {
+    internal class EmptyGlobalScope : IGlobalScope {
+        public EmptyGlobalScope(IPythonModule module) {
+            GlobalScope = this;
+            Module = module;
+        }
+
+        public IPythonModule Module { get; }
+        public string Name => string.Empty;
+        public ScopeStatement Node => Module.Analysis.Ast;
+        public IScope OuterScope => null;
+        public IGlobalScope GlobalScope { get; }
+        public IReadOnlyList<IScope> Children => Array.Empty<IScope>();
+        public IEnumerable<IScope> EnumerateTowardsGlobal => Enumerable.Repeat(this, 1);
+        public IEnumerable<IScope> EnumerateFromGlobal => Enumerable.Repeat(this, 1);
+        public IVariableCollection Variables => VariableCollection.Empty;
+        public IVariableCollection NonLocals => VariableCollection.Empty;
+        public IVariableCollection Globals => VariableCollection.Empty;
+        public IVariableCollection Imported => VariableCollection.Empty;
+
+        public void DeclareVariable(string name, IMember value, VariableSource source, Location location) { }
+        public void LinkVariable(string name, IVariable v, Location location) { }
+    }
+}

--- a/src/Analysis/Ast/Impl/Values/Scope.cs
+++ b/src/Analysis/Ast/Impl/Values/Scope.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Python.Analysis.Values {
         private VariableCollection _variables;
         private VariableCollection _nonLocals;
         private VariableCollection _globals;
+        private VariableCollection _imported;
         private List<Scope> _childScopes;
 
         public Scope(ScopeStatement node, IScope outerScope, IPythonModule module) {
@@ -50,6 +51,7 @@ namespace Microsoft.Python.Analysis.Values {
         public IVariableCollection Variables => _variables ?? VariableCollection.Empty;
         public IVariableCollection NonLocals => _nonLocals ?? VariableCollection.Empty;
         public IVariableCollection Globals => _globals ?? VariableCollection.Empty;
+        public IVariableCollection Imported => _imported ?? VariableCollection.Empty;
 
         public IGlobalScope GlobalScope {
             get {
@@ -85,6 +87,8 @@ namespace Microsoft.Python.Analysis.Values {
         public void DeclareGlobal(string name, Location location)
             => (_globals ?? (_globals = new VariableCollection())).DeclareVariable(name, null, VariableSource.Locality, location);
 
+        public void DeclareImported(string name, IMember value, Location location = default)
+            => (_imported ?? (_imported = new VariableCollection())).DeclareVariable(name, value, VariableSource.Import, location);
         #endregion
 
         internal void AddChildScope(Scope s) => (_childScopes ?? (_childScopes = new List<Scope>())).Add(s);
@@ -117,26 +121,5 @@ namespace Microsoft.Python.Analysis.Values {
                 VariableCollection.DeclareVariable("__self__", objType, VariableSource.Builtin, location);
             }
         }
-    }
-
-    internal class EmptyGlobalScope : IGlobalScope {
-        public EmptyGlobalScope(IPythonModule module) {
-            GlobalScope = this;
-            Module = module;
-        }
-        public IPythonModule Module { get; }
-        public string Name => string.Empty;
-        public ScopeStatement Node => Module.Analysis.Ast;
-        public IScope OuterScope => null;
-        public IGlobalScope GlobalScope { get; }
-        public IReadOnlyList<IScope> Children => Array.Empty<IScope>();
-        public IEnumerable<IScope> EnumerateTowardsGlobal => Enumerable.Repeat(this, 1);
-        public IEnumerable<IScope> EnumerateFromGlobal => Enumerable.Repeat(this, 1);
-        public IVariableCollection Variables => VariableCollection.Empty;
-        public IVariableCollection NonLocals => VariableCollection.Empty;
-        public IVariableCollection Globals => VariableCollection.Empty;
-
-        public void DeclareVariable(string name, IMember value, VariableSource source, Location location) { }
-        public void LinkVariable(string name, IVariable v, Location location) { }
     }
 }

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -698,6 +698,18 @@ x = A(1)[0]
         }
 
         [TestMethod, Priority(0)]
+        public async Task CircularBase() {
+            const string code = @"
+class A(B): ...
+class B(A): ...
+
+x = A(1)[0]
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveVariable("x");
+        }
+
+        [TestMethod, Priority(0)]
         public async Task ImportedBaseSameName() {
             const string code = @"
 from Base import A, B

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -764,5 +764,20 @@ class b(a):
                 .And.HaveMethod("methodABase")
                 .And.HaveMethod("methodBBase");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task CircularBaseImportLater() {
+            const string code = @"
+class A(A): ...
+
+def func():
+    from Base import A
+    return A()
+
+x = func()
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveVariable("x").OfType("A").Which.Should().HaveMember("methodABase");
+        }
     }
 }

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -739,5 +739,30 @@ class B(A):
                 .Should().HaveMethod("methodBBase")
                 .And.NotHaveMembers("methodB");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task ImportedVariableSameName() {
+            const string code = @"
+from Base import a, b
+
+class a(a, b):
+    def methodA(self, x):
+        return x
+
+class b(a):
+    def methodB(self, x):
+        return x
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveClass("a").Which
+                .Should().HaveMethod("methodABase")
+                .And.HaveMethod("methodBBase");
+
+            analysis.Should().HaveClass("b").Which
+                .Should().HaveMethod("methodA")
+                .And.HaveMethod("methodB")
+                .And.HaveMethod("methodABase")
+                .And.HaveMethod("methodBBase");
+        }
     }
 }

--- a/src/Analysis/Ast/Test/LibraryTests.cs
+++ b/src/Analysis/Ast/Test/LibraryTests.cs
@@ -81,6 +81,19 @@ x = requests.get('microsoft.com')
         }
 
         [TestMethod, Priority(0)]
+        public async Task GPy() {
+            const string code = @"
+import GPy.kern
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var v = analysis.GlobalScope.Variables["GPy"];
+            v.Should().NotBeNull();
+            if (v.Value.GetPythonType<IPythonModule>().ModuleType == ModuleType.Unresolved) {
+                Assert.Inconclusive("'GPy' package is not installed.");
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public async Task OpenBinaryFile() {
             const string code = @"
 with open('foo.txt', 'wb') as file:

--- a/src/Analysis/Ast/Test/LibraryTests.cs
+++ b/src/Analysis/Ast/Test/LibraryTests.cs
@@ -80,18 +80,18 @@ x = requests.get('microsoft.com')
             r.Should().HaveMember("encoding").Which.Should().HaveType(BuiltinTypeId.Str);
         }
 
-        [TestMethod, Priority(0)]
-        public async Task GPy() {
-            const string code = @"
-import GPy.kern
-";
-            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
-            var v = analysis.GlobalScope.Variables["GPy"];
-            v.Should().NotBeNull();
-            if (v.Value.GetPythonType<IPythonModule>().ModuleType == ModuleType.Unresolved) {
-                Assert.Inconclusive("'GPy' package is not installed.");
-            }
-        }
+//        [TestMethod, Priority(0)]
+//        public async Task GPy() {
+//            const string code = @"
+//import GPy.models
+//";
+//            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+//            var v = analysis.GlobalScope.Variables["GPy"];
+//            v.Should().NotBeNull();
+//            if (v.Value.GetPythonType<IPythonModule>().ModuleType == ModuleType.Unresolved) {
+//                Assert.Inconclusive("'GPy' package is not installed.");
+//            }
+//        }
 
         [TestMethod, Priority(0)]
         public async Task OpenBinaryFile() {

--- a/src/Analysis/Ast/Test/LibraryTests.cs
+++ b/src/Analysis/Ast/Test/LibraryTests.cs
@@ -80,18 +80,17 @@ x = requests.get('microsoft.com')
             r.Should().HaveMember("encoding").Which.Should().HaveType(BuiltinTypeId.Str);
         }
 
-//        [TestMethod, Priority(0)]
-//        public async Task GPy() {
-//            const string code = @"
-//import GPy.models
-//";
-//            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
-//            var v = analysis.GlobalScope.Variables["GPy"];
-//            v.Should().NotBeNull();
-//            if (v.Value.GetPythonType<IPythonModule>().ModuleType == ModuleType.Unresolved) {
-//                Assert.Inconclusive("'GPy' package is not installed.");
-//            }
-//        }
+        [TestMethod, Priority(0)]
+        [Ignore("Very long")]
+        public async Task GPy() {
+            const string code = @"import GPy.models";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var v = analysis.GlobalScope.Variables["GPy"];
+            v.Should().NotBeNull();
+            if (v.Value.GetPythonType<IPythonModule>().ModuleType == ModuleType.Unresolved) {
+                Assert.Inconclusive("'GPy' package is not installed.");
+            }
+        }
 
         [TestMethod, Priority(0)]
         public async Task OpenBinaryFile() {

--- a/src/Analysis/Ast/Test/LintNewTypeTests.cs
+++ b/src/Analysis/Ast/Test/LintNewTypeTests.cs
@@ -80,7 +80,7 @@ T = NewType(x, int)
         [DataRow("complex", "str")]
         [DataTestMethod, Priority(0)]
         public async Task DifferentTypesFirstArg(string nameType, string type) {
-            string code = $@"
+            var code = $@"
 from typing import NewType
 
 T = NewType({nameType}(10), {type})
@@ -96,7 +96,7 @@ T = NewType({nameType}(10), {type})
 
         [TestMethod, Priority(0)]
         public async Task ObjectFirstArg() {
-            string code = $@"
+            var code = $@"
 from typing import NewType
 
 class X:
@@ -118,7 +118,7 @@ T = NewType(h, int)
 
         [TestMethod, Priority(0)]
         public async Task TypeFirstArg() {
-            string code = $@"
+            var code = $@"
 from typing import NewType
 
 T = NewType(float, int)
@@ -134,7 +134,7 @@ T = NewType(float, int)
 
         [TestMethod, Priority(0)]
         public async Task GenericFirstArg() {
-            string code = $@"
+            var code = $@"
 from typing import NewType, Generic, TypeVar
 
 T = TypeVar('T', str, int)
@@ -159,7 +159,7 @@ T = NewType(h, int)
         [DataRow("testing", "int")]
         [DataTestMethod, Priority(0)]
         public async Task NoDiagnosticOnStringFirstArg(string name, string type) {
-            string code = $@"
+            var code = $@"
 from typing import NewType
 
 T = NewType('{name}', {type})
@@ -170,7 +170,7 @@ T = NewType('{name}', {type})
 
         [TestMethod, Priority(0)]
         public async Task NewTypeWrongNumArgs() {
-            string code = $@"
+            var code = $@"
 from typing import NewType
 
 Y = NewType()
@@ -197,7 +197,7 @@ Z = NewType('str', int, float)
 
         [TestMethod, Priority(0)]
         public async Task NewTypeOneArg() {
-            string code = $@"
+            var code = $@"
 from typing import NewType
 
 Y = NewType('str')

--- a/src/UnitTests/TestData/AstAnalysis/Base.py
+++ b/src/UnitTests/TestData/AstAnalysis/Base.py
@@ -1,0 +1,7 @@
+class A:
+    def methodABase(self, x):
+        return x
+
+class B:
+    def methodBBase(self, x):
+        return x

--- a/src/UnitTests/TestData/AstAnalysis/Base.py
+++ b/src/UnitTests/TestData/AstAnalysis/Base.py
@@ -5,3 +5,6 @@ class A:
 class B:
     def methodBBase(self, x):
         return x
+
+a = A
+b = B


### PR DESCRIPTION
Fixes #1495 

- Since we don't handle reassignments, improve handling of imported bases like 
```python
from Base import A, B

class A(A, B):
    def methodA(self, x):
        return x

class C(B): ...

class B(A):
    def methodB(self, x):
        return x
```
by declaring imported variables in regular collection as well as in special `imported` collection so they can be found when we need to resolve class base.
- Decide on declaration or import depending on location
- Implement deep filtering of circular base chains
- Tests