### PR TITLE
use LinkedList instead of List in PriorityProducerConsumer

### DIFF
--- a/src/Core/Impl/Extensions/TaskCompletionSourceExtensions.cs
+++ b/src/Core/Impl/Extensions/TaskCompletionSourceExtensions.cs
@@ -18,8 +18,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Python.Core {
     public static class TaskCompletionSourceExtensions {
+        private const int NO_DELAY = -1;
+
         public static CancellationTokenRegistration RegisterForCancellation<T>(this TaskCompletionSource<T> taskCompletionSource, CancellationToken cancellationToken) 
-            => taskCompletionSource.RegisterForCancellation(-1, cancellationToken);
+            => taskCompletionSource.RegisterForCancellation(millisecondsDelay: NO_DELAY, cancellationToken);
 
         public static CancellationTokenRegistration RegisterForCancellation<T>(this TaskCompletionSource<T> taskCompletionSource, int millisecondsDelay, CancellationToken cancellationToken) {
             if (millisecondsDelay >= 0) {

--- a/src/Core/Impl/Extensions/TaskCompletionSourceExtensions.cs
+++ b/src/Core/Impl/Extensions/TaskCompletionSourceExtensions.cs
@@ -18,10 +18,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Python.Core {
     public static class TaskCompletionSourceExtensions {
-        private const int NO_DELAY = -1;
+        private const int no_delay = -1;
 
         public static CancellationTokenRegistration RegisterForCancellation<T>(this TaskCompletionSource<T> taskCompletionSource, CancellationToken cancellationToken) 
-            => taskCompletionSource.RegisterForCancellation(millisecondsDelay: NO_DELAY, cancellationToken);
+            => taskCompletionSource.RegisterForCancellation(millisecondsDelay: no_delay, cancellationToken);
 
         public static CancellationTokenRegistration RegisterForCancellation<T>(this TaskCompletionSource<T> taskCompletionSource, int millisecondsDelay, CancellationToken cancellationToken) {
             if (millisecondsDelay >= 0) {

--- a/src/Core/Test/PriorityProducerConsumerTest.cs
+++ b/src/Core/Test/PriorityProducerConsumerTest.cs
@@ -14,6 +14,8 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Core.Threading;
@@ -24,102 +26,96 @@ namespace Microsoft.Python.Core.Tests {
     public class PriorityProducerConsumerTest {
         [TestMethod, Priority(0)]
         public void PriorityProducerConsumer_NoPending() {
-            using (var ppc = new PriorityProducerConsumer<int>()) {
-                ppc.Produce(5);
-                var consumerTask = ppc.ConsumeAsync();
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
-                Assert.AreEqual(5, consumerTask.Result);
-            }
+            using var ppc = new PriorityProducerConsumer<int>();
+
+            ppc.Produce(5);
+            var consumerTask = ppc.ConsumeAsync();
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
+            Assert.AreEqual(5, consumerTask.Result);
         }
 
         [TestMethod, Priority(0)]
         public void PriorityProducerConsumer_NoPending_Priority1() {
-            using (var ppc = new PriorityProducerConsumer<int>(2)) {
-                ppc.Produce(5);
-                ppc.Produce(6, 1);
-                var consumerTask = ppc.ConsumeAsync();
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
-                Assert.AreEqual(5, consumerTask.Result);
-            }
+            using var ppc = new PriorityProducerConsumer<int>(2);
+            ppc.Produce(5);
+            ppc.Produce(6, 1);
+            var consumerTask = ppc.ConsumeAsync();
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
+            Assert.AreEqual(5, consumerTask.Result);
         }
 
         [TestMethod, Priority(0)]
         public void PriorityProducerConsumer_NoPending_Priority2() {
-            using (var ppc = new PriorityProducerConsumer<int>(2)) {
-                ppc.Produce(6, 1);
-                ppc.Produce(5);
-                var consumerTask = ppc.ConsumeAsync();
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
-                Assert.AreEqual(5, consumerTask.Result);
-            }
+            using var ppc = new PriorityProducerConsumer<int>(2);
+            ppc.Produce(6, 1);
+            ppc.Produce(5);
+            var consumerTask = ppc.ConsumeAsync();
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
+            Assert.AreEqual(5, consumerTask.Result);
         }
 
         [TestMethod, Priority(0)]
         public void PriorityProducerConsumer_NoPending_Duplicates1() {
-            using (var ppc = new PriorityProducerConsumer<int>(3, true)) {
-                ppc.Produce(5, 2);
-                ppc.Produce(6, 1);
-                ppc.Produce(5);
-                var consumerTask1 = ppc.ConsumeAsync();
-                var consumerTask2 = ppc.ConsumeAsync();
-                var consumerTask3 = ppc.ConsumeAsync();
+            using var ppc = new PriorityProducerConsumer<int>(3, true);
+            ppc.Produce(5, 2);
+            ppc.Produce(6, 1);
+            ppc.Produce(5);
+            var consumerTask1 = ppc.ConsumeAsync();
+            var consumerTask2 = ppc.ConsumeAsync();
+            var consumerTask3 = ppc.ConsumeAsync();
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask3.Status);
-                Assert.AreEqual(5, consumerTask1.Result);
-                Assert.AreEqual(6, consumerTask2.Result);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask3.Status);
+            Assert.AreEqual(5, consumerTask1.Result);
+            Assert.AreEqual(6, consumerTask2.Result);
         }
 
         [TestMethod, Priority(0)]
         public void PriorityProducerConsumer_NoPending_Duplicates2() {
-            using (var ppc = new PriorityProducerConsumer<int>(3, true)) {
-                ppc.Produce(5);
-                ppc.Produce(6, 1);
-                ppc.Produce(5, 2);
-                var consumerTask1 = ppc.ConsumeAsync();
-                var consumerTask2 = ppc.ConsumeAsync();
-                var consumerTask3 = ppc.ConsumeAsync();
+            using var ppc = new PriorityProducerConsumer<int>(3, true);
+            ppc.Produce(5);
+            ppc.Produce(6, 1);
+            ppc.Produce(5, 2);
+            var consumerTask1 = ppc.ConsumeAsync();
+            var consumerTask2 = ppc.ConsumeAsync();
+            var consumerTask3 = ppc.ConsumeAsync();
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask3.Status);
-                Assert.AreEqual(5, consumerTask1.Result);
-                Assert.AreEqual(6, consumerTask2.Result);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask3.Status);
+            Assert.AreEqual(5, consumerTask1.Result);
+            Assert.AreEqual(6, consumerTask2.Result);
         }
 
         [TestMethod, Priority(0)]
         public void PriorityProducerConsumer_NoPending_Duplicates3() {
-            using (var ppc = new PriorityProducerConsumer<int>(3, true)) {
-                ppc.Produce(5, 1);
-                ppc.Produce(6, 1);
-                ppc.Produce(5, 1);
-                var consumerTask1 = ppc.ConsumeAsync();
-                var consumerTask2 = ppc.ConsumeAsync();
-                var consumerTask3 = ppc.ConsumeAsync();
+            using var ppc = new PriorityProducerConsumer<int>(3, true);
+            ppc.Produce(5, 1);
+            ppc.Produce(6, 1);
+            ppc.Produce(5, 1);
+            var consumerTask1 = ppc.ConsumeAsync();
+            var consumerTask2 = ppc.ConsumeAsync();
+            var consumerTask3 = ppc.ConsumeAsync();
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask3.Status);
-                Assert.AreEqual(6, consumerTask1.Result);
-                Assert.AreEqual(5, consumerTask2.Result);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask3.Status);
+            Assert.AreEqual(6, consumerTask1.Result);
+            Assert.AreEqual(5, consumerTask2.Result);
         }
 
         [TestMethod, Priority(0)]
         public async Task PriorityProducerConsumer_Pending() {
-            using (var ppc = new PriorityProducerConsumer<int>()) {
-                var consumerTask = ppc.ConsumeAsync();
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask.Status);
+            using var ppc = new PriorityProducerConsumer<int>();
+            var consumerTask = ppc.ConsumeAsync();
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask.Status);
 
-                ppc.Produce(5);
-                await consumerTask;
+            ppc.Produce(5);
+            await consumerTask;
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
-                Assert.AreEqual(5, consumerTask.Result);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
+            Assert.AreEqual(5, consumerTask.Result);
         }
 
         [TestMethod, Priority(0)]
@@ -138,72 +134,116 @@ namespace Microsoft.Python.Core.Tests {
 
         [TestMethod, Priority(0)]
         public async Task PriorityProducerConsumer_Pending_Priority1() {
-            using (var ppc = new PriorityProducerConsumer<int>(2)) {
-                var consumerTask = ppc.ConsumeAsync();
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask.Status);
+            using var ppc = new PriorityProducerConsumer<int>(2);
+            var consumerTask = ppc.ConsumeAsync();
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask.Status);
 
-                ppc.Produce(5);
-                ppc.Produce(6, 1);
-                await consumerTask;
+            ppc.Produce(5);
+            ppc.Produce(6, 1);
+            await consumerTask;
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
-                Assert.AreEqual(5, consumerTask.Result);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
+            Assert.AreEqual(5, consumerTask.Result);
         }
 
         [TestMethod, Priority(0)]
         public async Task PriorityProducerConsumer_Pending_Priority2() {
-            using (var ppc = new PriorityProducerConsumer<int>(2)) {
-                var consumerTask1 = ppc.ConsumeAsync();
-                var consumerTask2 = ppc.ConsumeAsync();
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask1.Status);
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask2.Status);
+            using var ppc = new PriorityProducerConsumer<int>(2);
+            var consumerTask1 = ppc.ConsumeAsync();
+            var consumerTask2 = ppc.ConsumeAsync();
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask1.Status);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask2.Status);
 
-                ppc.Produce(6, 1);
-                await consumerTask1;
+            ppc.Produce(6, 1);
+            await consumerTask1;
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask2.Status);
-                Assert.AreEqual(6, consumerTask1.Result);
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask1.Status);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask2.Status);
+            Assert.AreEqual(6, consumerTask1.Result);
 
-                ppc.Produce(5);
-                await consumerTask2;
+            ppc.Produce(5);
+            await consumerTask2;
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
-                Assert.AreEqual(5, consumerTask2.Result);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask2.Status);
+            Assert.AreEqual(5, consumerTask2.Result);
         }
 
         [TestMethod, Priority(0)]
         public async Task PriorityProducerConsumer_Pending_Priority3() {
-            using (var ppc = new PriorityProducerConsumer<int>(2)) {
-                var values = new int[3];
-                var tcsConsumer = new TaskCompletionSource<bool>();
-                var tcsProducer = new TaskCompletionSource<bool>();
-                var consumerTask = Task.Run(async () => {
-                    for (var i = 0; i < 3; i++) {
-                        var task = ppc.ConsumeAsync();
-                        tcsConsumer.TrySetResult(true);
-                        values[i] = await task;
-                        await tcsProducer.Task;
-                    }
-                });
+            using var ppc = new PriorityProducerConsumer<int>(2);
+            var values = new int[3];
+            var tcsConsumer = new TaskCompletionSource<bool>();
+            var tcsProducer = new TaskCompletionSource<bool>();
+            var consumerTask = Task.Run(async () => {
+                for (var i = 0; i < 3; i++) {
+                    var task = ppc.ConsumeAsync();
+                    tcsConsumer.TrySetResult(true);
+                    values[i] = await task;
+                    await tcsProducer.Task;
+                }
+            });
 
-                Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask.Status);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, consumerTask.Status);
 
