### PR TITLE
Update dependencies

### DIFF
--- a/src/Analysis/Ast/Test/FluentAssertions/AssertionsUtilities.cs
+++ b/src/Analysis/Ast/Test/FluentAssertions/AssertionsUtilities.cs
@@ -188,38 +188,38 @@ namespace Microsoft.Python.Analysis.Tests.FluentAssertions {
             => input.Replace("\r", "\\\u200Br").Replace("\n", "\\\u200Bn").Replace("\t", @"\t");
 
         [CustomAssertion]
-        public static Continuation AssertIsNotNull<T>(this AssertionScope assertionScope, T instance, string subjectName, string itemName, string accessorName)
+        public static Continuation AssertIsNotNull<T>(this IAssertionScope IAssertionScope, T instance, string subjectName, string itemName, string accessorName)
             where T : class
-            => assertionScope.ForCondition(!(instance is null))
+            => IAssertionScope.ForCondition(!(instance is null))
                 .FailWith($"Expected {subjectName} to have {itemName}{{reason}}, but {accessorName} is null.");
 
         [CustomAssertion]
-        public static Continuation AssertAtIndex<T, TItem>(this AssertionScope assertionScope, IReadOnlyList<T> collection, int index, string subjectName, string itemName)
-            where T : class => assertionScope.ForCondition(collection.Count > index)
+        public static Continuation AssertAtIndex<T, TItem>(this IAssertionScope IAssertionScope, IReadOnlyList<T> collection, int index, string subjectName, string itemName)
+            where T : class => IAssertionScope.ForCondition(collection.Count > index)
             .FailWith($"Expected {subjectName} to have {itemName} of type {typeof(T).Name} at index {index}{{reason}}, but collection has only {collection.Count} items.", subjectName, itemName)
             .Then
             .ForCondition(collection[index] is TItem)
             .FailWith($"Expected {subjectName} to have {itemName} of type `{typeof(T).Name}` at index {index}{{reason}}, but its type is `{collection[index].GetType().Name}`.");
 
         [CustomAssertion]
-        public static Continuation AssertHasMember(this AssertionScope assertionScope, IMember m, string memberName, string analysisValueName, string memberPrintName, out IMember member) {
+        public static Continuation AssertHasMember(this IAssertionScope IAssertionScope, IMember m, string memberName, string analysisValueName, string memberPrintName, out IMember member) {
             var t = m.GetPythonType();
             t.Should().BeAssignableTo<IMemberContainer>();
             try {
                 member = ((IMemberContainer)m).GetMember(memberName);
             } catch (Exception e) {
                 member = null;
-                return assertionScope.FailWith($"Expected {analysisValueName} to have a {memberPrintName}{{reason}}, but {nameof(t.GetMember)} has failed with exception: {e}.");
+                return IAssertionScope.FailWith($"Expected {analysisValueName} to have a {memberPrintName}{{reason}}, but {nameof(t.GetMember)} has failed with exception: {e}.");
             }
 
-            return assertionScope.ForCondition(!(member is null))
+            return IAssertionScope.ForCondition(!(member is null))
                 .FailWith($"Expected {analysisValueName} to have a {memberPrintName}{{reason}}.");
         }
 
         [CustomAssertion]
-        public static Continuation AssertHasMemberOfType<TMember>(this AssertionScope assertionScope, IPythonType type, string memberName, string analysisValueName, string memberPrintName, out TMember typedMember)
+        public static Continuation AssertHasMemberOfType<TMember>(this IAssertionScope IAssertionScope, IPythonType type, string memberName, string analysisValueName, string memberPrintName, out TMember typedMember)
             where TMember : class, IPythonType {
-            var continuation = assertionScope.AssertHasMember(type, memberName, analysisValueName, memberPrintName, out var member)
+            var continuation = IAssertionScope.AssertHasMember(type, memberName, analysisValueName, memberPrintName, out var member)
                 .Then
                 .ForCondition(member is TMember)
                 .FailWith($"Expected {analysisValueName} to have a {memberPrintName} of type {typeof(TMember)}{{reason}}, but its type is {member.GetType()}.");

--- a/src/Analysis/Ast/Test/Microsoft.Python.Analysis.Tests.csproj
+++ b/src/Analysis/Ast/Test/Microsoft.Python.Analysis.Tests.csproj
@@ -23,15 +23,15 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="4.0.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Core\Impl\Microsoft.Python.Core.csproj" />

--- a/src/Core/Test/Microsoft.Python.Core.Tests.csproj
+++ b/src/Core/Test/Microsoft.Python.Core.Tests.csproj
@@ -27,10 +27,10 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
+++ b/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
@@ -30,8 +30,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
-        <PackageReference Include="NewtonSoft.Json" Version="12.0.1" />
-        <PackageReference Include="StreamJsonRpc" Version="2.0.146" />
+        <PackageReference Include="NewtonSoft.Json" Version="12.0.2" />
+        <PackageReference Include="StreamJsonRpc" Version="2.1.55" />
     </ItemGroup>
     <ItemGroup Condition="$(AnalysisReference) != ''">
         <Reference Include="Microsoft.Python.Analysis.Engine">

--- a/src/LanguageServer/Test/Microsoft.Python.LanguageServer.Tests.csproj
+++ b/src/LanguageServer/Test/Microsoft.Python.LanguageServer.Tests.csproj
@@ -23,15 +23,15 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="4.0.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Analysis\Ast\Impl\Microsoft.Python.Analysis.csproj" />

--- a/src/Parsing/Test/Microsoft.Python.Parsing.Tests.csproj
+++ b/src/Parsing/Test/Microsoft.Python.Parsing.Tests.csproj
@@ -27,10 +27,10 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/UnitTests/Core/Impl/UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/UnitTests.Core.csproj
@@ -8,8 +8,8 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.1.4" />
-    <PackageReference Include="FluentAssertions" Version="5.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Updates everything. Only difference between this and https://github.com/microsoft/python-language-server/pull/1482/commits/227726c3d067ee1f33174aa4acab5f46cb8a2480 is that FluentAssertions gets updated too, but that requires an extension fix.

I can abandon this for a plain cherry pick if we don't care about updating FluentAssertions.