### PR TITLE
Add back the State property getter to the Tokenizer.

### DIFF
--- a/src/Parsing/Impl/Tokens/Tokenizer.cs
+++ b/src/Parsing/Impl/Tokens/Tokenizer.cs
@@ -111,6 +111,12 @@ namespace Microsoft.Python.Parsing {
             return tokens;
         }
 
+        /// <summary>
+        /// Current state, to be passed to <see cref="Initialize(object, TextReader, SourceLocation)"/>
+        /// or <see cref="Initialize(object, TextReader, SourceLocation, int)"/>./>
+        /// </summary>
+        public object CurrentState => _state;
+
         public int CurrentLine => _newLineLocations.Count;
         public SourceLocation CurrentPosition => IndexToLocation(CurrentIndex);
 

--- a/src/Parsing/Impl/Tokens/Tokenizer.cs
+++ b/src/Parsing/Impl/Tokens/Tokenizer.cs
@@ -115,6 +115,10 @@ namespace Microsoft.Python.Parsing {
         /// Current state, to be passed to <see cref="Initialize(object, TextReader, SourceLocation)"/>
         /// or <see cref="Initialize(object, TextReader, SourceLocation, int)"/>./>
         /// </summary>
+        /// <remarks>
+        /// This is used by PTVS to initialize a tokenizer with an existing state.
+        /// Do not remove, even though it is unused within language server.
+        /// </remarks>
         public object CurrentState => _state;
 
         public int CurrentLine => _newLineLocations.Count;


### PR DESCRIPTION
PTVS needs to initialize the Tokenizer with an existing state, but that property was removed in January, probably because that looked unused in the language server code base.