-                await tcsConsumer.Task;
-                ppc.Produce(5, 1);
-                ppc.Produce(6, 1);
-                ppc.Produce(7);
-                tcsProducer.SetResult(false);
+            await tcsConsumer.Task;
+            ppc.Produce(5, 1);
+            ppc.Produce(6, 1);
+            ppc.Produce(7);
+            tcsProducer.SetResult(false);
 
-                await consumerTask;
+            await consumerTask;
 
-                Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
-                Assert.AreEqual(5, values[0]);
-                Assert.AreEqual(7, values[1]);
-                Assert.AreEqual(6, values[2]);
-            }
+            Assert.AreEqual(TaskStatus.RanToCompletion, consumerTask.Status);
+            Assert.AreEqual(5, values[0]);
+            Assert.AreEqual(7, values[1]);
+            Assert.AreEqual(6, values[2]);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task PriorityProducerConsumer_ExcludeDuplicates() {
+            using var ppc = new PriorityProducerConsumer<int>(maxPriority: 2, excludeDuplicates: true);
+
+            ppc.Produce(value: 1, priority: 0);
+            ppc.Produce(value: 2, priority: 0);
+            ppc.Produce(value: 3, priority: 0);
+            ppc.Produce(value: 1, priority: 1);
+            ppc.Produce(value: 2, priority: 1);
+
+            var data1 = await ppc.ConsumeAsync(CancellationToken.None);
+            data1.Should().Be(3);
+
+            var data2 = await ppc.ConsumeAsync(CancellationToken.None);
+            data2.Should().Be(1);
+
+            var data3 = await ppc.ConsumeAsync(CancellationToken.None);
+            data3.Should().Be(2);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task PriorityProducerConsumer_ExcludeDuplicates_HigherPriority() {
+            using var ppc = new PriorityProducerConsumer<int>(maxPriority: 2, excludeDuplicates: true);
+
+            ppc.Produce(value: 1, priority: 1);
+            ppc.Produce(value: 2, priority: 1);
+            ppc.Produce(value: 3, priority: 1);
+            ppc.Produce(value: 1, priority: 0);
+            ppc.Produce(value: 2, priority: 0);
+
+            var data1 = await ppc.ConsumeAsync(CancellationToken.None);
+            data1.Should().Be(1);
+
+            var data2 = await ppc.ConsumeAsync(CancellationToken.None);
+            data2.Should().Be(2);
+
+            var data3 = await ppc.ConsumeAsync(CancellationToken.None);
+            data3.Should().Be(3);
+        }
+
+        [TestMethod, Priority(0)]
+        public void PriorityProducerConsumer_MaxPriority() {
+            using var ppc = new PriorityProducerConsumer<int>(maxPriority: 2, excludeDuplicates: false);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => ppc.Produce(value: 1, priority: 2));
         }
     }
 }

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             private readonly PriorityProducerConsumer<QueueItem> _ppc;
 
             public Prioritizer() {
-                _ppc = new PriorityProducerConsumer<QueueItem>(4);
+                _ppc = new PriorityProducerConsumer<QueueItem>(maxPriority: 4);
                 Task.Run(ConsumerLoop).DoNotWait();
             }
 
