### PR TITLE
Fix Python 3.8 version checks in tests

### DIFF
--- a/src/Analysis/Ast/Test/AssignmentTests.cs
+++ b/src/Analysis/Ast/Test/AssignmentTests.cs
@@ -686,8 +686,7 @@ from typing import List
 a: List[int]
 b = [(x := i) for i in a]
 ";
-            var analysis = await GetAnalysisAsync(code);
-
+            var analysis = await GetAnalysisAsync(code, PythonVersions.Required_Python38X);
             analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Int);
         }
     }

--- a/src/Analysis/Ast/Test/AssignmentTests.cs
+++ b/src/Analysis/Ast/Test/AssignmentTests.cs
@@ -674,8 +674,7 @@ e, (f, g), h = t
 if (x := 1234) == 1234:
     pass
 ";
-            var analysis = await GetAnalysisAsync(code);
-
+            var analysis = await GetAnalysisAsync(code, PythonVersions.Required_Python38X);
             analysis.Should().HaveVariable("x").OfType(BuiltinTypeId.Int);
         }
 

--- a/src/Analysis/Ast/Test/LintUndefinedVarsTests.cs
+++ b/src/Analysis/Ast/Test/LintUndefinedVarsTests.cs
@@ -764,7 +764,7 @@ x = 123
 if (y := x):
     print(y)
 ";
-            var d = await LintAsync(code, PythonVersions.Python38_x64);
+            var d = await LintAsync(code, PythonVersions.Required_Python38X);
             d.Should().BeEmpty();
         }
 
@@ -777,7 +777,7 @@ stuff = []
 [i+1 for i in range(2) for j in (k := stuff)]
 [i+1 for i in [j for j in (k := stuff)]]
 ";
-            var d = await LintAsync(code, PythonVersions.Python38_x64);
+            var d = await LintAsync(code, PythonVersions.Required_Python38X);
             d.Should().BeEmpty();
         }
 

--- a/src/LanguageServer/Test/HoverTests.cs
+++ b/src/LanguageServer/Test/HoverTests.cs
@@ -229,7 +229,7 @@ f'hey {some}'
             const string code = @"
 (a := 1)
 ";
-            var analysis = await GetAnalysisAsync(code);
+            var analysis = await GetAnalysisAsync(code, PythonVersions.Required_Python38X);
             var hs = new HoverSource(new PlainTextDocumentationSource());
             AssertHover(hs, analysis, new SourceLocation(2, 2), @"a: int", new SourceSpan(2, 2, 2, 3));
         }


### PR DESCRIPTION
Encountered this while I was working on the scope stuff. I think for version specific stuff like the := operator, we should specify the version of the test. 