### PR TITLE
Remove get_search_path.py's path from the search paths it returns

### DIFF
--- a/src/Analysis/Ast/Impl/get_search_paths.py
+++ b/src/Analysis/Ast/Impl/get_search_paths.py
@@ -44,6 +44,7 @@ def clean(path):
 
 BEFORE_SITE = set(clean(p) for p in BEFORE_SITE)
 AFTER_SITE = set(clean(p) for p in AFTER_SITE)
+SCRIPT_DIR = clean(os.path.dirname(os.path.realpath(__file__)))
 
 try:
     SITE_PKGS = set(clean(p) for p in site.getsitepackages())
@@ -72,9 +73,12 @@ import zipfile
 
 for p in sys.path:
     p = clean(p)
+    
+    if p == SCRIPT_DIR or p.startswith(SCRIPT_DIR + os.sep):
+        continue
 
     if not os.path.isdir(p) and not (os.path.isfile(p) and zipfile.is_zipfile(p)):
-	    continue
+        continue
 
     if p in BEFORE_SITE:
         print("%s|stdlib|" % p)

--- a/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
+++ b/src/Analysis/Core/Impl/Interpreter/PythonLibraryPath.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Python.Analysis.Core.Interpreter {
 
             var output = await ps.ExecuteAndCaptureOutputAsync(startInfo, cancellationToken);
             return output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
-                .Skip(1).Select(s => {
+                .Select(s => {
                     try {
                         return Parse(s);
                     } catch (ArgumentException) {


### PR DESCRIPTION
Fixes #1676.

Make `get_search_paths.py` remove subpaths of its own directory from the returned paths.

Only question I would have is if `clean` should also be doing `os.path.realpath` to resolve symlinks (i.e. what if the language server's directory is symlinked somewhere up the chain).