@@ -346,16 +346,16 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             }
 
             public Task<IDisposable> InitializePriorityAsync(CancellationToken cancellationToken = default(CancellationToken))
-                => Enqueue(InitializePriority, true, cancellationToken);
+                => Enqueue(InitializePriority, isAwaitable: true, cancellationToken);
 
             public Task<IDisposable> ConfigurationPriorityAsync(CancellationToken cancellationToken = default(CancellationToken))
-                => Enqueue(ConfigurationPriority, true, cancellationToken);
+                => Enqueue(ConfigurationPriority, isAwaitable: true, cancellationToken);
 
             public Task<IDisposable> DocumentChangePriorityAsync(CancellationToken cancellationToken = default(CancellationToken))
-                => Enqueue(DocumentChangePriority, true, cancellationToken);
+                => Enqueue(DocumentChangePriority, isAwaitable: true, cancellationToken);
 
             public Task DefaultPriorityAsync(CancellationToken cancellationToken = default(CancellationToken))
-                => Enqueue(DefaultPriority, false, cancellationToken);
+                => Enqueue(DefaultPriority, isAwaitable: false, cancellationToken);
 
             private Task<IDisposable> Enqueue(int priority, bool isAwaitable, CancellationToken cancellationToken = default(CancellationToken)) {
                 var item = new QueueItem(isAwaitable, cancellationToken);

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-#define WAIT_FOR_DEBUGGER
+// #define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-// #define WAIT_FOR_DEBUGGER
+#define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;


### PR DESCRIPTION
simple clean up. PriorityProducerConsumer was using List but removed element from head. but never took advantage of indexer so changed it to use LinkedList.