### PR TITLE
Add 1 minute timeout to analysis tests run via AnalysisTestBase

### DIFF
--- a/src/Analysis/Ast/Test/AnalysisTestBase.cs
+++ b/src/Analysis/Ast/Test/AnalysisTestBase.cs
@@ -37,6 +37,8 @@ using TestUtilities;
 
 namespace Microsoft.Python.Analysis.Tests {
     public abstract class AnalysisTestBase {
+        private static readonly TimeSpan AnalysisTimeout = TimeSpan.FromMinutes(1);
+
         protected TestLogger TestLogger { get; } = new TestLogger();
         protected ServiceManager Services { get; private set; }
 
@@ -152,8 +154,13 @@ namespace Microsoft.Python.Analysis.Tests {
             TestLogger.Log(TraceEventType.Information, "Test: AST end.");
 
             TestLogger.Log(TraceEventType.Information, "Test: Analysis begin.");
-            await services.GetService<IPythonAnalyzer>().WaitForCompleteAnalysisAsync();
-            var analysis = await doc.GetAnalysisAsync(-1);
+
+            IDocumentAnalysis analysis;
+            using (var cts = new CancellationTokenSource(AnalysisTimeout)) {
+                await services.GetService<IPythonAnalyzer>().WaitForCompleteAnalysisAsync(cts.Token);
+                analysis = await doc.GetAnalysisAsync(-1, cts.Token);
+            }
+
             analysis.Should().NotBeNull();
             TestLogger.Log(TraceEventType.Information, "Test: Analysis end.");
 
@@ -162,8 +169,10 @@ namespace Microsoft.Python.Analysis.Tests {
 
         protected async Task<IDocumentAnalysis> GetDocumentAnalysisAsync(IDocument document) {
             var analyzer = Services.GetService<IPythonAnalyzer>();
-            await analyzer.WaitForCompleteAnalysisAsync();
-            return await document.GetAnalysisAsync(Timeout.Infinite);
+            using (var cts = new CancellationTokenSource(AnalysisTimeout)) {
+                await analyzer.WaitForCompleteAnalysisAsync(cts.Token);
+                return await document.GetAnalysisAsync(Timeout.Infinite, cts.Token);
+            }
         }
     }
 }


### PR DESCRIPTION
Try and cancel analysis requests if the tests appear to be hanging. Doesn't fix the underlying issue, but helps us work on other things.