### PR TITLE
Implement proper line split + tests

### DIFF
--- a/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
@@ -13,7 +13,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -47,23 +46,18 @@ namespace Microsoft.Python.Analysis.Documents {
             lock (_lock) {
                 _sb = _sb ?? new StringBuilder(_content);
 
-                var lastStart = int.MaxValue;
-                var lineLoc = SplitLines(_sb).ToArray();
-
                 foreach (var change in changes) {
+                    // Every change may change where the lines end so in order 
+                    // to correctly determine line/offsets we must re-split buffer
+                    // into lines after each change.
+                    var lineLoc = SplitLines().ToArray();
+
                     if (change.ReplaceAllText) {
                         _sb = new StringBuilder(change.InsertedText);
-                        lastStart = int.MaxValue;
-                        lineLoc = SplitLines(_sb).ToArray();
                         continue;
                     }
 
                     var start = NewLineLocation.LocationToIndex(lineLoc, change.ReplacedSpan.Start, _sb.Length);
-                    if (start > lastStart) {
-                        throw new InvalidOperationException("changes must be in reverse order of start location");
-                    }
-                    lastStart = start;
-
                     var end = NewLineLocation.LocationToIndex(lineLoc, change.ReplacedSpan.End, _sb.Length);
                     if (end > start) {
                         _sb.Remove(start, end - start);
@@ -78,20 +72,33 @@ namespace Microsoft.Python.Analysis.Documents {
             }
         }
 
-        private static IEnumerable<NewLineLocation> SplitLines(StringBuilder text) {
-            NewLineLocation nextLine;
+        public IEnumerable<NewLineLocation> SplitLines() {
+            _sb = _sb ?? new StringBuilder(_content); // for tests
 
-            // TODO: Avoid string allocation by operating directly on StringBuilder
-            var str = text.ToString();
-
-            var lastLineEnd = 0;
-            while ((nextLine = NewLineLocation.FindNewLine(str, lastLineEnd)).EndIndex != lastLineEnd) {
-                yield return nextLine;
-                lastLineEnd = nextLine.EndIndex;
+            if (_sb.Length == 0) {
+                yield return new NewLineLocation(0, NewLineKind.None);
             }
 
-            if (lastLineEnd != str.Length) {
-                yield return nextLine;
+            for (var i = 0; i < _sb.Length; i++) {
+                var ch = _sb[i];
+                var nextCh = i < _sb.Length - 1 ? _sb[i + 1] : '\0';
+                switch (ch) {
+                    case '\r' when nextCh == '\n':
+                        i++;
+                        yield return new NewLineLocation(i + 1, NewLineKind.CarriageReturnLineFeed);
+                        break;
+                    case '\n':
+                        yield return new NewLineLocation(i + 1, NewLineKind.LineFeed);
+                        break;
+                    case '\r':
+                        yield return new NewLineLocation(i + 1, NewLineKind.CarriageReturn);
+                        break;
+                    default:
+                        if (i == _sb.Length - 1) {
+                            yield return new NewLineLocation(i + 1, NewLineKind.None);
+                        }
+                        break;
+                }
             }
         }
     }

--- a/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
+++ b/src/Analysis/Ast/Impl/Documents/DocumentBuffer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Python.Analysis.Documents {
                     // Every change may change where the lines end so in order 
                     // to correctly determine line/offsets we must re-split buffer
                     // into lines after each change.
-                    var lineLoc = SplitLines().ToArray();
+                    var lineLoc = GetNewLineLications().ToArray();
 
                     if (change.ReplaceAllText) {
                         _sb = new StringBuilder(change.InsertedText);
@@ -72,7 +72,7 @@ namespace Microsoft.Python.Analysis.Documents {
             }
         }
 
-        public IEnumerable<NewLineLocation> SplitLines() {
+        public IEnumerable<NewLineLocation> GetNewLineLications() {
             _sb = _sb ?? new StringBuilder(_content); // for tests
 
             if (_sb.Length == 0) {

--- a/src/Analysis/Ast/Test/DocumentBufferTests.cs
+++ b/src/Analysis/Ast/Test/DocumentBufferTests.cs
@@ -215,6 +215,20 @@ line4
 ", doc.Text);
         }
 
+        [TestMethod, Priority(0)]
+        public void InsertTopToBottom() {
+            var doc = new DocumentBuffer();
+            doc.Reset(0, @"linelinelineline");
+            doc.Update(new[] {
+                DocumentChange.Insert("\n", new SourceLocation(1, 1)),
+                DocumentChange.Insert("1\n", new SourceLocation(2, 5)),
+                DocumentChange.Insert("2\r", new SourceLocation(3, 5)),
+                DocumentChange.Insert("3\r\n", new SourceLocation(4, 5)),
+                DocumentChange.Insert("4\r\n", new SourceLocation(5, 5)),
+            });
+            Assert.AreEqual("\nline1\nline2\rline3\r\nline4\r\n", doc.Text);
+        }
+
         [NewLineTestData]
         [DataTestMethod, Priority(0)]
         public void NewLines(string s, NewLineLocation[] expected) {

--- a/src/Analysis/Ast/Test/DocumentBufferTests.cs
+++ b/src/Analysis/Ast/Test/DocumentBufferTests.cs
@@ -234,7 +234,7 @@ line4
         public void NewLines(string s, NewLineLocation[] expected) {
             var doc = new DocumentBuffer();
             doc.Reset(0, s);
-            var nls = doc.SplitLines().ToArray();
+            var nls = doc.GetNewLineLications().ToArray();
             for (var i = 0; i < nls.Length; i++) {
                 Assert.AreEqual(nls[i].Kind, expected[i].Kind);
                 Assert.AreEqual(nls[i].EndIndex, expected[i].EndIndex);

--- a/src/Analysis/Ast/Test/DocumentBufferTests.cs
+++ b/src/Analysis/Ast/Test/DocumentBufferTests.cs
@@ -15,9 +15,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using FluentAssertions;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Core.Text;
+using Microsoft.Python.Parsing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Python.Analysis.Tests {
@@ -77,7 +80,7 @@ def g(y):
             doc.Reset(0, string.Empty);
             Assert.AreEqual(string.Empty, doc.Text);
 
-            doc.Update(new[] { 
+            doc.Update(new[] {
                 DocumentChange.Insert("text", SourceLocation.MinValue)
             });
 
@@ -126,6 +129,150 @@ def g(y):
 
             Assert.AreEqual(@"text1234", doc.Text);
             Assert.AreEqual(4, doc.Version);
+        }
+
+        [TestMethod, Priority(0)]
+        public void DeleteMultipleDisjoint() {
+            var doc = new DocumentBuffer();
+            doc.Reset(0, @"
+line1
+line2
+line3
+line4
+");
+            doc.Update(new[] {
+                DocumentChange.Delete(new SourceSpan(5, 5, 5, 6)),
+                DocumentChange.Delete(new SourceSpan(4, 5, 4, 6)),
+                DocumentChange.Delete(new SourceSpan(3, 5, 3, 6)),
+                DocumentChange.Delete(new SourceSpan(2, 5, 2, 6))
+            });
+            Assert.AreEqual(@"
+line
+line
+line
+line
+", doc.Text);
+        }
+
+        [TestMethod, Priority(0)]
+        public void InsertMultipleDisjoint() {
+            var doc = new DocumentBuffer();
+            doc.Reset(0, @"
+line
+line
+line
+line
+");
+            doc.Update(new[] {
+                DocumentChange.Insert("4", new SourceLocation(5, 5)),
+                DocumentChange.Insert("3", new SourceLocation(4, 5)),
+                DocumentChange.Insert("2", new SourceLocation(3, 5)),
+                DocumentChange.Insert("1", new SourceLocation(2, 5)),
+            });
+            Assert.AreEqual(@"
+line1
+line2
+line3
+line4
+", doc.Text);
+        }
+
+        [TestMethod, Priority(0)]
+        public void DeleteAcrossLines() {
+            var doc = new DocumentBuffer();
+            doc.Reset(0, @"
+line1
+line2
+line3
+line4
+");
+            doc.Update(new[] {
+                DocumentChange.Delete(new SourceSpan(4, 5, 5, 5)),
+                DocumentChange.Delete(new SourceSpan(2, 5, 3, 5)),
+            });
+            Assert.AreEqual(@"
+line2
+line4
+", doc.Text);
+        }
+
+        [TestMethod, Priority(0)]
+        public void SequentialChanges() {
+            var doc = new DocumentBuffer();
+            doc.Reset(0, @"
+line1
+line2
+line3
+line4
+");
+            doc.Update(new[] {
+                DocumentChange.Delete(new SourceSpan(2, 5, 3, 5)),
+                DocumentChange.Delete(new SourceSpan(3, 5, 4, 5))
+            });
+            Assert.AreEqual(@"
+line2
+line4
+", doc.Text);
+        }
+
+        [NewLineTestData]
+        [DataTestMethod, Priority(0)]
+        public void NewLines(string s, NewLineLocation[] expected) {
+            var doc = new DocumentBuffer();
+            doc.Reset(0, s);
+            var nls = doc.SplitLines().ToArray();
+            for (var i = 0; i < nls.Length; i++) {
+                Assert.AreEqual(nls[i].Kind, expected[i].Kind);
+                Assert.AreEqual(nls[i].EndIndex, expected[i].EndIndex);
+            }
+        }
+
+        private sealed class NewLineTestDataAttribute : Attribute, ITestDataSource {
+            public IEnumerable<object[]> GetData(MethodInfo methodInfo) =>
+                new List<object[]> {
+                    new object[] {
+                        string.Empty,
+                        new NewLineLocation[] {
+                            new NewLineLocation(0, NewLineKind.None),
+                        }
+                    },
+                    new object[] {
+                        "\r\r",
+                        new NewLineLocation[] {
+                            new NewLineLocation(1, NewLineKind.CarriageReturn),
+                            new NewLineLocation(2, NewLineKind.CarriageReturn)
+                        }
+                    },
+                    new object[] {
+                        "\n\n",
+                        new NewLineLocation[] {
+                            new NewLineLocation(1, NewLineKind.LineFeed),
+                            new NewLineLocation(2, NewLineKind.LineFeed)
+                        }
+                    },
+                    new object[] {
+                        "\r\n\n\r",
+                        new NewLineLocation[] {
+                            new NewLineLocation(2, NewLineKind.CarriageReturnLineFeed),
+                            new NewLineLocation(3, NewLineKind.LineFeed),
+                            new NewLineLocation(4, NewLineKind.CarriageReturn)
+                        }
+                    },
+                    new object[] {
+                        "a\r\nb\r\n c\r d\ne",
+                        new NewLineLocation[] {
+                            new NewLineLocation(3, NewLineKind.CarriageReturnLineFeed),
+                            new NewLineLocation(6, NewLineKind.CarriageReturnLineFeed),
+                            new NewLineLocation(9, NewLineKind.CarriageReturn),
+                            new NewLineLocation(12, NewLineKind.LineFeed),
+                            new NewLineLocation(13, NewLineKind.None)
+                        }
+                    }
+                };
+            public string GetDisplayName(MethodInfo methodInfo, object[] data)
+                => data != null ? $"{methodInfo.Name} ({FormatName((string)data[0])})" : null;
+
+            private static string FormatName(string s) => s.Replace("\n", "\\n").Replace("\r", "\\r");
         }
     }
 }

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -133,15 +133,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             }
         }
 
-        private static DidChangeTextDocumentParams CreateDidChangeTextDocumentParams(DidChangeTextDocumentParams @params, int version, Stack<TextDocumentContentChangedEvent> contentChanges)
-            => new DidChangeTextDocumentParams {
-                contentChanges = contentChanges.ToArray(),
-                textDocument = new VersionedTextDocumentIdentifier {
-                    uri = @params.textDocument.uri,
-                    version = version
-                }
-            };
-
         [JsonRpcMethod("textDocument/willSave")]
         public void WillSaveTextDocument(JToken token) { }
 

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -129,50 +129,12 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _idleTimeTracker?.NotifyUserActivity();
             using (await _prioritizer.DocumentChangePriorityAsync(cancellationToken)) {
                 var @params = ToObject<DidChangeTextDocumentParams>(token);
-                var version = @params.textDocument.version;
-                if (version == null || @params.contentChanges.IsNullOrEmpty()) {
-                    _server.DidChangeTextDocument(@params);
-                    return;
-                }
-
-                // _server.DidChangeTextDocument can handle change buckets with decreasing version and without overlapping 
-                // Split change into buckets that will be properly handled
-                var changes = SplitDidChangeTextDocumentParams(@params, version.Value);
-
-                foreach (var change in changes) {
-                    _server.DidChangeTextDocument(change);
-                }
+                _server.DidChangeTextDocument(@params);
             }
-        }
-
-        private static IEnumerable<DidChangeTextDocumentParams> SplitDidChangeTextDocumentParams(DidChangeTextDocumentParams @params, int version) {
-            var changes = new Stack<DidChangeTextDocumentParams>();
-            var contentChanges = new Stack<TextDocumentContentChangedEvent>();
-            var previousRange = new Range();
-
-            for (var i = @params.contentChanges.Length - 1; i >= 0; i--) {
-                var contentChange = @params.contentChanges[i];
-                var range = contentChange.range.GetValueOrDefault();
-                if (previousRange.end > range.start) {
-                    changes.Push(CreateDidChangeTextDocumentParams(@params, version, contentChanges));
-                    contentChanges = new Stack<TextDocumentContentChangedEvent>();
-                    version--;
-                }
-
-                contentChanges.Push(contentChange);
-                previousRange = range;
-            }
-
-            if (contentChanges.Count > 0) {
-                changes.Push(CreateDidChangeTextDocumentParams(@params, version, contentChanges));
-            }
-
-            return changes;
         }
 
         private static DidChangeTextDocumentParams CreateDidChangeTextDocumentParams(DidChangeTextDocumentParams @params, int version, Stack<TextDocumentContentChangedEvent> contentChanges)
             => new DidChangeTextDocumentParams {
-                _enqueueForAnalysis = @params._enqueueForAnalysis,
                 contentChanges = contentChanges.ToArray(),
                 textDocument = new VersionedTextDocumentIdentifier {
                     uri = @params.textDocument.uri,

--- a/src/LanguageServer/Impl/Protocol/Messages.cs
+++ b/src/LanguageServer/Impl/Protocol/Messages.cs
@@ -126,9 +126,6 @@ namespace Microsoft.Python.LanguageServer.Protocol {
     public sealed class DidChangeTextDocumentParams {
         public VersionedTextDocumentIdentifier textDocument;
         public TextDocumentContentChangedEvent[] contentChanges;
-
-        // Defaults to true, but can be set to false to suppress analysis
-        public bool? _enqueueForAnalysis;
     }
 
     [Serializable]


### PR DESCRIPTION
Fixes #1543 

- Changes were applied incorrectly. Changes across line spans caused buffer corruption. Typical example is undoing multiple changes via fast `Ctrl+Z`.
- Simplified change handling: per LSP, any sequence applies
```
 * The actual content changes. The content changes describe single state changes
 * to the document. So if there are two content changes c1 and c2 for a document
 * in state S then c1 move the document to S' and c2 to S''.
```
and we can now handle this since line splits update after each change.
- Implement new line location without creating extra strings
- Add tests for new lines as well as for multi-line edits.
- Remove unused flags
- Remove change reordering/versions.

