### PR TITLE
Fix analysis module key duplication is stubs

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/AnalysisModuleKey.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/AnalysisModuleKey.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public AnalysisModuleKey(IPythonModule module) : this(
             module.Name,
             module.ModuleType == ModuleType.CompiledBuiltin ? null : module.FilePath,
-            IsTypeshedModule(module),
+            module.IsTypeshed,
             IsNonUserAsDocumentModule(module)) { }
 
         public AnalysisModuleKey(string name, string filePath, bool isTypeshed)
@@ -73,8 +73,6 @@ namespace Microsoft.Python.Analysis.Analyzer {
 
         public override string ToString() => $"{Name}({FilePath})";
 
-        private static bool IsTypeshedModule(IPythonModule module)
-            => module is StubPythonModule stubPythonModule && stubPythonModule.IsTypeshed;
         private static bool IsNonUserAsDocumentModule(IPythonModule module)
             => (module.IsNonUserFile() || module.IsCompiled()) && module is IDocument document && document.IsOpen;
     }

--- a/src/Analysis/Ast/Impl/Dependencies/DependencyCollector.cs
+++ b/src/Analysis/Ast/Impl/Dependencies/DependencyCollector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Python.Analysis.Dependencies {
 
         public DependencyCollector(IPythonModule module, bool? isTypeShed = null) {
             _module = module;
-            _isTypeshed = isTypeShed ?? module is StubPythonModule stub && stub.IsTypeshed;
+            _isTypeshed = isTypeShed ?? module.IsTypeshed;
             _moduleResolution = module.Interpreter.ModuleResolution;
             _pathResolver = _isTypeshed
                 ? module.Interpreter.TypeshedResolution.CurrentPathResolver

--- a/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
+++ b/src/Analysis/Ast/Impl/Documents/RunningDocumentTable.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Python.Analysis.Documents {
             IDocument document;
             switch (mco.ModuleType) {
                 case ModuleType.Compiled when TryAddModulePath(mco):
-                    document = new CompiledPythonModule(mco.ModuleName, ModuleType.Compiled, mco.FilePath, mco.Stub, mco.IsPersistent, _services);
+                    document = new CompiledPythonModule(mco.ModuleName, ModuleType.Compiled, mco.FilePath, mco.Stub, mco.IsPersistent, mco.IsTypeshed, _services);
                     break;
                 case ModuleType.CompiledBuiltin:
                     document = new CompiledBuiltinPythonModule(mco.ModuleName, mco.Stub, mco.IsPersistent, _services);

--- a/src/Analysis/Ast/Impl/Modules/BuiltinsPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/BuiltinsPythonModule.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Python.Analysis.Modules {
         private IPythonType _boolType;
 
         public BuiltinsPythonModule(string moduleName, string filePath, IServiceContainer services)
-            : base(moduleName, ModuleType.Builtins, filePath, null, false, services) { } // TODO: builtins stub & persistence
+            : base(moduleName, ModuleType.Builtins, filePath, null, false, false, services) { } // TODO: builtins stub & persistence
 
         public override IMember GetMember(string name) => _hiddenNames.Contains(name) ? null : base.GetMember(name);
 

--- a/src/Analysis/Ast/Impl/Modules/CompiledBuiltinPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/CompiledBuiltinPythonModule.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Python.Analysis.Modules {
     /// </summary>
     internal sealed class CompiledBuiltinPythonModule : CompiledPythonModule {
         public CompiledBuiltinPythonModule(string moduleName, IPythonModule stub, bool isPersistent, IServiceContainer services)
-            : base(moduleName, ModuleType.CompiledBuiltin, MakeFakeFilePath(moduleName, services), stub, isPersistent, services) { }
+            : base(moduleName, ModuleType.CompiledBuiltin, MakeFakeFilePath(moduleName, services), stub, isPersistent, false, services) { }
 
         protected override string[] GetScrapeArguments(IPythonInterpreter interpreter)
             => !InstallPath.TryGetFile("scrape_module.py", out var sm) ? null : new [] { "-W", "ignore", "-B", "-E", sm, "-u8", Name };

--- a/src/Analysis/Ast/Impl/Modules/CompiledPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/CompiledPythonModule.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Python.Analysis.Modules {
     internal class CompiledPythonModule : PythonModule {
         protected IStubCache StubCache => Interpreter.ModuleResolution.StubCache;
 
-        public CompiledPythonModule(string moduleName, ModuleType moduleType, string filePath, IPythonModule stub, bool isPersistent, IServiceContainer services)
-            : base(moduleName, filePath, moduleType, stub, isPersistent, services) { }
+        public CompiledPythonModule(string moduleName, ModuleType moduleType, string filePath, IPythonModule stub, bool isPersistent, bool isTypeshed, IServiceContainer services)
+            : base(moduleName, filePath, moduleType, stub, isPersistent, isTypeshed, services) { }
 
         public override string Documentation
             => GetMember("__doc__").TryGetConstant<string>(out var s) ? s : string.Empty;

--- a/src/Analysis/Ast/Impl/Modules/Definitions/ModuleCreationOptions.cs
+++ b/src/Analysis/Ast/Impl/Modules/Definitions/ModuleCreationOptions.cs
@@ -52,5 +52,11 @@ namespace Microsoft.Python.Analysis.Modules {
         /// Indicates if module is restored from database.
         /// </summary>
         public bool IsPersistent { get; set; }
+
+        /// <summary>
+        /// Defines if module belongs to Typeshed and hence resolved
+        /// via typeshed module resolution service.
+        /// </summary>
+        public bool IsTypeshed { get; set; }
     }
 }

--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -86,12 +86,13 @@ namespace Microsoft.Python.Analysis.Modules {
             SetDeclaringModule(this);
         }
 
-        protected PythonModule(string moduleName, string filePath, ModuleType moduleType, IPythonModule stub, bool isPersistent, IServiceContainer services) :
+        protected PythonModule(string moduleName, string filePath, ModuleType moduleType, IPythonModule stub, bool isPersistent, bool isTypeshed, IServiceContainer services) :
             this(new ModuleCreationOptions {
                 ModuleName = moduleName,
                 FilePath = filePath,
                 ModuleType = moduleType,
                 Stub = stub,
+                IsTypeshed = isTypeshed,
                 IsPersistent = isPersistent
             }, services) { }
 
@@ -119,6 +120,8 @@ namespace Microsoft.Python.Analysis.Modules {
             }
 
             IsPersistent = creationOptions.IsPersistent;
+            IsTypeshed = creationOptions.IsTypeshed;
+
             InitializeContent(creationOptions.Content, 0);
         }
 
@@ -222,6 +225,12 @@ namespace Microsoft.Python.Analysis.Modules {
         /// Indicates if module is restored from database.
         /// </summary>
         public bool IsPersistent { get; }
+
+        /// <summary>
+        /// Defines if module belongs to Typeshed and hence resolved
+        /// via typeshed module resolution service.
+        /// </summary>
+        public bool IsTypeshed { get; }
         #endregion
 
         #region IDisposable

--- a/src/Analysis/Ast/Impl/Modules/PythonVariableModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonVariableModule.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Python.Analysis.Modules {
         public Uri Uri => Module?.Uri;
         public override PythonMemberType MemberType => PythonMemberType.Module;
         public bool IsPersistent => Module?.IsPersistent == true;
+        public bool IsTypeshed => Module?.IsTypeshed == true;
 
         public PythonVariableModule(string name, IPythonInterpreter interpreter) : base(null) { 
             Name = name;

--- a/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/MainModuleResolution.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
             if (moduleImport.IsCompiled) {
                 Log?.Log(TraceEventType.Verbose, "Create compiled (scraped): ", moduleImport.FullName, moduleImport.ModulePath, moduleImport.RootPath);
-                return new CompiledPythonModule(moduleImport.FullName, ModuleType.Compiled, moduleImport.ModulePath, stub, moduleImport.IsPersistent, Services);
+                return new CompiledPythonModule(moduleImport.FullName, ModuleType.Compiled, moduleImport.ModulePath, stub, moduleImport.IsPersistent, false, Services);
             }
 
             Log?.Log(TraceEventType.Verbose, "Import: ", moduleImport.FullName, moduleImport.ModulePath);

--- a/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
         protected abstract IPythonModule CreateModule(string name);
 
         public IPythonModule GetImportedModule(string name) {
-            if (name == "__builtin__") {
+            if (name == Interpreter.ModuleResolution.BuiltinsModule.Name) {
                 return Interpreter.ModuleResolution.BuiltinsModule;
             }
             return Modules.TryGetValue(name, out var moduleRef)

--- a/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
+++ b/src/Analysis/Ast/Impl/Modules/Resolution/ModuleResolutionBase.cs
@@ -62,8 +62,14 @@ namespace Microsoft.Python.Analysis.Modules.Resolution {
 
         protected abstract IPythonModule CreateModule(string name);
 
-        public IPythonModule GetImportedModule(string name)
-            => Modules.TryGetValue(name, out var moduleRef) ? moduleRef.Value : Interpreter.ModuleResolution.GetSpecializedModule(name);
+        public IPythonModule GetImportedModule(string name) {
+            if (name == "__builtin__") {
+                return Interpreter.ModuleResolution.BuiltinsModule;
+            }
+            return Modules.TryGetValue(name, out var moduleRef)
+                ? moduleRef.Value
+                : Interpreter.ModuleResolution.GetSpecializedModule(name);
+        }
 
         public IPythonModule GetOrLoadModule(string name) {
             // Specialized should always win. However, we don't want

--- a/src/Analysis/Ast/Impl/Modules/SpecializedModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/SpecializedModule.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Python.Analysis.Modules {
     /// </remarks>
     internal abstract class SpecializedModule : PythonModule {
         protected SpecializedModule(string name, string modulePath, IServiceContainer services)
-            : base(name, modulePath, ModuleType.Specialized, null, false, services) { }
+            : base(name, modulePath, ModuleType.Specialized, null, false, false, services) { }
 
         protected override string LoadContent() {
             // Exceptions are handled in the base

--- a/src/Analysis/Ast/Impl/Modules/StubPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/StubPythonModule.cs
@@ -22,11 +22,8 @@ namespace Microsoft.Python.Analysis.Modules {
     /// Represents module that contains stub code such as from typeshed.
     /// </summary>
     internal class StubPythonModule : CompiledPythonModule {
-        public bool IsTypeshed { get; }
-
         public StubPythonModule(string moduleName, string stubPath, bool isTypeshed, IServiceContainer services)
-            : base(moduleName, ModuleType.Stub, stubPath, null, false, services) {
-            IsTypeshed = isTypeshed;
+            : base(moduleName, ModuleType.Stub, stubPath, null, false, isTypeshed, services) {
         }
 
         protected override string LoadContent() {

--- a/src/Analysis/Ast/Impl/Types/Definitions/IPythonModule.cs
+++ b/src/Analysis/Ast/Impl/Types/Definitions/IPythonModule.cs
@@ -68,5 +68,11 @@ namespace Microsoft.Python.Analysis.Types {
         /// Indicates if module is restored from database.
         /// </summary>
         bool IsPersistent { get; }
+
+        /// <summary>
+        /// Defines if module belongs to Typeshed and hence resolved
+        /// via typeshed module resolution service.
+        /// </summary>
+        bool IsTypeshed { get; }
     }
 }


### PR DESCRIPTION
- Fix analysis module key duplication is stubs: IsTypeshed is set in `StubPythonModule` after base initiated loading of content and analysis so occasionally there may be two keys in the analyzer - one with IsTypeshed set and one without.
- Fix builtins module resolution in typeshed - so it resolves to the same common builtins and not to stub