### PR TITLE
Use an infinite timeout when debugger is attached

### DIFF
--- a/src/Analysis/Ast/Test/AnalysisTestBase.cs
+++ b/src/Analysis/Ast/Test/AnalysisTestBase.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Python.Analysis.Tests {
     public abstract class AnalysisTestBase {
         protected TimeSpan AnalysisTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
+        private TimeSpan GetAnalysisTimeout() => Debugger.IsAttached ? Timeout.InfiniteTimeSpan : AnalysisTimeout;
+
         protected TestLogger TestLogger { get; } = new TestLogger();
         protected ServiceManager Services { get; private set; }
 
@@ -156,7 +158,7 @@ namespace Microsoft.Python.Analysis.Tests {
             TestLogger.Log(TraceEventType.Information, "Test: Analysis begin.");
 
             IDocumentAnalysis analysis;
-            using (var cts = new CancellationTokenSource(AnalysisTimeout)) {
+            using (var cts = new CancellationTokenSource(GetAnalysisTimeout())) {
                 await services.GetService<IPythonAnalyzer>().WaitForCompleteAnalysisAsync(cts.Token);
                 analysis = await doc.GetAnalysisAsync(-1, cts.Token);
             }
@@ -169,7 +171,7 @@ namespace Microsoft.Python.Analysis.Tests {
 
         protected async Task<IDocumentAnalysis> GetDocumentAnalysisAsync(IDocument document) {
             var analyzer = Services.GetService<IPythonAnalyzer>();
-            using (var cts = new CancellationTokenSource(AnalysisTimeout)) {
+            using (var cts = new CancellationTokenSource(GetAnalysisTimeout())) {
                 await analyzer.WaitForCompleteAnalysisAsync(cts.Token);
                 return await document.GetAnalysisAsync(Timeout.Infinite, cts.Token);
             }


### PR DESCRIPTION
With the old timeout, sessions over a minute would fall apart as things would start getting cancelled.