### PR TITLE
Ignore null/empty named symbols during symbol index walk

### DIFF
--- a/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
+++ b/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
@@ -12,6 +12,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
@@ -655,6 +656,14 @@ if b := a:
                 new HierarchicalSymbol("a", SymbolKind.Variable, new SourceSpan(1, 1, 1, 2)),
                 new HierarchicalSymbol("b", SymbolKind.Variable, new SourceSpan(2, 4, 2, 5))
             });
+        }
+
+        [TestMethod, Priority(0)]
+        public void WalkerNoNameFunction() {
+            var code = @"def ():";
+
+            var symbols = WalkSymbols(code);
+            symbols.Should().BeEmpty();
         }
 
         private PythonAst GetParse(string code, PythonLanguageVersion version)

--- a/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
+++ b/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
@@ -12,7 +12,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;


### PR DESCRIPTION
Fixes #958.

Took the opportunity to modify `Root` to make it obvious that it should not be modified.

Note that in the case where a symbol with no name has children, it's going to still be skipped; in order to do otherwise we'd need to pick a name for it (which is possible to do if we find that it's necessary).