### PR TITLE
Make sure we pass lookup options to expression evaluation

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Callables.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return value;
         }
 
-        public IMember GetValueFromLambda(LambdaExpression expr, LookupOptions lookupOptions = LookupOptions.Normal) {
+        public IMember GetValueFromLambda(LambdaExpression expr) {
             if (expr == null) {
                 return null;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             var location = GetLocationOfName(fd);
             var ft = new PythonFunctionType(fd, null, location);
             var overload = new PythonFunctionOverload(ft, fd, location, expr.Function.ReturnAnnotation?.ToCodeString(Ast));
-            overload.SetParameters(CreateFunctionParameters(null, ft, fd, false, lookupOptions));
+            overload.SetParameters(CreateFunctionParameters(null, ft, fd, false));
             ft.AddOverload(overload);
             return ft;
         }
@@ -320,8 +320,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             IPythonClassType self, 
             IPythonClassMember function, 
             FunctionDefinition fd, 
-            bool declareVariables,
-            LookupOptions lookupOptions) {
+            bool declareVariables) {
             // For class method no need to add extra parameters, but first parameter type should be the class.
             // For static and unbound methods do not add or set anything.
             // For regular bound methods add first parameter and set it to the class.
@@ -351,8 +350,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             for (var i = skip; i < fd.Parameters.Length; i++) {
                 var p = fd.Parameters[i];
                 if (!string.IsNullOrEmpty(p.Name)) {
-                    var defaultValue = GetValueFromExpression(p.DefaultValue, lookupOptions);
-                    var paramType = GetTypeFromAnnotation(p.Annotation, out var isGeneric, lookupOptions) ?? UnknownType;
+                    var defaultValue = GetValueFromExpression(p.DefaultValue);
+                    var paramType = GetTypeFromAnnotation(p.Annotation, out var isGeneric) ?? UnknownType;
                     if (paramType.IsUnknown()) {
                         // If parameter has default value, look for the annotation locally first
                         // since outer type may be getting redefined. Consider 's = None; def f(s: s = 123): ...

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Collections.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.Collections.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
     internal sealed partial class ExpressionEval {
         private const int MaxCollectionSize = 1000;
 
-        public IMember GetValueFromIndex(IndexExpression expr) {
+        public IMember GetValueFromIndex(IndexExpression expr, LookupOptions lookupOptions = LookupOptions.Normal) {
             if (expr?.Target == null) {
                 return null;
             }
 
-            var target = GetValueFromExpression(expr.Target);
+            var target = GetValueFromExpression(expr.Target, lookupOptions);
             // Try generics first since this may be an expression like Dict[int, str]
-            var result = GetValueFromGeneric(target, expr);
+            var result = GetValueFromGeneric(target, expr, lookupOptions);
             if (result != null) {
                 return result;
             }
@@ -47,7 +47,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 if (!(target is IPythonInstance instance)) {
                     instance = type.CreateInstance(ArgumentSet.Empty(expr, this));
                 }
-                var index = GetValueFromExpression(expr.Index);
+                var index = GetValueFromExpression(expr.Index, lookupOptions);
                 if (index != null) {
                     return type.Index(instance, new ArgumentSet(new[] { index }, expr, this));
                 }
@@ -56,52 +56,52 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return UnknownType;
         }
 
-        public IMember GetValueFromList(ListExpression expression) {
+        public IMember GetValueFromList(ListExpression expression, LookupOptions lookupOptions = LookupOptions.Normal) {
             var contents = new List<IMember>();
             foreach (var item in expression.Items.Take(MaxCollectionSize)) {
-                var value = GetValueFromExpression(item) ?? UnknownType;
+                var value = GetValueFromExpression(item, lookupOptions) ?? UnknownType;
                 contents.Add(value);
             }
             return PythonCollectionType.CreateList(Module, contents, exact: expression.Items.Count <= MaxCollectionSize);
         }
 
-        public IMember GetValueFromDictionary(DictionaryExpression expression) {
+        public IMember GetValueFromDictionary(DictionaryExpression expression, LookupOptions lookupOptions = LookupOptions.Normal) {
             var contents = new Dictionary<IMember, IMember>();
             foreach (var item in expression.Items.Take(MaxCollectionSize)) {
-                var key = GetValueFromExpression(item.SliceStart) ?? UnknownType;
-                var value = GetValueFromExpression(item.SliceStop) ?? UnknownType;
+                var key = GetValueFromExpression(item.SliceStart, lookupOptions) ?? UnknownType;
+                var value = GetValueFromExpression(item.SliceStop, lookupOptions) ?? UnknownType;
                 contents[key] = value;
             }
             return new PythonDictionary(Module, contents, exact: expression.Items.Count <= MaxCollectionSize);
         }
 
-        private IMember GetValueFromTuple(TupleExpression expression) {
+        private IMember GetValueFromTuple(TupleExpression expression, LookupOptions lookupOptions = LookupOptions.Normal) {
             var contents = new List<IMember>();
             foreach (var item in expression.Items.Take(MaxCollectionSize)) {
-                var value = GetValueFromExpression(item) ?? UnknownType;
+                var value = GetValueFromExpression(item, lookupOptions) ?? UnknownType;
                 contents.Add(value);
             }
             return PythonCollectionType.CreateTuple(Module, contents, exact: expression.Items.Count <= MaxCollectionSize);
         }
 
-        public IMember GetValueFromSet(SetExpression expression) {
+        public IMember GetValueFromSet(SetExpression expression, LookupOptions lookupOptions = LookupOptions.Normal) {
             var contents = new List<IMember>();
             foreach (var item in expression.Items.Take(MaxCollectionSize)) {
-                var value = GetValueFromExpression(item) ?? UnknownType;
+                var value = GetValueFromExpression(item, lookupOptions) ?? UnknownType;
                 contents.Add(value);
             }
             return PythonCollectionType.CreateSet(Module, contents, exact: expression.Items.Count <= MaxCollectionSize);
         }
 
-        public IMember GetValueFromGenerator(GeneratorExpression expression) {
+        public IMember GetValueFromGenerator(GeneratorExpression expression, LookupOptions lookupOptions = LookupOptions.Normal) {
             var iter = expression.Iterators.OfType<ComprehensionFor>().FirstOrDefault();
             if (iter != null) {
-                return GetValueFromExpression(iter.List) ?? UnknownType;
+                return GetValueFromExpression(iter.List, lookupOptions) ?? UnknownType;
             }
             return UnknownType;
         }
 
-        public IMember GetValueFromComprehension(Comprehension node) {
+        public IMember GetValueFromComprehension(Comprehension node, LookupOptions lookupOptions = LookupOptions.Normal) {
             var oldVariables = CurrentScope.Variables.OfType<Variable>().ToDictionary(k => k.Name, v => v);
             try {
                 ProcessComprehension(node);
@@ -109,14 +109,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                 // TODO: Evaluate comprehensions to produce exact contents, if possible.
                 switch (node) {
                     case ListComprehension lc:
-                        var v1 = GetValueFromExpression(lc.Item) ?? UnknownType;
+                        var v1 = GetValueFromExpression(lc.Item, lookupOptions) ?? UnknownType;
                         return PythonCollectionType.CreateList(Module, new[] { v1 });
                     case SetComprehension sc:
-                        var v2 = GetValueFromExpression(sc.Item) ?? UnknownType;
+                        var v2 = GetValueFromExpression(sc.Item, lookupOptions) ?? UnknownType;
                         return PythonCollectionType.CreateSet(Module, new[] { v2 });
                     case DictionaryComprehension dc:
-                        var k = GetValueFromExpression(dc.Key) ?? UnknownType;
-                        var v = GetValueFromExpression(dc.Value) ?? UnknownType;
+                        var k = GetValueFromExpression(dc.Key, lookupOptions) ?? UnknownType;
+                        var v = GetValueFromExpression(dc.Value, lookupOptions) ?? UnknownType;
                         return new PythonDictionary(new PythonDictionaryType(Interpreter.ModuleResolution.BuiltinsModule), new Dictionary<IMember, IMember> { { k, v } });
                 }
 
@@ -134,9 +134,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
         }
 
-        internal void ProcessComprehension(Comprehension node) {
+        internal void ProcessComprehension(Comprehension node, LookupOptions lookupOptions = LookupOptions.Normal) {
             foreach (var cfor in node.Iterators.OfType<ComprehensionFor>().Where(c => c.Left != null)) {
-                var value = GetValueFromExpression(cfor.List);
+                var value = GetValueFromExpression(cfor.List, lookupOptions);
                 if (value != null) {
                     switch (cfor.Left) {
                         case NameExpression nex when value is IPythonCollection c1:

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                     m = GetValueFromComprehension(comp, lookupOptions);
                     break;
                 case LambdaExpression lambda:
-                    m = GetValueFromLambda(lambda, lookupOptions);
+                    m = GetValueFromLambda(lambda);
                     break;
                 case FString fString:
                     m = GetValueFromFString(fString);

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/ExpressionEval.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         public IDisposable OpenScope(IPythonModule module, ScopeStatement scope) => OpenScope(module, scope, out _);
         #endregion
 
-        public IMember GetValueFromExpression(Expression expr, LookupOptions options = LookupOptions.Normal) {
+        public IMember GetValueFromExpression(Expression expr, LookupOptions lookupOptions = LookupOptions.Normal) {
             if (expr == null) {
                 return null;
             }
@@ -134,46 +134,46 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             IMember m;
             switch (expr) {
                 case NameExpression nex:
-                    m = GetValueFromName(nex, options);
+                    m = GetValueFromName(nex, lookupOptions);
                     break;
                 case MemberExpression mex:
-                    m = GetValueFromMember(mex);
+                    m = GetValueFromMember(mex, lookupOptions);
                     break;
                 case CallExpression cex:
-                    m = GetValueFromCallable(cex);
+                    m = GetValueFromCallable(cex, lookupOptions);
                     break;
                 case UnaryExpression uex:
-                    m = GetValueFromUnaryOp(uex);
+                    m = GetValueFromUnaryOp(uex, lookupOptions);
                     break;
                 case IndexExpression iex:
-                    m = GetValueFromIndex(iex);
+                    m = GetValueFromIndex(iex, lookupOptions);
                     break;
                 case ConditionalExpression coex:
-                    m = GetValueFromConditional(coex);
+                    m = GetValueFromConditional(coex, lookupOptions);
                     break;
                 case ListExpression listex:
-                    m = GetValueFromList(listex);
+                    m = GetValueFromList(listex, lookupOptions);
                     break;
                 case DictionaryExpression dictex:
-                    m = GetValueFromDictionary(dictex);
+                    m = GetValueFromDictionary(dictex, lookupOptions);
                     break;
                 case SetExpression setex:
-                    m = GetValueFromSet(setex);
+                    m = GetValueFromSet(setex, lookupOptions);
                     break;
                 case TupleExpression tex:
-                    m = GetValueFromTuple(tex);
+                    m = GetValueFromTuple(tex, lookupOptions);
                     break;
                 case YieldExpression yex:
-                    m = GetValueFromExpression(yex.Expression);
+                    m = GetValueFromExpression(yex.Expression, lookupOptions);
                     break;
                 case GeneratorExpression genex:
-                    m = GetValueFromGenerator(genex);
+                    m = GetValueFromGenerator(genex, lookupOptions);
                     break;
                 case Comprehension comp:
-                    m = GetValueFromComprehension(comp);
+                    m = GetValueFromComprehension(comp, lookupOptions);
                     break;
                 case LambdaExpression lambda:
-                    m = GetValueFromLambda(lambda);
+                    m = GetValueFromLambda(lambda, lookupOptions);
                     break;
                 case FString fString:
                     m = GetValueFromFString(fString);
@@ -182,14 +182,14 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
                     m = GetValueFromFormatSpecifier(formatSpecifier);
                     break;
                 case NamedExpression namedExpr:
-                    m = GetValueFromExpression(namedExpr.Value);
+                    m = GetValueFromExpression(namedExpr.Value, lookupOptions);
                     break;
                 // indexing with nothing, e.g Generic[]
                 case ErrorExpression error:
                     m = null;
                     break;
                 default:
-                    m = GetValueFromBinaryOp(expr) ?? GetConstantFromLiteral(expr);
+                    m = GetValueFromBinaryOp(expr, lookupOptions) ?? GetConstantFromLiteral(expr);
                     break;
             }
             if (m == null) {
@@ -232,12 +232,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             return UnknownType;
         }
 
-        private IMember GetValueFromMember(MemberExpression expr) {
+        private IMember GetValueFromMember(MemberExpression expr, LookupOptions lookupOptions = LookupOptions.Normal) {
             if (expr?.Target == null || string.IsNullOrEmpty(expr.Name)) {
                 return null;
             }
 
-            var m = GetValueFromExpression(expr.Target);
+            var m = GetValueFromExpression(expr.Target, lookupOptions);
             if (m == null) {
                 return UnknownType;
             }
@@ -286,13 +286,13 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             }
         }
 
-        private IMember GetValueFromConditional(ConditionalExpression expr) {
+        private IMember GetValueFromConditional(ConditionalExpression expr, LookupOptions lookupOptions = LookupOptions.Normal) {
             if (expr == null) {
                 return null;
             }
 
-            var trueValue = GetValueFromExpression(expr.TrueExpression);
-            var falseValue = GetValueFromExpression(expr.FalseExpression);
+            var trueValue = GetValueFromExpression(expr.TrueExpression, lookupOptions);
+            var falseValue = GetValueFromExpression(expr.FalseExpression, lookupOptions);
 
             return trueValue ?? falseValue ?? UnknownType;
         }

--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/FunctionCallEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/FunctionCallEvaluator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
         }
 
         public override bool Walk(ReturnStatement node) {
-            var value = Eval.GetValueFromExpression(node.Expression);
+            var value = Eval.GetValueFromExpression(node.Expression, LookupOptions.Normal);
             if (!value.IsUnknown()) {
                 _result = value;
                 return false;

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
     internal sealed class AssignmentHandler : StatementHandler {
         public AssignmentHandler(AnalysisWalker walker) : base(walker) { }
 
-        public void HandleAssignment(AssignmentStatement node) {
+        public void HandleAssignment(AssignmentStatement node, LookupOptions lookupOptions = LookupOptions.Normal) {
             if (node.Right is ErrorExpression) {
                 return;
             }
@@ -34,7 +34,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
 
             // TODO: Assigning like this is wrong; the assignment needs to be considering the
             // right side's unpacking for what's on the left, not just apply it to every case.
-            var value = ExtractRhs(node.Right, lhs.FirstOrDefault());
+            var value = ExtractRhs(node.Right, lhs.FirstOrDefault(), lookupOptions);
             if (value != null) {
                 foreach (var expr in lhs) {
                     AssignToExpr(expr, value);
@@ -55,8 +55,8 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             }
         }
 
-        private IMember ExtractRhs(Expression rhs, Expression typed) {
-            var value = Eval.GetValueFromExpression(rhs) ?? Eval.UnknownType;
+        private IMember ExtractRhs(Expression rhs, Expression typed, LookupOptions lookupOptions = LookupOptions.Normal) {
+            var value = Eval.GetValueFromExpression(rhs, lookupOptions) ?? Eval.UnknownType;
 
             // Check PEP hint first
             var valueType = Eval.GetTypeFromPepHint(rhs);
@@ -117,12 +117,12 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             }
         }
 
-        public void HandleAnnotatedExpression(ExpressionWithAnnotation expr, IMember value) {
+        public void HandleAnnotatedExpression(ExpressionWithAnnotation expr, IMember value, LookupOptions lookupOptions = LookupOptions.Normal) {
             if (expr?.Annotation == null) {
                 return;
             }
 
-            var variableType = Eval.GetTypeFromAnnotation(expr.Annotation);
+            var variableType = Eval.GetTypeFromAnnotation(expr.Annotation, lookupOptions);
             // If value is null, then this is a pure declaration like 
             //   x: List[str]
             // without a value. If value is provided, then this is

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/ClassEvaluator.cs
@@ -90,10 +90,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             foreach (var s in GetStatements<Statement>(_classDef)) {
                 switch (s) {
                     case AssignmentStatement assignment:
-                        AssignmentHandler.HandleAssignment(assignment);
+                        AssignmentHandler.HandleAssignment(assignment, LookupOptions.All);
                         break;
                     case ExpressionStatement e:
-                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null);
+                        AssignmentHandler.HandleAnnotatedExpression(e.Expression as ExpressionWithAnnotation, null, LookupOptions.All);
                         break;
                 }
             }
@@ -113,7 +113,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             using (Eval.OpenScope(Eval.CurrentScope.OuterScope)) {
                 var bases = new List<IPythonType>();
                 foreach (var a in _classDef.Bases.Where(a => string.IsNullOrEmpty(a.Name))) {
-                    if (IsValidBase(a)) {
+                    if (IsValidBase(a, LookupOptions.Normal)) {
                         TryAddBase(bases, a);
                     } else {
                         ReportInvalidBase(a);
@@ -123,9 +123,9 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             }
         }
 
-        private bool IsValidBase(Arg a) {
+        private bool IsValidBase(Arg a, LookupOptions lookupOptions) {
             var expr = a.Expression;
-            var m = Eval.GetValueFromExpression(expr);
+            var m = Eval.GetValueFromExpression(expr, lookupOptions);
 
             // Allow any unknown members
             if (m.IsUnknown()) {

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             using (Eval.OpenScope(_function.DeclaringModule, FunctionDefinition, out _)) {
                 var returnType = TryDetermineReturnValue();
 
-                var parameters = Eval.CreateFunctionParameters(_self, _function, FunctionDefinition, !stub);
+                var parameters = Eval.CreateFunctionParameters(_self, _function, FunctionDefinition, !stub, LookupOptions.All);
                 CheckValidOverload(parameters);
                 _overload.SetParameters(parameters);
 
@@ -82,7 +82,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
         }
 
         private IPythonType TryDetermineReturnValue() {
-            var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation);
+            var annotationType = Eval.GetTypeFromAnnotation(FunctionDefinition.ReturnAnnotation, LookupOptions.All);
             if (!annotationType.IsUnknown()) {
                 // Annotations are typically types while actually functions return
                 // instances unless specifically annotated to a type such as Type[T].

--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
             using (Eval.OpenScope(_function.DeclaringModule, FunctionDefinition, out _)) {
                 var returnType = TryDetermineReturnValue();
 
-                var parameters = Eval.CreateFunctionParameters(_self, _function, FunctionDefinition, !stub, LookupOptions.All);
+                var parameters = Eval.CreateFunctionParameters(_self, _function, FunctionDefinition, !stub);
                 CheckValidOverload(parameters);
                 _overload.SetParameters(parameters);
 

--- a/src/Analysis/Ast/Impl/Types/ArgumentSet.cs
+++ b/src/Analysis/Ast/Impl/Types/ArgumentSet.cs
@@ -286,25 +286,25 @@ namespace Microsoft.Python.Analysis.Types {
             }
         }
 
-        public ArgumentSet Evaluate() {
+        public ArgumentSet Evaluate(LookupOptions lookupOptions = LookupOptions.Normal) {
             if (_evaluated || Eval == null) {
                 return this;
             }
 
             foreach (var a in _arguments.Where(x => x.Value == null)) {
-                a.Value = GetArgumentValue(a);
+                a.Value = GetArgumentValue(a, lookupOptions);
             }
 
             if (_listArgument != null) {
                 foreach (var e in _listArgument.Expressions) {
-                    var value = Eval.GetValueFromExpression(e) ?? Eval.UnknownType;
+                    var value = Eval.GetValueFromExpression(e, lookupOptions) ?? Eval.UnknownType;
                     _listArgument._Values.Add(value);
                 }
             }
 
             if (_dictArgument != null) {
                 foreach (var e in _dictArgument.Expressions) {
-                    var value = Eval.GetValueFromExpression(e.Value) ?? Eval.UnknownType;
+                    var value = Eval.GetValueFromExpression(e.Value, lookupOptions) ?? Eval.UnknownType;
                     _dictArgument._Args[e.Key] = value;
                 }
             }
@@ -313,7 +313,7 @@ namespace Microsoft.Python.Analysis.Types {
             return this;
         }
 
-        private IMember GetArgumentValue(Argument arg) {
+        private IMember GetArgumentValue(Argument arg, LookupOptions lookupOptions) {
             if (arg.Value is IMember m) {
                 return m;
             }
@@ -326,10 +326,10 @@ namespace Microsoft.Python.Analysis.Types {
 
             if (arg.ValueIsDefault) {
                 using (Eval.OpenScope(DeclaringModule.GlobalScope)) {
-                    return Eval.GetValueFromExpression(arg.ValueExpression) ?? Eval.UnknownType;
+                    return Eval.GetValueFromExpression(arg.ValueExpression, lookupOptions) ?? Eval.UnknownType;
                 }
             }
-            return Eval.GetValueFromExpression(arg.ValueExpression) ?? Eval.UnknownType;
+            return Eval.GetValueFromExpression(arg.ValueExpression, lookupOptions) ?? Eval.UnknownType;
         }
 
         private Expression CreateExpression(string paramName, string defaultValue) {

--- a/src/Analysis/Ast/Test/ClassesTests.cs
+++ b/src/Analysis/Ast/Test/ClassesTests.cs
@@ -834,5 +834,28 @@ x = func()
             var analysis = await GetAnalysisAsync(code);
             analysis.Should().HaveVariable("x").OfType("A").Which.Should().HaveMember("methodABase");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task InnerClassAsClassMember() {
+            const string code = @"
+class test():
+    class Test2():
+        def Z(self):
+            return
+    A = Test2()
+
+    def X(self) -> Test2:
+        return Test2()
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+            var test = analysis.Should().HaveClass("test").Which;
+            
+            test.Should().HaveMember<IPythonInstance>("A").Which
+                .Should().HaveMethod("Z");
+            
+            test.Should().HaveMethod("X").Which
+                .Should().HaveSingleOverload().Which
+                .Should().HaveReturnType("Test2");
+        }
     }
 }


### PR DESCRIPTION
Fixes #1600 

We must make sure lookup options for name resolution are passed since additional `ClassMembers` is passed in the class scope context so we can find class members without `self.`.