### PR TITLE
Make PythonKeywords class public for use in PTVS

### DIFF
--- a/src/LanguageServer/Impl/Completion/TopLevelCompletion.cs
+++ b/src/LanguageServer/Impl/Completion/TopLevelCompletion.cs
@@ -22,6 +22,7 @@ using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.LanguageServer.Protocol;
+using Microsoft.Python.Parsing;
 using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Completion {

--- a/src/Parsing/Impl/PythonKeywords.cs
+++ b/src/Parsing/Impl/PythonKeywords.cs
@@ -16,13 +16,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Python.Parsing;
 
-namespace Microsoft.Python.LanguageServer.Completion {
+namespace Microsoft.Python.Parsing {
     /// <summary>
     /// The canonical source of keyword names for Python.
     /// </summary>
-    internal static class PythonKeywords {
+    public static class PythonKeywords {
         /// <summary>
         /// Returns true if the specified identifier is a keyword in a
         /// particular version of Python.


### PR DESCRIPTION
It didn't seem appropriate to leave it in the current namespace/location since everything in there was private. I can move it somewhere else if you don't like it in parser project.