### PR TITLE
addressed csharp compiler breaking changes around default with binary…

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/ImportHandler.cs
@@ -65,16 +65,16 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
                     break;
                 }
 
-                if (firstModule == default) {
+                if (firstModule == null) {
                     firstModule = lastModule;
                 }
             }
 
             // "import fob.oar.baz as baz" is handled as baz = import_module('fob.oar.baz')
             // "import fob.oar.baz" is handled as fob = import_module('fob')
-            if (!string.IsNullOrEmpty(asNameExpression?.Name) && lastModule != default) {
+            if (!string.IsNullOrEmpty(asNameExpression?.Name) && lastModule != null) {
                 Eval.DeclareVariable(asNameExpression.Name, lastModule, VariableSource.Import, asNameExpression);
-            } else if (firstModule != default && !string.IsNullOrEmpty(importNames[0])) {
+            } else if (firstModule != null && !string.IsNullOrEmpty(importNames[0])) {
                 var firstName = moduleImportExpression.Names[0];
                 Eval.DeclareVariable(importNames[0], firstModule, VariableSource.Import, firstName);
             }
@@ -132,7 +132,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             var fullName = possibleModuleImport.PrecedingModuleFullName;
             var module = ModuleResolution.GetOrLoadModule(possibleModuleImport.PrecedingModuleFullName);
 
-            if (module == default) {
+            if (module == null) {
                 MakeUnresolvedImport(possibleModuleImport.PrecedingModuleFullName, fullName, location);
                 return false;
             }

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -313,8 +313,8 @@ namespace Microsoft.Python.Analysis.Analyzer {
                     // Library analysis exists, don't analyze again
                     return false;
                 }
-                if (ast == default) {
-                    if (currentAnalysis == default) {
+                if (ast == null) {
+                    if (currentAnalysis == null) {
                         // Entry doesn't have ast yet. There should be at least one more session.
                         Cancel();
                         _log?.Log(TraceEventType.Verbose, $"Analysis of {module.Name}({module.ModuleType}) canceled (no AST yet).");

--- a/src/Analysis/Ast/Impl/Dependencies/DependencyResolver.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/DependencyResolver.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
         private int _version;
 
         public int Version => _version;
-        
+
         public int ChangeValue(in TKey key, in TValue value, in bool isRoot, params TKey[] incomingKeys)
             => ChangeValue(key, value, isRoot, ImmutableArray<TKey>.Create(incomingKeys));
 
@@ -53,7 +53,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     index = _keys.Count;
                     _keys[key] = index;
                     _vertices.Add(default);
-                } else if (_vertices[index] != default) {
+                } else if (_vertices[index] != null) {
                     return _version;
                 }
 
@@ -71,14 +71,14 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 var version = Interlocked.Increment(ref _version);
 
                 var vertex = _vertices[index];
-                if (vertex == default) {
+                if (vertex == null) {
                     return version;
                 }
 
                 _vertices[index] = default;
                 foreach (var incomingIndex in vertex.Incoming) {
                     var incoming = _vertices[incomingIndex];
-                    if (incoming != default && incoming.IsSealed) {
+                    if (incoming != null && incoming.IsSealed) {
                         _vertices[incomingIndex] = new DependencyVertex<TKey, TValue>(incoming, version, false);
                     }
                 }
@@ -86,10 +86,10 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 if (!vertex.IsSealed) {
                     return version;
                 }
-                
+
                 foreach (var outgoingIndex in vertex.Outgoing) {
                     var outgoing = _vertices[outgoingIndex];
-                    if (outgoing != default && !outgoing.IsNew) {
+                    if (outgoing != null && !outgoing.IsNew) {
                         _vertices[outgoingIndex] = new DependencyVertex<TKey, TValue>(outgoing, version, true);
                     }
                 }
@@ -116,7 +116,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 _vertices.Clear();
 
                 foreach (var oldVertex in oldVertices) {
-                    if (oldVertex == default) {
+                    if (oldVertex == null) {
                         continue;
                     }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                         _keys[key] = index;
                         _vertices.Add(default);
                     }
-                    
+
                     Update(key, value, isRoot, incomingKeys, index);
                 }
 
@@ -157,7 +157,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     _vertices.Add(default);
                 } else {
                     var vertex = _vertices[keyIndex];
-                    if (vertex != default && vertex.IsSealed && !vertex.ContainsOutgoing(index)) {
+                    if (vertex != null && vertex.IsSealed && !vertex.ContainsOutgoing(index)) {
                         _vertices[keyIndex] = new DependencyVertex<TKey, TValue>(vertex, version, false);
                     }
                 }
@@ -241,7 +241,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
 
             var outgoingVertices = new HashSet<int>[vertices.Count];
             foreach (var vertex in vertices) {
-                if (vertex == default) {
+                if (vertex == null) {
                     continue;
                 }
 
@@ -250,12 +250,12 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 }
 
                 foreach (var incomingIndex in vertex.Incoming) {
-                    if (vertices[incomingIndex] != default) {
+                    if (vertices[incomingIndex] != null) {
                         var outgoing = outgoingVertices[incomingIndex];
-                        if (outgoing == default) {
+                        if (outgoing == null) {
                             outgoing = new HashSet<int>();
                             outgoingVertices[incomingIndex] = outgoing;
-                        } 
+                        }
 
                         outgoing.Add(vertex.Index);
                     }
@@ -268,7 +268,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                 }
 
                 foreach (var vertex in vertices) {
-                    if (vertex != default && !vertex.IsSealed) {
+                    if (vertex != null && !vertex.IsSealed) {
                         vertex.Seal(outgoingVertices[vertex.Index]);
                     }
                 }
@@ -341,7 +341,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     SetDepths(depths, vertices, vertex.Incoming, 1);
                 }
             }
-            
+
             return ImmutableArray<int>.Create(depths);
         }
 
@@ -437,7 +437,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     var secondPassVertex = vertex.CreateSecondPassVertex();
                     var loopNumber = vertex.LoopNumber;
                     if (secondPassLoops[loopNumber] == null) {
-                        secondPassLoops[loopNumber] = new List<WalkingVertex<TKey, TValue>> {secondPassVertex};
+                        secondPassLoops[loopNumber] = new List<WalkingVertex<TKey, TValue>> { secondPassVertex };
                     } else {
                         secondPassLoops[loopNumber].Add(secondPassVertex);
                     }
@@ -533,12 +533,12 @@ namespace Microsoft.Python.Analysis.Dependencies {
 
             // First, go through all the vertices and find those that have missing incoming edges
             foreach (var vertex in vertices) {
-                if (vertex == default) {
+                if (vertex == null) {
                     continue;
                 }
 
                 foreach (var incoming in vertex.Incoming) {
-                    if (vertices[incoming] == default) {
+                    if (vertices[incoming] == null) {
                         haveMissingDependencies[vertex.Index] = true;
                         queue.Enqueue(vertex);
                         missingIndicesHashSet.Add(incoming);
@@ -556,7 +556,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
 
                 var vertex = queue.Dequeue();
                 foreach (var outgoing in vertex.Outgoing) {
-                    if (vertices[outgoing] == default) {
+                    if (vertices[outgoing] == null) {
                         continue;
                     }
 
@@ -583,7 +583,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
                     }
                 }
             }
-            
+
             return version == _version;
         }
 
@@ -690,7 +690,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
             public TValue Value => _vertex.DependencyVertex.Value;
             public int VertexDepth { get; }
             public bool HasMissingDependencies => _vertex.HasMissingDependencies;
-            public bool HasOnlyWalkedDependencies => _vertex.HasOnlyWalkedIncoming && _vertex.SecondPass == default;
+            public bool HasOnlyWalkedDependencies => _vertex.HasOnlyWalkedIncoming && _vertex.SecondPass == null;
             public bool IsWalkedWithDependencies => _vertex.HasOnlyWalkedIncoming && _vertex.DependencyVertex.IsWalked;
             public bool IsValidVersion => _walker.IsValidVersion;
 

--- a/src/Analysis/Ast/Impl/Modules/Resolution/TypeshedResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/TypeshedResolution.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
         protected override IPythonModule CreateModule(string name) {
             var moduleImport = CurrentPathResolver.GetModuleImportFromModuleName(name);
-            if (moduleImport != default) {
+            if (moduleImport != null) {
                 if (moduleImport.IsCompiled) {
                     Log?.Log(TraceEventType.Warning, "Unsupported native module in stubs", moduleImport.FullName, moduleImport.ModulePath);
                     return null;

--- a/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.cs
+++ b/src/Analysis/Core/Impl/DependencyResolution/PathResolverSnapshot.cs
@@ -709,7 +709,7 @@ namespace Microsoft.Python.Analysis.Core.DependencyResolution {
             => builder.AppendIf(builder.Length > 0, ".").Append(name);
 
         private static Node UpdateNodesFromEnd(Edge lastEdge, Node newEnd) {
-            while (lastEdge.Start != default) {
+            while (lastEdge.Start != null) {
                 var newStart = lastEdge.Start.ReplaceChildAt(newEnd, lastEdge.EndIndex);
                 lastEdge = lastEdge.Previous;
                 newEnd = newStart;

--- a/src/Core/Impl/Threading/AsyncAutoResetEvent.cs
+++ b/src/Core/Impl/Threading/AsyncAutoResetEvent.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Python.Core {
                     }
                 }
 
-                if (!_isSignaled && (waiterToRelease == default || waiterToRelease.Task.IsCompleted)) {
+                if (!_isSignaled && (waiterToRelease == null || waiterToRelease.Task.IsCompleted)) {
                     _isSignaled = true;
                 }
             }


### PR DESCRIPTION
… operators

more detail
https://github.com/dotnet/roslyn/blob/master/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20post%20VS2019.md

breaking change number 3

and here is excerpt of the change

...

https://github.com/dotnet/roslyn/issues/35684 In C# 7.1 the resolution of a binary operator with a default literal could result in using an object equality and giving the literal a type object. For example, given a variable t of an unconstrained type T, t == default would be improperly allowed and emitted as t == default(object). Similarly, for a reference type without a custom == operator, x == default would be improperly allowed and emitted as x == default(object). In Visual Studio 2019 version 16.4 these scenarios will now produce an error.

....