### PR TITLE
Handle Unions of collections in ValueEnumerator, recursively

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/AssignmentHandler.cs
@@ -32,8 +32,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             // Filter out parenthesis expression in assignment because it makes no difference.
             var lhs = node.Left.Select(s => s.RemoveParenthesis());
 
-            // TODO: Assigning like this is wrong; the assignment needs to be considering the
-            // right side's unpacking for what's on the left, not just apply it to every case.
+            // Note that this is handling assignments of the same value to multiple variables,
+            // i.e. with "x = y = z = value", x/y/z are the items in lhs. If an expression looks
+            // like "x, y, z = value", then "x, y, z" is a *single* lhs value and its unpacking
+            // will be handled by AssignToExpr.
             var value = ExtractRhs(node.Right, lhs.FirstOrDefault(), lookupOptions);
             if (value != null) {
                 foreach (var expr in lhs) {
@@ -49,6 +51,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
 
             var lhs = node.Target.RemoveParenthesis();
 
+            // This is fine, as named expression targets are not allowed to be anything but simple names.
             var value = ExtractRhs(node.Value, lhs);
             if (value != null) {
                 AssignToExpr(lhs, value);

--- a/src/Analysis/Ast/Impl/Utilities/ValueEnumerator.cs
+++ b/src/Analysis/Ast/Impl/Utilities/ValueEnumerator.cs
@@ -1,13 +1,32 @@
-﻿using System.Linq;
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Linq;
 using Microsoft.Python.Analysis.Specializations.Typing;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.Collections;
 
 namespace Microsoft.Python.Analysis.Utilities {
     internal sealed class ValueEnumerator {
         private readonly IMember _value;
         private readonly IPythonType _unknown;
-        private readonly IMember[] _values;
+        private readonly IPythonModule _declaringModule;
+        private readonly ImmutableArray<IMember> _values;
+        private readonly ImmutableArray<ValueEnumerator> _nested;
         private int _index;
 
         /// <summary>
@@ -15,36 +34,50 @@ namespace Microsoft.Python.Analysis.Utilities {
         /// </summary>
         /// <param name="value">Collection to iterate over</param>
         /// <param name="unknown">Default type when we cannot find type from collection</param>
-        public ValueEnumerator(IMember value, IPythonType unknown) {
+        public ValueEnumerator(IMember value, IPythonType unknown, IPythonModule declaringModule) {
             _value = value;
             _unknown = unknown;
+            _declaringModule = declaringModule;
+
+            if (value.GetPythonType() is IPythonUnionType union) {
+                _nested = union.Select(v => new ValueEnumerator(v.CreateInstance(ArgumentSet.WithoutContext), unknown, declaringModule)).ToImmutableArray();
+                return;
+            }
+
             switch (value) {
                 // Tuple = 'tuple value' (such as from callable). Transfer values.
                 case IPythonCollection seq:
-                    _values = seq.Contents.ToArray();
+                    _values = seq.Contents.ToImmutableArray();
                     break;
                 // Create singleton list of value when cannot identify tuple
                 default:
-                    _values = new[] { value };
+                    _values = ImmutableArray<IMember>.Create(value);
                     break;
             }
         }
 
-        public IMember Next {
-            get {
-                IMember t = Peek;
-                _index++;
-                return t;
+        public IMember Next() {
+            IMember t = Peek;
+            _index++;
+
+            foreach (var ve in _nested) {
+                ve.Next();
             }
+
+            return t;
         }
 
         public IMember Peek {
             get {
-                if (_values.Length > 0) {
-                    return _index < _values.Length ? _values[_index] : _values[_values.Length - 1];
-                } else {
-                    return Filler.CreateInstance(ArgumentSet.WithoutContext);
+                if (_nested.Count > 0) {
+                    return new PythonUnionType(_nested.Select(ve => ve.Peek.GetPythonType()), _declaringModule).CreateInstance(ArgumentSet.WithoutContext);
                 }
+
+                if (_values.Count > 0) {
+                    return _index < _values.Count ? _values[_index] : _values[_values.Count - 1];
+                }
+
+                return Filler.CreateInstance(ArgumentSet.WithoutContext);
             }
         }
 

--- a/src/Analysis/Ast/Test/TypingTests.cs
+++ b/src/Analysis/Ast/Test/TypingTests.cs
@@ -343,6 +343,39 @@ x: Tuple[None, None, None]
         }
 
         [TestMethod, Priority(0)]
+        public async Task UnionOfTuples() {
+            const string code = @"
+from typing import Union, Tuple, Type
+
+class TracebackType: ...
+
+_ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
+_OptExcInfo = Union[_ExcInfo, Tuple[None, None, None]]
+
+x: _ExcInfo
+y: _OptExcInfo
+
+a, b, c = y
+";
+            var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
+
+            analysis.Should().HaveVariable("x")
+                .Which.Should().HaveType("Tuple[Type[BaseException], BaseException, TracebackType]");
+
+            analysis.Should().HaveVariable("y")
+                .Which.Should().HaveType("Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]");
+
+            analysis.Should().HaveVariable("a")
+                .Which.Should().HaveType("Union[Type[BaseException], None]");
+
+            analysis.Should().HaveVariable("b")
+                .Which.Should().HaveType("Union[BaseException, None]");
+
+            analysis.Should().HaveVariable("c")
+                .Which.Should().HaveType("Union[TracebackType, None]");
+        }
+
+        [TestMethod, Priority(0)]
         public void AnnotationParsing() {
             AssertTransform("List", "NameOp:List");
             AssertTransform("List[Int]", "NameOp:List", "NameOp:Int", "MakeGenericOp");


### PR DESCRIPTION
Fixes #1622.

If we're trying to unpack a union, store a ValueEnumerator per union item, then produce unions as items from each of the nested enumerators.

Note that since the unions are of types and are not values, we need to do some extra work to shift back and forth between types and instances where needed.

Also:

- Replace the `Next` property with a method, since it has side effects.
- Replace a comment I added in a previous PR with a new one explaining what's _actually_ happening.
- Use ImmutableArray in ValueEnumerator (the default works better).