### PR TITLE
Add support for Python 3.8 fstring debug `=`

### DIFF
--- a/src/Core/Impl/Text/StringSpan.cs
+++ b/src/Core/Impl/Text/StringSpan.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Python.Core.Text {
         public int End => Start + Length;
         public bool IsValid => Source != null && Start >= 0 && Length >= 0 && Source.Length >= End;
 
+        public StringSpan(string source) : this(source, 0, source.Length) { }
+
         public StringSpan(string source, int start, int length) {
             Source = source;
             Start = start;

--- a/src/Parsing/Impl/FStringParser.cs
+++ b/src/Parsing/Impl/FStringParser.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Python.Parsing {
             Debug.Assert(_nestedParens.Count == 0);
 
             char? quoteChar = null;
-            int stringType = 0;
+            var stringType = 0;
 
             while (!EndOfFString) {
                 var ch = CurrentChar;
@@ -298,7 +298,7 @@ namespace Microsoft.Python.Parsing {
                 }
                 /* Start looking for the end of the string. */
             } else if ((ch == ')' || ch == '}' || ch == ']') && _nestedParens.Count > 0) {
-                char opening = _nestedParens.Pop();
+                var opening = _nestedParens.Pop();
                 if (!IsOpeningOf(opening, ch)) {
                     ReportSyntaxError(Resources.ClosingParensNotMatchFStringErrorMsg.FormatInvariant(ch, opening));
                 }
@@ -332,7 +332,7 @@ namespace Microsoft.Python.Parsing {
             } else if (ch == '#') {
                 ReportSyntaxError(Resources.NumberSignFStringExpressionErrorMsg);
             } else if ((ch == ')' || ch == '}' || ch == ']') && _nestedParens.Count > 0) {
-                char opening = _nestedParens.Pop();
+                var opening = _nestedParens.Pop();
                 if (!IsOpeningOf(opening, ch)) {
                     ReportSyntaxError(Resources.ClosingParensNotMatchFStringErrorMsg.FormatInvariant(ch, opening));
                 }
@@ -408,7 +408,7 @@ namespace Microsoft.Python.Parsing {
                 return false;
             }
 
-            bool expected = CurrentChar == nextChar;
+            var expected = CurrentChar == nextChar;
             if (!expected) {
                 ReportSyntaxError(Resources.ExpectingCharButFoundFStringErrorMsg.FormatInvariant(nextChar, CurrentChar));
             }
@@ -423,7 +423,7 @@ namespace Microsoft.Python.Parsing {
             }
             var s = _buffer.ToString();
             _buffer.Clear();
-            string contents = "";
+            var contents = "";
             try {
                 contents = LiteralParser.ParseString(s.ToCharArray(),
                 0, s.Length, _isRaw, isUni: true, normalizeLineEndings: true, allowTrailingBackslash: true);

--- a/src/Parsing/Impl/FStringParser.cs
+++ b/src/Parsing/Impl/FStringParser.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Python.Parsing {
                 NextChar();
             }
 
-            while (!EndOfFString() && IsAsciiWhitespace()) {
+            while (!EndOfFString() && IsAsciiWhiteSpace()) {
                 NextChar();
             }
         }
@@ -467,7 +467,7 @@ namespace Microsoft.Python.Parsing {
             return expr;
         }
 
-        private bool IsAsciiWhitespace() {
+        private bool IsAsciiWhiteSpace() {
             switch (CurrentChar()) {
                 case '\t':
                 case '\n':

--- a/src/Parsing/Impl/FStringParser.cs
+++ b/src/Parsing/Impl/FStringParser.cs
@@ -142,10 +142,7 @@ namespace Microsoft.Python.Parsing {
             var conversion = MaybeReadConversionChar();
             var formatSpecifier = MaybeReadFormatSpecifier();
 
-            if (CurrentChar != '}') {
-                _incomplete = true;
-            }
-            Read('}');
+            _incomplete = !Read('}');
 
             if (fStringExpression == null) {
                 return Error(initialPosition);

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -416,6 +416,63 @@ namespace Microsoft.Python.Parsing.Tests {
         }
 
         [TestMethod, Priority(0)]
+        public void FStringEquals() {
+            foreach (var version in V38AndUp) {
+                var errors = new CollectingErrorSink();
+                CheckAst(
+                    ParseFile("FStringEquals.py", errors, version),
+                    CheckSuite(
+                        CheckExprStmt(
+                            CheckFString(
+                                CheckFormattedValue(
+                                    CheckNameExpr("name")
+                                )
+                            )
+                        ),
+                        CheckExprStmt(
+                            CheckFString(
+                                CheckFormattedValue(
+                                    CheckNameExpr("name")
+                                )
+                            )
+                        ),
+                        CheckExprStmt(
+                            CheckFString(
+                                CheckFormattedValue(
+                                    CheckNameExpr("name")
+                                )
+                            )
+                        ),
+                        CheckExprStmt(
+                            CheckFString(
+                                CheckFormattedValue(
+                                    CheckCallExpression(CheckMemberExpr(CheckNameExpr("foo"), "bar"))
+                                )
+                            )
+                        ),
+                        CheckExprStmt(
+                            CheckFString(
+                                CheckFormattedValue(
+                                    CheckNameExpr("user"),
+                                    's'
+                                ),
+                                CheckNodeConstant("  "),
+                                CheckFormattedValue(
+                                    CheckMemberExpr(CheckNameExpr("delta"), "days"),
+                                    formatSpecifier: CheckFormatSpecifer(
+                                        CheckNodeConstant(",d")
+                                   )
+                                )
+                            )
+                        )
+                    )
+                );
+
+                errors.Errors.Should().BeEmpty();
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public void GeneralizedUnpacking() {
             foreach (var version in V35AndUp) {
                 CheckAst(

--- a/src/Parsing/Test/ParserTests.cs
+++ b/src/Parsing/Test/ParserTests.cs
@@ -473,6 +473,15 @@ namespace Microsoft.Python.Parsing.Tests {
         }
 
         [TestMethod, Priority(0)]
+        public void FStringEqualsErrors() {
+            ParseErrors("FStringEqualsErrors.py",
+                PythonLanguageVersion.V38,
+                new ErrorResult("f-string: expecting '}' but found 'f'", new SourceSpan(1, 9, 1, 10)),
+                new ErrorResult("f-string: expecting '}' but found 'a'", new SourceSpan(2, 10, 2, 11))
+            );
+        }
+
+        [TestMethod, Priority(0)]
         public void GeneralizedUnpacking() {
             foreach (var version in V35AndUp) {
                 CheckAst(
@@ -3711,7 +3720,7 @@ pass
         #endregion
 
         #region Checker Factories / Helpers
-        
+
         private void ParseErrors(string filename, PythonLanguageVersion version, params ErrorResult[] errors) {
             ParseErrors(filename, version, Severity.Hint, errors);
         }

--- a/src/UnitTests/TestData/Grammar/FStringEquals.py
+++ b/src/UnitTests/TestData/Grammar/FStringEquals.py
@@ -1,0 +1,5 @@
+f"{name=}"
+f"{name =}"
+f"{name = }"
+f"{foo.bar()=}"
+f'{user=!s}  {delta.days=:,d}'

--- a/src/UnitTests/TestData/Grammar/FStringEqualsErrors.py
+++ b/src/UnitTests/TestData/Grammar/FStringEqualsErrors.py
@@ -1,0 +1,2 @@
+f"{name=foo}"
+f"{bad = a }"


### PR DESCRIPTION
Fixes #1102.

Plus a few extra cleanups (methods to properties, error reporting fixes, etc)