### PR TITLE
Avoid breaking the op stack when an unknown constant value is found

### DIFF
--- a/src/Analysis/Ast/Test/FunctionTests.cs
+++ b/src/Analysis/Ast/Test/FunctionTests.cs
@@ -669,5 +669,19 @@ def f(a, b, /, c, d):
                     .Which.Should().HaveSingleOverload()
                     .Which.Should().HaveParameters("a", "b", "c", "d");
         }
+
+        [TestMethod, Priority(0)]
+        public async Task LiteralParameter() {
+            const string code = @"
+from typing import Literal
+
+def f(handle: int, overlapped: Literal[True]):
+    pass
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Should().HaveFunction("f")
+                    .Which.Should().HaveSingleOverload()
+                    .Which.Should().HaveParameters("handle", "overlapped");
+        }
     }
 }

--- a/src/Parsing/Impl/Ast/TypeAnnotation.cs
+++ b/src/Parsing/Impl/Ast/TypeAnnotation.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Python.Parsing.Ast {
 
             class MakeUnknownOp : Op {
                 public override bool Apply<T>(TypeAnnotationConverter<T> converter, Stack<KeyValuePair<string, T>> stack) {
-                    stack.Push(new KeyValuePair<string, T>("Unknown", default));
+                    stack.Push(new KeyValuePair<string, T>(null, default));
                     return true;
                 }
             }

--- a/src/Parsing/Impl/Ast/TypeAnnotation.cs
+++ b/src/Parsing/Impl/Ast/TypeAnnotation.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Python.Parsing.Ast {
             }
 
             public override bool Walk(ConstantExpression node) {
+                // TODO: Do not perform recursive string parsing.
                 switch (node.Value) {
                     case string s:
                         _parse(s)?.Walk(this);
@@ -90,6 +91,9 @@ namespace Microsoft.Python.Parsing.Ast {
                         break;
                     case null:
                         _ops.Add(new NameOp { Name = "None" });
+                        break;
+                    default:
+                        _ops.Add(new MakeUnknownOp());
                         break;
                 }
 
@@ -274,6 +278,13 @@ namespace Microsoft.Python.Parsing.Ast {
                         return false;
                     }
                     stack.Push(t);
+                    return true;
+                }
+            }
+
+            class MakeUnknownOp : Op {
+                public override bool Apply<T>(TypeAnnotationConverter<T> converter, Stack<KeyValuePair<string, T>> stack) {
+                    stack.Push(new KeyValuePair<string, T>("Unknown", default));
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes #1640.

This is sort of a red herring, since the exception will actually be caught then the entire annotation converted to `default`, but explicitly pushing something onto the op stack when an unknown constant value is seen is better than destroying the entire annotation parse.