### PR TITLE
reporting unused imports

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         /// <summary>
         /// Runs linters on the modules
         /// </summary>
-        IReadOnlyList<DiagnosticsEntry> LintModule(IPythonModule module);
+        IReadOnlyList<DiagnosticsEntry> LintModule(IPythonModule module, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes all the modules from the analysis and restarts it, including stubs.

--- a/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Definitions/IPythonAnalyzer.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Python.Analysis.Analyzer {
         /// </summary>
         IReadOnlyList<DiagnosticsEntry> LintModule(IPythonModule module);
 
-
         /// <summary>
         /// Removes all the modules from the analysis and restarts it, including stubs.
         /// </summary>

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -163,18 +163,12 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
         }
 
-        public IReadOnlyList<DiagnosticsEntry> LintModule(IPythonModule module) {
+        public IReadOnlyList<DiagnosticsEntry> LintModule(IPythonModule module, CancellationToken cancellationToken = default) {
             if (module.ModuleType != ModuleType.User) {
                 return Array.Empty<DiagnosticsEntry>();
             }
 
-            // Linter always runs no matter of the option since it looks up variables
-            // which also enumerates and updates variable references for find all
-            // references and rename operations.
-            var result = new LinterAggregator().Lint(module, _services);
-
-            var optionsProvider = _services.GetService<IAnalysisOptionsProvider>();
-            return optionsProvider?.Options?.LintingEnabled == false ? Array.Empty<DiagnosticsEntry>() : result;
+            return new LinterAggregator().Lint(module, _services, cancellationToken);
         }
 
         public async Task ResetAnalyzer() {

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
                 entry.TrySetAnalysis(analysis, version);
 
                 if (module.ModuleType == ModuleType.User) {
-                    var linterDiagnostics = _analyzer.LintModule(module);
+                    var linterDiagnostics = _analyzer.LintModule(module, _analyzerCancellationToken);
                     _diagnosticsService?.Replace(entry.Module.Uri, linterDiagnostics, DiagnosticSource.Linter);
                 }
             }

--- a/src/Analysis/Ast/Impl/Diagnostics/DiagnosticsEntry.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/DiagnosticsEntry.cs
@@ -13,6 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
@@ -21,12 +22,18 @@ using Microsoft.Python.Parsing;
 
 namespace Microsoft.Python.Analysis.Diagnostics {
     public sealed class DiagnosticsEntry {
-        public DiagnosticsEntry(string message, SourceSpan span, string errorCode, Severity severity, DiagnosticSource source) {
+        public DiagnosticsEntry(string message,
+                                SourceSpan span,
+                                string errorCode,
+                                Severity severity,
+                                DiagnosticSource source,
+                                DiagnosticTags[] tags = null) {
             Message = message;
             SourceSpan = span;
             ErrorCode = errorCode;
             Severity = severity;
             Source = source;
+            Tags = tags ?? Array.Empty<DiagnosticTags>();
         }
 
         /// <summary>
@@ -54,6 +61,8 @@ namespace Microsoft.Python.Analysis.Diagnostics {
         /// </summary>
         public DiagnosticSource Source { get; }
 
+        public DiagnosticTags[] Tags { get; }
+
         public bool ShouldReport(IPythonModule module) {
             // Only report for user written modules
             if (module.ModuleType != ModuleType.User) {
@@ -72,8 +81,28 @@ namespace Microsoft.Python.Analysis.Diagnostics {
             if (!(obj is DiagnosticsEntry e)) {
                 return false;
             }
+            
+            // for now, we ignore tags equality since we don't want to show duplicated errors
+            // just because tags are different
             return ErrorCode == e.ErrorCode && SourceSpan == e.SourceSpan;
         }
         public override int GetHashCode() => 0;
+
+        public enum DiagnosticTags {
+            /// <summary>
+            /// Unused or unnecessary code.
+            /// 
+            /// Clients are allowed to render diagnostics with this tag faded out instead of having
+            /// an error squiggle.
+            /// </summary>
+            Unnecessary = 1,
+
+            /// <summary>
+            /// Deprecated or obsolete code.
+            ///
+            /// Clients are allowed to rendered diagnostics with this tag strike through.
+            /// </summary>
+            Deprecated = 2
+        }
     }
 }

--- a/src/Analysis/Ast/Impl/Diagnostics/DiagnosticsEntry.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/DiagnosticsEntry.cs
@@ -63,6 +63,10 @@ namespace Microsoft.Python.Analysis.Diagnostics {
 
         public DiagnosticTags[] Tags { get; }
 
+        public DiagnosticsEntry WithSeverity(Severity severity) {
+            return new DiagnosticsEntry(Message, SourceSpan, ErrorCode, severity, Source, Tags);
+        }
+
         public bool ShouldReport(IPythonModule module) {
             // Only report for user written modules
             if (module.ModuleType != ModuleType.User) {
@@ -81,7 +85,7 @@ namespace Microsoft.Python.Analysis.Diagnostics {
             if (!(obj is DiagnosticsEntry e)) {
                 return false;
             }
-            
+
             // for now, we ignore tags equality since we don't want to show duplicated errors
             // just because tags are different
             return ErrorCode == e.ErrorCode && SourceSpan == e.SourceSpan;

--- a/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
+++ b/src/Analysis/Ast/Impl/Diagnostics/ErrorCodes.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Python.Analysis.Diagnostics {
         public const string TypingTypeVarArguments = "typing-typevar-arguments";
         public const string UnknownParameterName = "unknown-parameter-name";
         public const string UnresolvedImport = "unresolved-import";
+        public const string UnusedImport = "unused-import";
         public const string UndefinedVariable = "undefined-variable";
         public const string VariableNotDefinedGlobally= "variable-not-defined-globally";
         public const string VariableNotDefinedNonLocal = "variable-not-defined-nonlocal";

--- a/src/Analysis/Ast/Impl/Extensions/ScopeExtensions.cs
+++ b/src/Analysis/Ast/Impl/Extensions/ScopeExtensions.cs
@@ -13,6 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Analysis.Types;
@@ -115,6 +116,24 @@ namespace Microsoft.Python.Analysis.Analyzer {
             }
 
             return child;
+        }
+
+        /// <summary>
+        /// this returns __all__ contents we understood.
+        /// this is different than StartImportMemberNames since that only returns results when
+        /// all entries are known. this returns whatever we understood even if there are 
+        /// ones we couldn't understand in __all__
+        /// </summary>
+        public static IEnumerable<string> GetAllVariablesBestEffort(this IScope scope) {
+            if (scope.Variables.TryGetVariable("__all__", out var variable) &&
+                variable?.Value is IPythonCollection collection) {
+                return collection.Contents
+                    .OfType<IPythonConstant>()
+                    .Select(c => c.GetString())
+                    .Where(s => !string.IsNullOrEmpty(s));
+            }
+
+            return Enumerable.Empty<string>();
         }
 
         private static int GetLineIndent(IDocument document, int index, out bool lineIsEmpty) {

--- a/src/Analysis/Ast/Impl/Linting/ILinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/ILinter.cs
@@ -14,11 +14,12 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Core;
 
 namespace Microsoft.Python.Analysis.Linting {
     public interface ILinter {
-        IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services);
+        IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services, CancellationToken cancellationToken);
     }
 }

--- a/src/Analysis/Ast/Impl/Linting/LinterAggregator.cs
+++ b/src/Analysis/Ast/Impl/Linting/LinterAggregator.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Python.Analysis.Linting {
         public LinterAggregator() {
             // TODO: develop mechanism for dynamic and external linter discovery.
             _linters.Add(new UndefinedVariablesLinter());
+            _linters.Add(new UnusedImportsLinter());
         }
+
+        // * NOTE * linter is not cancellable? is this by design?
         public IReadOnlyList<DiagnosticsEntry> Lint(IPythonModule module, IServiceContainer services)
             => _linters.SelectMany(l => l.Lint(module.Analysis, services)).Where(d => d.ShouldReport(module)).ToArray();
     }

--- a/src/Analysis/Ast/Impl/Linting/UndefinedVariables/UndefinedVariablesLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UndefinedVariables/UndefinedVariablesLinter.cs
@@ -14,12 +14,15 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Core;
 
 namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
     internal sealed class UndefinedVariablesLinter : ILinter {
-        public IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services) {
+        public IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services, CancellationToken cancellationToken) {
+            // this linter is special and we never cancel this linter. this will always run as the first linter in the aggregator and this will
+            // set references in the analyzed module as it runs
             var w = new UndefinedVariablesWalker(analysis, services);
             analysis.Ast.Walk(w);
             return w.Diagnostics;

--- a/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
                 // we have variable from import statement, but we don't have any variable declared from actual
                 // usage. meaning the import is not used.
                 if (!variableDeclared.TryGetVariable(name, out var variableFromVariableCollection)) {
-                    AppendDiagnostic(variableFromImportCollection, ref result);
+                    ReportUnusedImports(variableFromImportCollection, ref result);
                     continue;
                 }
 
@@ -57,14 +57,15 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
                     continue;
                 }
 
-                AppendDiagnostic(variableFromImportCollection, ref result);
+                ReportUnusedImports(variableFromImportCollection, ref result);
             }
 
             return result;
         }
 
-        private static void AppendDiagnostic(IVariable variable, ref ImmutableArray<DiagnosticsEntry> result) {
-            result = result.Add(new DiagnosticsEntry("unused imports", variable.Definition.Span, "unused imports", Parsing.Severity.Hint, DiagnosticSource.Linter));
+        private static void ReportUnusedImports(IVariable variable, ref ImmutableArray<DiagnosticsEntry> result) {
+            var message = Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatInvariant(variable.Value.MemberType, variable.Name);
+            result = result.Add(new DiagnosticsEntry(message, variable.Definition.Span, ErrorCodes.UnusedImport, Parsing.Severity.Hint, DiagnosticSource.Linter));
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
@@ -27,6 +28,7 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
             var result = ImmutableArray<DiagnosticsEntry>.Empty;
 
             var imported = analysis.GlobalScope.Imported;
+            var allVariables = new HashSet<string>(analysis.GlobalScope.GetAllVariablesBestEffort());
 
             // * NOTE * variable declared in imported is different than same variable referenced in the code.
             //          that is because that variable is re-declared in another variable collection
@@ -35,6 +37,11 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
             var variableDeclared = analysis.GlobalScope.Variables;
             foreach (var name in imported.Names) {
                 if (!imported.TryGetVariable(name, out var variableFromImportCollection)) {
+                    continue;
+                }
+
+                // name appeared in __all__ in considered used.
+                if (allVariables.Contains(name)) {
                     continue;
                 }
 

--- a/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
@@ -13,20 +13,23 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.Python.Analysis.Analyzer;
+using Microsoft.Python.Analysis.Analyzer.Expressions;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Analysis.Values;
 using Microsoft.Python.Core;
+using Microsoft.Python.Core.Text;
+using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
     internal sealed class UnusedImportsLinter : ILinter {
-        private readonly static DiagnosticsEntry.DiagnosticTags[] tags = new[] { DiagnosticsEntry.DiagnosticTags.Unnecessary };
-
         public IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services) {
-            var results = new List<DiagnosticsEntry>();
+            var results = new List<Info>();
 
             var imported = analysis.GlobalScope.Imported;
             var allVariables = new HashSet<string>(analysis.GlobalScope.GetAllVariablesBestEffort());
@@ -49,7 +52,7 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
                 // we have variable from import statement, but we don't have any variable declared from actual
                 // usage. meaning the import is not used.
                 if (!variableDeclared.TryGetVariable(name, out var variableFromVariableCollection)) {
-                    ReportUnusedImports(variableFromImportCollection, results);
+                    ReportUnusedImports(variableFromImportCollection, results, CancellationToken.None);
                     continue;
                 }
 
@@ -65,21 +68,170 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
                     continue;
                 }
 
-                ReportUnusedImports(variableFromImportCollection, results);
+                ReportUnusedImports(variableFromImportCollection, results, CancellationToken.None);
+            }
+
+            return CreateDiagnostics(results);
+        }
+
+        private IReadOnlyList<DiagnosticsEntry> CreateDiagnostics(List<Info> info) {
+            if (info.Count == 0) {
+                return Array.Empty<DiagnosticsEntry>();
+            }
+
+            var results = new List<DiagnosticsEntry>();
+            var groupByImportStatement = info.GroupBy(i => i.ImportStatement);
+
+            foreach (var imports in groupByImportStatement) {
+                if (ShouldMerge(imports)) {
+                    results.Add(Info.ToDiagnostic(imports));
+                } else {
+                    foreach (var import in imports) {
+                        results.Add(import.ToDiagnostic());
+                    }
+                }
             }
 
             return results;
         }
 
-        private static void ReportUnusedImports(IVariable variable, List<DiagnosticsEntry> results) {
-            var message = Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatUI(variable.Value.MemberType, variable.Name);
-            results.Add(new DiagnosticsEntry(
-                message,
-                variable.Definition.Span,
-                ErrorCodes.UnusedImport,
-                Parsing.Severity.Hint,
-                DiagnosticSource.Linter,
-                tags));
+        private bool ShouldMerge(IGrouping<Statement, Info> imports) {
+            var first = imports.First();
+
+            if (imports.Count() == 1) {
+                if (first.ImportStatement == null) {
+                    // can't determine whether we need to merge or not
+                    return false;
+                }
+
+                var names = GetNames(first.ImportStatement);
+                return names.Count() == 1;
+            }
+
+            return false;
+        }
+
+        private static void ReportUnusedImports(IVariable variable, List<Info> results, CancellationToken cancellationToken) {
+            var (span, ast, import) = GetDiagnosticSpan(variable, cancellationToken);
+
+            results.Add(new Info(
+                variable.Value.MemberType,
+                variable.Name,
+                span,
+                ast,
+                import));
+        }
+
+        private static IEnumerable<(IndexSpan?, IndexSpan?)> GetNames(Statement statement) {
+            switch (statement) {
+                case ImportStatement import:
+                    return import.Names.Select(n => n?.IndexSpan).Zip(import.AsNames.Select(n => n?.IndexSpan), (i, i2) => (i, i2));
+                case FromImportStatement fromImport:
+                    return fromImport.Names.Select(n => n?.IndexSpan).Zip(fromImport.AsNames.Select(n => n?.IndexSpan), (i, i2) => (i, i2));
+                default:
+                    throw new InvalidOperationException($"unexpected statement: {statement}");
+            }
+        }
+
+        private static (SourceSpan, PythonAst, Statement) GetDiagnosticSpan(IVariable variable, CancellationToken cancellationToken) {
+            // use some heuristic on where to show diagnostics
+            var definitionSpan = variable.Definition.Span;
+            var ast = variable.Location.Module.Analysis.Ast ?? variable.Location.Module.GetAst();
+            if (ast == null) {
+                return (definitionSpan, null, null);
+            }
+
+            // see whether import statement contains just 1 symbol or multiple one
+            var finder = new ExpressionFinder(ast, new FindExpressionOptions() { ImportNames = true, ImportAsNames = true, Names = true });
+            var identifier = finder.GetExpression(definitionSpan);
+            if (identifier == null) {
+                return (definitionSpan, ast, null);
+            }
+
+            var statement = GetAncestorsOrThis(ast.Body, identifier, cancellationToken).FirstOrDefault(c => c is ImportStatement || c is FromImportStatement) as Statement;
+            switch (statement) {
+                case ImportStatement _:
+                case FromImportStatement _:
+                    return (definitionSpan, ast, statement);
+                default:
+                    return (definitionSpan, ast, null);
+            }
+        }
+
+        private static List<Node> GetAncestorsOrThis(Node root, Node node, CancellationToken cancellationToken) {
+            var parentChain = new List<Node>();
+
+            // there seems no way to go up the parent chain. always has to go down from the top
+            while (root != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var temp = root;
+                root = null;
+
+                // this assumes node is not overlapped and children are ordered from left to right
+                // in textual position
+                foreach (var current in temp.GetChildNodes()) {
+                    if (!current.IndexSpan.Contains(node.IndexSpan)) {
+                        continue;
+                    }
+
+                    parentChain.Add(current);
+                    root = current;
+                    break;
+                }
+            }
+
+            return parentChain;
+        }
+
+        private struct Info {
+            private readonly static DiagnosticsEntry.DiagnosticTags[] Tags = new[] { DiagnosticsEntry.DiagnosticTags.Unnecessary };
+
+            public readonly PythonMemberType Type;
+            public readonly string Name;
+            public readonly SourceSpan Span;
+            public readonly PythonAst Ast;
+            public readonly Statement ImportStatement;
+
+            public Info(PythonMemberType type, string name, SourceSpan span, PythonAst ast, Statement importStatement) {
+                Type = type;
+                Name = name;
+                Span = span;
+                Ast = ast;
+                ImportStatement = importStatement;
+            }
+
+            public DiagnosticsEntry ToDiagnostic() {
+                return ToDiagnostic(Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatUI(Type, Name), Span);
+            }
+
+            public static DiagnosticsEntry ToDiagnostic(IEnumerable<Info> info) {
+                var first = info.First();
+
+                if (info.Count() == 1) {
+                    return ToDiagnostic(
+                        Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatUI(first.Type, first.Name),
+                        first.ImportStatement.GetSpan(first.Ast));
+                }
+
+                return new DiagnosticsEntry(
+                    Resources._0_1_are_declared_but_they_are_never_used_within_the_current_file.FormatUI(first.Type, first.Name),
+                    first.ImportStatement.GetSpan(first.Ast),
+                    ErrorCodes.UnusedImport,
+                    Parsing.Severity.Hint,
+                    DiagnosticSource.Linter,
+                    Tags);
+            }
+
+            private static DiagnosticsEntry ToDiagnostic(string message, SourceSpan span) {
+                return new DiagnosticsEntry(
+                    message,
+                    span,
+                    ErrorCodes.UnusedImport,
+                    Parsing.Severity.Hint,
+                    DiagnosticSource.Linter,
+                    Tags);
+            }
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
         }
 
         private static void ReportUnusedImports(IVariable variable, ref ImmutableArray<DiagnosticsEntry> result) {
-            var message = Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatInvariant(variable.Value.MemberType, variable.Name);
+            var message = Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatUI(variable.Value.MemberType, variable.Name);
             result = result.Add(new DiagnosticsEntry(message, variable.Definition.Span, ErrorCodes.UnusedImport, Parsing.Severity.Hint, DiagnosticSource.Linter));
         }
     }

--- a/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
@@ -1,0 +1,70 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Python.Analysis.Diagnostics;
+using Microsoft.Python.Analysis.Types;
+using Microsoft.Python.Analysis.Values;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.Collections;
+
+namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
+    internal sealed class UnusedImportsLinter : ILinter {
+        public IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services) {
+            var result = ImmutableArray<DiagnosticsEntry>.Empty;
+
+            var imported = analysis.GlobalScope.Imported;
+
+            // * NOTE * variable declared in imported is different than same variable referenced in the code.
+            //          that is because that variable is re-declared in another variable collection
+            //          not sure whether it is a bug or intentional behavior. might be intentional to distinguish
+            //          same name used for 2 different varialbes. need to check
+            var variableDeclared = analysis.GlobalScope.Variables;
+            foreach (var name in imported.Names) {
+                if (!imported.TryGetVariable(name, out var variableFromImportCollection)) {
+                    continue;
+                }
+
+                // we have variable from import statement, but we don't have any variable declared from actual
+                // usage. meaning the import is not used.
+                if (!variableDeclared.TryGetVariable(name, out var variableFromVariableCollection)) {
+                    AppendDiagnostic(variableFromImportCollection, ref result);
+                    continue;
+                }
+
+                // * NOTE * this seems won't work if variable with same name declared multiple times?
+                if (!LocationInfo.FullComparer.Equals(variableFromVariableCollection.Definition, variableFromImportCollection.Definition)) {
+                    continue;
+                }
+
+                // find any reference in current file which is not the import variable definition itself
+                // we need to use one from variable declared collection since FAR info is only there
+                if (variableFromVariableCollection.References.Any(r => r.DocumentUri == variableFromImportCollection.Definition.DocumentUri &&
+                                                                       r.Span != variableFromImportCollection.Definition.Span)) {
+                    continue;
+                }
+
+                AppendDiagnostic(variableFromImportCollection, ref result);
+            }
+
+            return result;
+        }
+
+        private static void AppendDiagnostic(IVariable variable, ref ImmutableArray<DiagnosticsEntry> result) {
+            result = result.Add(new DiagnosticsEntry("unused imports", variable.Definition.Span, "unused imports", Parsing.Severity.Hint, DiagnosticSource.Linter));
+        }
+    }
+}

--- a/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
+++ b/src/Analysis/Ast/Impl/Linting/UnusedImports/UnusedImportsLinter.cs
@@ -24,6 +24,8 @@ using Microsoft.Python.Core.Collections;
 
 namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
     internal sealed class UnusedImportsLinter : ILinter {
+        private readonly static DiagnosticsEntry.DiagnosticTags[] tags = new[] { DiagnosticsEntry.DiagnosticTags.Unnecessary };
+
         public IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, IServiceContainer services) {
             var result = ImmutableArray<DiagnosticsEntry>.Empty;
 
@@ -72,7 +74,13 @@ namespace Microsoft.Python.Analysis.Linting.UndefinedVariables {
 
         private static void ReportUnusedImports(IVariable variable, ref ImmutableArray<DiagnosticsEntry> result) {
             var message = Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file.FormatUI(variable.Value.MemberType, variable.Name);
-            result = result.Add(new DiagnosticsEntry(message, variable.Definition.Span, ErrorCodes.UnusedImport, Parsing.Severity.Hint, DiagnosticSource.Linter));
+            result = result.Add(new DiagnosticsEntry(
+                message,
+                variable.Definition.Span,
+                ErrorCodes.UnusedImport,
+                Parsing.Severity.Hint,
+                DiagnosticSource.Linter,
+                tags));
         }
     }
 }

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0} {1}&apos; is declared but it&apos;s never used within the current file..
+        /// </summary>
+        internal static string _0_1_is_declared_but_it_is_never_used_within_the_current_file {
+            get {
+                return ResourceManager.GetString("0_1_is_declared_but_it_is_never_used_within_the_current_file", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parameter {0} already specified..
         /// </summary>
         internal static string Analysis_ParameterAlreadySpecified {

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -61,7 +61,16 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0} {1}&apos; is declared but it&apos;s never used within the current file..
+        ///   Looks up a localized string similar to &apos;{0} {1} and more&apos; are declared but they are never used within the current file..
+        /// </summary>
+        internal static string _0_1_are_declared_but_they_are_never_used_within_the_current_file {
+            get {
+                return ResourceManager.GetString("0_1_are_declared_but_they_are_never_used_within_the_current_file", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0} {1}&apos; is declared but it is never used within the current file..
         /// </summary>
         internal static string _0_1_is_declared_but_it_is_never_used_within_the_current_file {
             get {

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -223,6 +223,9 @@
     <value>Positional only argument '{0}' may not be named.</value>
   </data>
   <data name="0_1_is_declared_but_it_is_never_used_within_the_current_file" xml:space="preserve">
-    <value>'{0} {1}' is declared but it's never used within the current file.</value>
+    <value>'{0} {1}' is declared but it is never used within the current file.</value>
+  </data>
+  <data name="0_1_are_declared_but_they_are_never_used_within_the_current_file" xml:space="preserve">
+    <value>'{0} {1} and more' are declared but they are never used within the current file.</value>
   </data>
 </root>

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -222,4 +222,7 @@
   <data name="Analysis_PositionalOnlyArgumentNamed" xml:space="preserve">
     <value>Positional only argument '{0}' may not be named.</value>
   </data>
+  <data name="0_1_is_declared_but_it_is_never_used_within_the_current_file" xml:space="preserve">
+    <value>'{0} {1}' is declared but it's never used within the current file.</value>
+  </data>
 </root>

--- a/src/Analysis/Ast/Test/LintUndefinedVarsTests.cs
+++ b/src/Analysis/Ast/Test/LintUndefinedVarsTests.cs
@@ -14,6 +14,7 @@
 // permissions and limitations under the License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Analysis.Analyzer;
@@ -28,6 +29,13 @@ using ErrorCodes = Microsoft.Python.Analysis.Diagnostics.ErrorCodes;
 namespace Microsoft.Python.Analysis.Tests {
     [TestClass]
     public class LintUndefinedVarsTests : AnalysisTestBase {
+        private readonly static HashSet<string> UndefinedVarsErrorCodes =
+            new HashSet<string>() {
+                ErrorCodes.UndefinedVariable,
+                ErrorCodes.VariableNotDefinedGlobally,
+                ErrorCodes.VariableNotDefinedNonLocal,
+            };
+
         public TestContext TestContext { get; set; }
 
         [TestInitialize]
@@ -674,8 +682,8 @@ class Test:
 with Test() as (test, test1):
     pass
 ";
-            var d = await LintAsync(code);
-            d.Should().BeEmpty();
+            var ds = await LintAsync(code);
+            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -693,8 +701,8 @@ class Test:
 with Test() as (test, test1):
     pass
 ";
-            var d = await LintAsync(code);
-            d.Should().BeEmpty();
+            var ds = await LintAsync(code);
+            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -733,8 +741,8 @@ class Test:
 with Test() as (a):
     pass
 ";
-            var d = await LintAsync(code);
-            d.Should().BeEmpty();
+            var ds = await LintAsync(code);
+            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -753,8 +761,8 @@ class Test:
 with Test() as [a]:
     pass
 ";
-            var d = await LintAsync(code);
-            d.Should().BeEmpty();
+            var ds = await LintAsync(code);
+            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -787,8 +795,8 @@ stuff = []
 from thismoduledoesnotexist import something
 something()
 ";
-            var d = await LintAsync(code);
-            d.Should().BeEmpty();
+            var ds = await LintAsync(code);
+            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
         }
 
         private async Task<IReadOnlyList<DiagnosticsEntry>> LintAsync(string code, InterpreterConfiguration configuration = null) {

--- a/src/Analysis/Ast/Test/LintUndefinedVarsTests.cs
+++ b/src/Analysis/Ast/Test/LintUndefinedVarsTests.cs
@@ -683,7 +683,7 @@ with Test() as (test, test1):
     pass
 ";
             var ds = await LintAsync(code);
-            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
+            ds.Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -701,8 +701,8 @@ class Test:
 with Test() as (test, test1):
     pass
 ";
-            var ds = await LintAsync(code);
-            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
+            var d = await LintAsync(code);
+            d.Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -741,8 +741,8 @@ class Test:
 with Test() as (a):
     pass
 ";
-            var ds = await LintAsync(code);
-            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
+            var d = await LintAsync(code);
+            d.Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -761,8 +761,8 @@ class Test:
 with Test() as [a]:
     pass
 ";
-            var ds = await LintAsync(code);
-            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
+            var d = await LintAsync(code);
+            d.Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]
@@ -795,14 +795,14 @@ stuff = []
 from thismoduledoesnotexist import something
 something()
 ";
-            var ds = await LintAsync(code);
-            ds.Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).Should().BeEmpty();
+            var d = await LintAsync(code);
+            d.Should().BeEmpty();
         }
 
         private async Task<IReadOnlyList<DiagnosticsEntry>> LintAsync(string code, InterpreterConfiguration configuration = null) {
             var analysis = await GetAnalysisAsync(code, configuration ?? PythonVersions.LatestAvailable3X);
             var a = Services.GetService<IPythonAnalyzer>();
-            return a.LintModule(analysis.Document);
+            return a.LintModule(analysis.Document).Where(d => UndefinedVarsErrorCodes.Contains(d.ErrorCode)).ToList();
         }
 
         private class AnalysisOptionsProvider : IAnalysisOptionsProvider {

--- a/src/Analysis/Ast/Test/LintUnusedImportTests.cs
+++ b/src/Analysis/Ast/Test/LintUnusedImportTests.cs
@@ -222,8 +222,8 @@ p = path.join('', '')", PythonMemberType.Module, "os", multiple: false);
         [TestMethod, Priority(0)]
         public async Task MultipleImports2() {
             await TestAsync(@"{|diagnostic:import os|}
-{|diagnostic:import math|}", 
-                (PythonMemberType.Module, "os", multiple: false), 
+{|diagnostic:import math|}",
+                (PythonMemberType.Module, "os", multiple: false),
                 (PythonMemberType.Module, "math", multiple: false));
         }
 
@@ -233,6 +233,48 @@ p = path.join('', '')", PythonMemberType.Module, "os", multiple: false);
 {|diagnostic:import os.path|}",
                 (PythonMemberType.Module, "os", multiple: false),
                 (PythonMemberType.Module, "os", multiple: false));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports4() {
+            await TestAsync(@"{|diagnostic:import os as o|}
+import {|diagnostic:os.path as p|}, math
+e = math.e",
+                (PythonMemberType.Module, "o", multiple: false),
+                (PythonMemberType.Module, "p", multiple: false));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports5() {
+            await TestAsync(@"{|diagnostic:import os|}
+import {|diagnostic:os.path|}, math
+e = math.e",
+                (PythonMemberType.Module, "os", multiple: false),
+                (PythonMemberType.Module, "os", multiple: false));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports6() {
+            await TestAsync(@"{|diagnostic:import os, os.path|}",
+                PythonMemberType.Module, "os", multiple: true);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports7() {
+            await TestAsync(@"import {|diagnostic:os|}, {|diagnostic:os.path|}, math
+e = math.e",
+                (PythonMemberType.Module, "os", multiple: false),
+                (PythonMemberType.Module, "os", multiple: false));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports8() {
+            await TestAsync(@"{|diagnostic:import os|}
+
+def Method():
+    {|diagnostic:import math|}",
+                (PythonMemberType.Module, "os", multiple: false),
+                (PythonMemberType.Module, "math", multiple: false));
         }
 
         private Task TestNoUnusedAsync(string markup) {

--- a/src/Analysis/Ast/Test/LintUnusedImportTests.cs
+++ b/src/Analysis/Ast/Test/LintUnusedImportTests.cs
@@ -13,6 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -49,257 +50,241 @@ namespace Microsoft.Python.Analysis.Tests {
 
         [TestMethod, Priority(0)]
         public async Task BasicUnusedImport() {
-            await TestAsync(@"{|diagnostic:import os|}", PythonMemberType.Module, "os", multiple: false);
+            await TestAsync(@"{|Module.os.single:import os|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task BasicUnusedImportWithAsName() {
-            await TestAsync(@"{|diagnostic:import os as o|}", PythonMemberType.Module, "o", multiple: false);
+            await TestAsync(@"{|Module.o.single:import os as o|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleModulesInImport() {
-            await TestAsync(@"import {|diagnostic:os|}, math
+            await TestAsync(@"import {|Module.os.single:os|}, math
 
-e = math.e", PythonMemberType.Module, "os", multiple: false);
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleModulesInImportWithAsName() {
-            await TestAsync(@"import {|diagnostic:os as o|}, math
+            await TestAsync(@"import {|Module.o.single:os as o|}, math
 
-e = math.e", PythonMemberType.Module, "o", multiple: false);
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleModulesInImportWithAsName2() {
-            await TestAsync(@"import os as o, {|diagnostic:math as m|}
+            await TestAsync(@"import os as o, {|Module.m.single:math as m|}
 
-p = o.path", PythonMemberType.Module, "m", multiple: false);
+p = o.path");
         }
 
         [TestMethod, Priority(0)]
         public async Task BasicUnusedFromImport() {
-            await TestAsync(@"{|diagnostic:from os import path|}", PythonMemberType.Module, "path", multiple: false);
+            await TestAsync(@"{|Module.path.single:from os import path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task BasicUnusedFromImportWithAsName() {
-            await TestAsync(@"{|diagnostic:from os import path as p|}", PythonMemberType.Module, "p", multiple: false);
+            await TestAsync(@"{|Module.p.single:from os import path as p|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleModulesInFromImport() {
-            await TestAsync(@"from os import {|diagnostic:path|}, pathconf
-p = pathconf('', '')", PythonMemberType.Module, "path", multiple: false);
+            await TestAsync(@"from os import {|Module.path.single:path|}, pathconf
+p = pathconf('', '')");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleModulesInFromImportWithAsName() {
-            await TestAsync(@"from os import {|diagnostic:path as p1|}, pathconf
-p = pathconf('', '')", PythonMemberType.Module, "p1", multiple: false);
+            await TestAsync(@"from os import {|Module.p1.single:path as p1|}, pathconf
+p = pathconf('', '')");
         }
 
         [TestMethod, Priority(0)]
         public async Task DottedNameImport() {
-            await TestAsync(@"{|diagnostic:import os.path|}", PythonMemberType.Module, "os", multiple: false);
+            await TestAsync(@"{|Module.os.single:import os.path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task DottedNameImport2() {
-            await TestAsync(@"import {|diagnostic:os.path|}, math
-e = math.e", PythonMemberType.Module, "os", multiple: false);
+            await TestAsync(@"import {|Module.os.single:os.path|}, math
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task DottedNameImport3() {
-            await TestAsync(@"import {|diagnostic:os.path as p|}, math
-e = math.e", PythonMemberType.Module, "p", multiple: false);
+            await TestAsync(@"import {|Module.p.single:os.path as p|}, math
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task DottedNameImport4() {
-            await TestAsync(@"import os.path as p, {|diagnostic:xml.dom as d|}
-a = p.join('', '')", PythonMemberType.Module, "d", multiple: false);
+            await TestAsync(@"import os.path as p, {|Module.d.single:xml.dom as d|}
+a = p.join('', '')");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleNames() {
-            await TestAsync(@"{|diagnostic:import os.path, math|}", PythonMemberType.Module, "os", multiple: true);
+            await TestAsync(@"{|Module.os.multiple:import os.path, math|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleNames2() {
-            await TestAsync(@"{|diagnostic:import math, os.path|}", PythonMemberType.Module, "math", multiple: true);
+            await TestAsync(@"{|Module.math.multiple:import math, os.path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleNames3() {
-            await TestAsync(@"{|diagnostic:import os.path as p, xml.dom as d|}", PythonMemberType.Module, "p", multiple: true);
+            await TestAsync(@"{|Module.p.multiple:import os.path as p, xml.dom as d|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleNamesFromImport() {
-            await TestAsync(@"{|diagnostic:from os import path, pathconf|}", PythonMemberType.Module, "path", multiple: true);
+            await TestAsync(@"{|Module.path.multiple:from os import path, pathconf|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleNamesFromImport2() {
-            await TestAsync(@"{|diagnostic:from os import pathconf, path|}", PythonMemberType.Function, "pathconf", multiple: true);
+            await TestAsync(@"{|Function.pathconf.multiple:from os import pathconf, path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleNamesFromImport3() {
-            await TestAsync(@"{|diagnostic:from os import path as p, pathconf as c|}", PythonMemberType.Module, "p", multiple: true);
+            await TestAsync(@"{|Module.p.multiple:from os import path as p, pathconf as c|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task ReferenceInAllVariable() {
-            await TestAsync(@"from os import path as p, {|diagnostic:pathconf as c|}
+            await TestAsync(@"from os import path as p, {|Function.c.single:pathconf as c|}
 __all__ = [ 'p' ]
-", PythonMemberType.Function, "c", multiple: false);
+");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused() {
-            await TestNoUnusedAsync(@"import os
+            await TestAsync(@"import os
 path = os.path");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused2() {
-            await TestNoUnusedAsync(@"import os as o, math as m
+            await TestAsync(@"import os as o, math as m
 p = o.path
 c = m.acos(10)");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused3() {
-            await TestNoUnusedAsync(@"import os.path
+            await TestAsync(@"import os.path
 s = os.sys");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused4() {
-            await TestNoUnusedAsync(@"import os.path as s
+            await TestAsync(@"import os.path as s
 p = s.join('', '')");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused5() {
-            await TestNoUnusedAsync(@"import os.path
+            await TestAsync(@"import os.path
 o = os");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused6() {
-            await TestNoUnusedAsync(@"from os import path as p, pathconf as c
+            await TestAsync(@"from os import path as p, pathconf as c
 s = p.join('', '')
 v = c('')");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused7() {
-            await TestNoUnusedAsync(@"import os.path
+            await TestAsync(@"import os.path
 __all__ = [ 'os' ]
 ");
         }
 
         [TestMethod, Priority(0)]
         public async Task NoUnused8() {
-            await TestNoUnusedAsync(@"import os.path as p
+            await TestAsync(@"import os.path as p
 __all__ = [ 'p' ]
 ");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports() {
-            await TestAsync(@"{|diagnostic:import os|}
+            await TestAsync(@"{|Module.os.single:import os|}
 from os import path
-p = path.join('', '')", PythonMemberType.Module, "os", multiple: false);
+p = path.join('', '')");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports2() {
-            await TestAsync(@"{|diagnostic:import os|}
-{|diagnostic:import math|}",
-                (PythonMemberType.Module, "os", multiple: false),
-                (PythonMemberType.Module, "math", multiple: false));
+            await TestAsync(@"{|Module.os.single:import os|}
+{|Module.math.single:import math|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports3() {
-            await TestAsync(@"{|diagnostic:import os|}
-{|diagnostic:import os.path|}",
-                (PythonMemberType.Module, "os", multiple: false),
-                (PythonMemberType.Module, "os", multiple: false));
+            await TestAsync(@"{|Module.os.single:import os|}
+{|Module.os.single:import os.path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports4() {
-            await TestAsync(@"{|diagnostic:import os as o|}
-import {|diagnostic:os.path as p|}, math
-e = math.e",
-                (PythonMemberType.Module, "o", multiple: false),
-                (PythonMemberType.Module, "p", multiple: false));
+            await TestAsync(@"{|Module.o.single:import os as o|}
+import {|Module.p.single:os.path as p|}, math
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports5() {
-            await TestAsync(@"{|diagnostic:import os|}
-import {|diagnostic:os.path|}, math
-e = math.e",
-                (PythonMemberType.Module, "os", multiple: false),
-                (PythonMemberType.Module, "os", multiple: false));
+            await TestAsync(@"{|Module.os.single:import os|}
+import {|Module.os.single:os.path|}, math
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports6() {
-            await TestAsync(@"{|diagnostic:import os, os.path|}",
-                PythonMemberType.Module, "os", multiple: true);
+            await TestAsync(@"{|Module.os.multiple:import os, os.path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports7() {
-            await TestAsync(@"import {|diagnostic:os|}, {|diagnostic:os.path|}, math
-e = math.e",
-                (PythonMemberType.Module, "os", multiple: false),
-                (PythonMemberType.Module, "os", multiple: false));
+            await TestAsync(@"import {|Module.os.single:os|}, {|Module.os.single:os.path|}, math
+e = math.e");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports8() {
-            await TestAsync(@"{|diagnostic:import os|}
+            await TestAsync(@"{|Module.os.single:import os|}
 
 def Method():
-    {|diagnostic:import math|}",
-                (PythonMemberType.Module, "os", multiple: false),
-                (PythonMemberType.Module, "math", multiple: false));
+    {|Module.math.single:import math|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports9() {
-            await TestAsync(@"{|diagnostic:import os|}
+            await TestAsync(@"{|Module.os.single:import os|}
 
 def Method():
-    {|diagnostic:import os.path|}",
-                (PythonMemberType.Module, "os", multiple: false),
-                (PythonMemberType.Module, "os", multiple: false));
+    {|Module.os.single:import os.path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports10() {
-            await TestAsync(@"{|diagnostic:import os|}
+            await TestAsync(@"{|Module.os.single:import os|}
 
 def Method():
     import os.path
-    p = os.path",
-                PythonMemberType.Module, "os", multiple: false);
+    p = os.path");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports11() {
-            await TestNoUnusedAsync(@"import os
+            await TestAsync(@"import os
 o = os.path
 
 def Method():
@@ -310,7 +295,7 @@ def Method():
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports12() {
-            await TestNoUnusedAsync(@"import os
+            await TestAsync(@"import os
 o = os.path
 
 import os.path
@@ -319,11 +304,10 @@ p = os.path");
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports13() {
-            await TestAsync(@"{|diagnostic:import os|}
+            await TestAsync(@"{|Module.os.single:import os|}
 import os.path
 
-p = os.path",
-            PythonMemberType.Module, "os", multiple: false);
+p = os.path");
         }
 
         [TestMethod, Priority(0)]
@@ -331,13 +315,12 @@ p = os.path",
             await TestAsync(@"import os
 p = os.path
 
-{|diagnostic:import os.path|}",
-            PythonMemberType.Module, "os", multiple: false);
+{|Module.os.single:import os.path|}");
         }
 
         [TestMethod, Priority(0)]
         public async Task MultipleImports15() {
-            await TestNoUnusedAsync(@"import os
+            await TestAsync(@"import os
 o = os.path
 
 os = 1
@@ -351,7 +334,7 @@ p = os.path");
             // currently, our engine doesn't handle
             // varaible being reassigned to different type
             // in same scope. so it can't handle this case
-            await TestNoUnusedAsync(@"import os
+            await TestAsync(@"import os
 
 os = 1
 p2 = os
@@ -363,48 +346,42 @@ p = os.path");
         [TestMethod, Priority(0)]
         public async Task MultipleImports17() {
             await TestAsync(@"os = 1
-{|diagnostic:import os.path|}
+{|Module.os.single:import os.path|}
 
 import os
-p = os.path",
-            PythonMemberType.Module, "os", multiple: false);
+p = os.path");
         }
 
-        private Task TestNoUnusedAsync(string markup) {
-            return TestAsync(markup);
-        }
-
-        private Task TestAsync(string markup, PythonMemberType type, string name, bool multiple) {
-            // another way of doing this is putting (type, name, multiple) as a annotation in markup itself.
-            return TestAsync(markup, (type, name, multiple));
-        }
-
-        private async Task TestAsync(string markup, params (PythonMemberType type, string name, bool multiple)[] expected) {
+        private async Task TestAsync(string markup) {
             MarkupUtils.GetNamedSpans(markup, out var code, out var spans);
 
             var analysis = await GetAnalysisAsync(code);
             var actual = Lint(analysis);
 
-            spans.TryGetValue("diagnostic", out var expectedDiagnostics);
+            var expectedDiagnostics = new List<(string type, string name, bool multiple, IndexSpan span)>();
+            foreach (var kv in spans) {
+                var (type, name, multiple) = GetAnnotatedInfo(kv.Key);
+                foreach (var span in kv.Value) {
+                    expectedDiagnostics.Add((type, name, multiple, span));
+                }
+            }
 
-            expectedDiagnostics = expectedDiagnostics ?? new List<IndexSpan>();
             actual.Should().HaveCount(expectedDiagnostics.Count);
-            actual.Should().HaveCount(expected.Length);
-
-            var set = new HashSet<SourceSpan>(expectedDiagnostics.Select(i => i.ToSourceSpan(analysis.Ast)));
-            foreach (var item in actual.Zip(expected, (d, e) => (d: d, e: e))) {
+            foreach (var item in actual.Zip(expectedDiagnostics, (d, e) => (d, e))) {
                 item.d.ErrorCode.Should().Be(ErrorCodes.UnusedImport);
+                item.d.SourceSpan.Should().Be(item.e.span.ToSourceSpan(analysis.Ast));
                 item.d.Message.Should().Be(GetMessage(item.e.type, item.e.name, item.e.multiple));
                 item.d.Tags.Should().HaveCount(1);
                 item.d.Tags[0].Should().Be(DiagnosticsEntry.DiagnosticTags.Unnecessary);
-
-                set.Remove(item.d.SourceSpan).Should().BeTrue();
             }
-
-            set.Should().BeEmpty();
         }
 
-        private string GetMessage(PythonMemberType type, string name, bool multiple) {
+        private (string type, string name, bool multiple) GetAnnotatedInfo(string key) {
+            var data = key.Split(".");
+            return (data[0], data[1], data[2] == "single" ? false : true);
+        }
+
+        private string GetMessage(string type, string name, bool multiple) {
             if (!multiple) {
                 return string.Format(CultureInfo.CurrentCulture, Resources._0_1_is_declared_but_it_is_never_used_within_the_current_file, type, name);
             }

--- a/src/Analysis/Ast/Test/LintUnusedImportTests.cs
+++ b/src/Analysis/Ast/Test/LintUnusedImportTests.cs
@@ -13,7 +13,6 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -22,7 +21,6 @@ using FluentAssertions;
 using Microsoft.Python.Analysis.Analyzer;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Tests.FluentAssertions;
-using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core.Text;
 using Microsoft.Python.Parsing.Ast;
 using Microsoft.Python.Parsing.Tests;

--- a/src/Analysis/Ast/Test/LintUnusedImportTests.cs
+++ b/src/Analysis/Ast/Test/LintUnusedImportTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Python.Analysis.Analyzer;
+using Microsoft.Python.Analysis.Core.Interpreter;
+using Microsoft.Python.Analysis.Diagnostics;
+using Microsoft.Python.Analysis.Tests.FluentAssertions;
+using Microsoft.Python.Core.Text;
+using Microsoft.Python.Parsing.Ast;
+using Microsoft.Python.Parsing.Tests;
+using Microsoft.Python.UnitTests.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+using ErrorCodes = Microsoft.Python.Analysis.Diagnostics.ErrorCodes;
+
+namespace Microsoft.Python.Analysis.Tests {
+    [TestClass]
+    public class LintUnusedImportTests : AnalysisTestBase {
+        private readonly static HashSet<string> UnusedImportErrorCodes =
+            new HashSet<string>() {
+                ErrorCodes.UnusedImport
+            };
+
+        public TestContext TestContext { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+            => TestEnvironmentImpl.TestInitialize($"{TestContext.FullyQualifiedTestClassName}.{TestContext.TestName}");
+
+        [TestCleanup]
+        public void Cleanup() => TestEnvironmentImpl.TestCleanup();
+
+        [TestMethod, Priority(0)]
+        public async Task BasicUnusedImport() {
+            await TestAsync(@"import {|diagnostic:os|}");
+        }
+
+        private async Task TestAsync(string markup) {
+            MarkupUtils.GetNamedSpans(markup, out var code, out var spans);
+
+            var analysis = await GetAnalysisAsync(code);
+            var actual = Lint(analysis, code);
+
+            var expected = spans["diagnostic"];
+            actual.Should().HaveCount(expected.Count);
+
+            var set = new HashSet<SourceSpan>(expected.Select(i => i.ToSourceSpan(analysis.Ast)));
+            foreach (var diagnostic in actual) {
+                diagnostic.ErrorCode.Should().Be(ErrorCodes.UnusedImport);
+                set.Remove(diagnostic.SourceSpan).Should().BeTrue();
+            }
+
+            set.Should().BeEmpty();
+        }
+
+        private IReadOnlyList<DiagnosticsEntry> Lint(IDocumentAnalysis analysis, string code) {
+            var a = Services.GetService<IPythonAnalyzer>();
+            return a.LintModule(analysis.Document).Where(d => UnusedImportErrorCodes.Contains(d.ErrorCode)).ToList();
+        }
+    }
+}

--- a/src/Analysis/Ast/Test/LintUnusedImportTests.cs
+++ b/src/Analysis/Ast/Test/LintUnusedImportTests.cs
@@ -277,6 +277,99 @@ def Method():
                 (PythonMemberType.Module, "math", multiple: false));
         }
 
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports9() {
+            await TestAsync(@"{|diagnostic:import os|}
+
+def Method():
+    {|diagnostic:import os.path|}",
+                (PythonMemberType.Module, "os", multiple: false),
+                (PythonMemberType.Module, "os", multiple: false));
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports10() {
+            await TestAsync(@"{|diagnostic:import os|}
+
+def Method():
+    import os.path
+    p = os.path",
+                PythonMemberType.Module, "os", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports11() {
+            await TestNoUnusedAsync(@"import os
+o = os.path
+
+def Method():
+    import os.path
+    p = os.path");
+        }
+
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports12() {
+            await TestNoUnusedAsync(@"import os
+o = os.path
+
+import os.path
+p = os.path");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports13() {
+            await TestAsync(@"{|diagnostic:import os|}
+import os.path
+
+p = os.path",
+            PythonMemberType.Module, "os", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports14() {
+            await TestAsync(@"import os
+p = os.path
+
+{|diagnostic:import os.path|}",
+            PythonMemberType.Module, "os", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports15() {
+            await TestNoUnusedAsync(@"import os
+o = os.path
+
+os = 1
+
+import os
+p = os.path");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports16() {
+            // currently, our engine doesn't handle
+            // varaible being reassigned to different type
+            // in same scope. so it can't handle this case
+            await TestNoUnusedAsync(@"import os
+
+os = 1
+p2 = os
+
+import os
+p = os.path");
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleImports17() {
+            await TestAsync(@"os = 1
+{|diagnostic:import os.path|}
+
+import os
+p = os.path",
+            PythonMemberType.Module, "os", multiple: false);
+        }
+
         private Task TestNoUnusedAsync(string markup) {
             return TestAsync(markup);
         }

--- a/src/Analysis/Ast/Test/LintUnusedImportTests.cs
+++ b/src/Analysis/Ast/Test/LintUnusedImportTests.cs
@@ -67,9 +67,38 @@ e = math.e", PythonMemberType.Module, "os", multiple: false);
 
         [TestMethod, Priority(0)]
         public async Task MultipleModulesInImportWithAsName() {
-            await TestAsync(@"import os as {|diagnostic:o|}, math
+            await TestAsync(@"import {|diagnostic:os as o|}, math
 
 e = math.e", PythonMemberType.Module, "o", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleModulesInImportWithAsName2() {
+            await TestAsync(@"import os as o, {|diagnostic:math as m|}
+
+p = o.path", PythonMemberType.Module, "m", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task BasicUnusedFromImport() {
+            await TestAsync(@"{|diagnostic:from os import path|}", PythonMemberType.Module, "path", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task BasicUnusedFromImportWithAsName() {
+            await TestAsync(@"{|diagnostic:from os import path as p|}", PythonMemberType.Module, "p", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleModulesInFromImport() {
+            await TestAsync(@"from os import {|diagnostic:path|}, pathconf
+p = pathconf('', '')", PythonMemberType.Module, "path", multiple: false);
+        }
+
+        [TestMethod, Priority(0)]
+        public async Task MultipleModulesInFromImportWithAsName() {
+            await TestAsync(@"from os import {|diagnostic:path as p1|}, pathconf
+p = pathconf('', '')", PythonMemberType.Module, "p1", multiple: false);
         }
 
         private async Task TestAsync(string markup, PythonMemberType type, string name, bool multiple) {

--- a/src/Core/Impl/Text/SourceSpan.cs
+++ b/src/Core/Impl/Text/SourceSpan.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Python.Core.Text {
     /// </summary>
     [Serializable]
     [DebuggerDisplay("({Start.Line}, {Start.Column})-({End.Line}, {End.Column})")]
-    public struct SourceSpan: IComparable<SourceSpan> {
+    public struct SourceSpan : IComparable<SourceSpan> {
         /// <summary>
         /// Constructs a new span with a specific start and end location.
         /// </summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Python.Core.Text {
         /// <param name="left">One span to compare.</param>
         /// <param name="right">The other span to compare.</param>
         /// <returns>True if the spans are the same, False otherwise.</returns>
-        public static bool operator ==(SourceSpan left, SourceSpan right) 
+        public static bool operator ==(SourceSpan left, SourceSpan right)
             => left.Start == right.Start && left.End == right.End;
 
         /// <summary>
@@ -118,6 +118,10 @@ namespace Microsoft.Python.Core.Text {
                 return Start.Column == other.Start.Column ? 0 : 1;
             }
             return 1;
+        }
+
+        public bool Contains(SourceSpan other) {
+            return this.Start <= other.Start && this.End <= other.End;
         }
 
         public override bool Equals(object obj) {

--- a/src/LanguageServer/Impl/Diagnostics/DiagnosticsService.cs
+++ b/src/LanguageServer/Impl/Diagnostics/DiagnosticsService.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Documents;
 using Microsoft.Python.Core;
+using Microsoft.Python.Core.Collections;
 using Microsoft.Python.Core.Disposables;
 using Microsoft.Python.Core.Idle;
 using Microsoft.Python.Core.Services;
@@ -62,16 +63,20 @@ namespace Microsoft.Python.LanguageServer.Diagnostics {
         private readonly DisposableBag _disposables = DisposableBag.Create<DiagnosticsService>();
         private readonly IServiceContainer _services;
         private readonly IClientApplication _clientApp;
+        private readonly ImmutableArray<DiagnosticTag> _supportedDiagnosticTags;
+
         private readonly object _lock = new object();
+
         private DiagnosticsSeverityMap _severityMap = new DiagnosticsSeverityMap();
         private IRunningDocumentTable _rdt;
         private DateTime _lastChangeTime;
 
         private IRunningDocumentTable Rdt => _rdt ?? (_rdt = _services.GetService<IRunningDocumentTable>());
 
-        public DiagnosticsService(IServiceContainer services) {
+        public DiagnosticsService(IServiceContainer services, DiagnosticTag[] supportedDiagnosticTags = null) {
             _services = services;
             _clientApp = services.GetService<IClientApplication>();
+            _supportedDiagnosticTags = supportedDiagnosticTags?.ToImmutableArray() ?? ImmutableArray<DiagnosticTag>.Empty;
 
             var idleTimeService = services.GetService<IIdleTimeService>();
             if (idleTimeService != null) {

--- a/src/LanguageServer/Impl/Diagnostics/DiagnosticsService.cs
+++ b/src/LanguageServer/Impl/Diagnostics/DiagnosticsService.cs
@@ -214,12 +214,7 @@ namespace Microsoft.Python.LanguageServer.Diagnostics {
             => d.Entries
                 .SelectMany(kvp => kvp.Value)
                 .Where(e => DiagnosticsSeverityMap.GetEffectiveSeverity(e.ErrorCode, e.Severity) != Severity.Suppressed)
-                .Select(e => new DiagnosticsEntry(
-                    e.Message,
-                    e.SourceSpan,
-                    e.ErrorCode,
-                    DiagnosticsSeverityMap.GetEffectiveSeverity(e.ErrorCode, e.Severity),
-                    e.Source)
+                .Select(e => e.WithSeverity(DiagnosticsSeverityMap.GetEffectiveSeverity(e.ErrorCode, e.Severity))
                 ).ToArray();
 
         private void ConnectToRdt() {

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -120,7 +120,8 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         public async Task InitializedAsync(InitializedParams @params, CancellationToken cancellationToken = default, IReadOnlyList<string> userConfiguredPaths = null) {
             var initializationOptions = _initParams?.initializationOptions;
 
-            _services.AddService(new DiagnosticsService(_services));
+            var textDocCaps = _initParams?.capabilities?.textDocument;
+            _services.AddService(new DiagnosticsService(_services, textDocCaps.publishDiagnostics.tagSupport?.valueSet));
 
             var cacheFolderPath = initializationOptions?.cacheFolderPath;
             var fs = _services.GetService<IFileSystem>();
@@ -163,8 +164,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _indexManager.IndexWorkspace().DoNotWait();
             _services.AddService(_indexManager);
             _disposableBag.Add(_indexManager);
-
-            var textDocCaps = _initParams?.capabilities?.textDocument;
 
             _completionSource = new CompletionSource(
                 ChooseDocumentationSource(textDocCaps?.completion?.completionItem?.documentationFormat),

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-#define WAIT_FOR_DEBUGGER
+// #define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-// #define WAIT_FOR_DEBUGGER
+#define WAIT_FOR_DEBUGGER
 
 using System;
 using System.Diagnostics;

--- a/src/LanguageServer/Impl/Protocol/Classes.cs
+++ b/src/LanguageServer/Impl/Protocol/Classes.cs
@@ -377,6 +377,28 @@ namespace Microsoft.Python.LanguageServer.Protocol {
         [Serializable]
         public sealed class RenameCapabilities { public bool dynamicRegistration; }
         public RenameCapabilities rename;
+
+        [Serializable]
+        public sealed class PublishDiagnosticsClientCapabilities {
+            /// <summary>
+            /// Whether the clients accepts diagnostics with related information.
+            /// </summary>
+            public bool? relatedInformation;
+
+            public sealed class TagSupport {
+                /// <summary>
+                /// The tags supported by the client.
+                /// </summary>
+                public DiagnosticTag[] valueSet;
+            }
+            /// <summary>
+            /// Client supports the tag property to provide meta data about a diagnostic.
+            /// Clients supporting tags have to handle unknown tags gracefully.
+            /// </summary>
+            public TagSupport tagSupport;
+        }
+
+        public PublishDiagnosticsClientCapabilities publishDiagnostics;
     }
 
     [Serializable]

--- a/src/LanguageServer/Impl/Protocol/Diagnostic.cs
+++ b/src/LanguageServer/Impl/Protocol/Diagnostic.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Python.LanguageServer.Protocol {
         /// The diagnostics message.
         /// </summary>
         public string message;
+
+        /// <summary>
+        /// Additional metadata about the diagnostic.
+        /// </summary>
+        public DiagnosticTag[] tags;
     }
 
     public enum DiagnosticSeverity : int {
@@ -50,5 +55,22 @@ namespace Microsoft.Python.LanguageServer.Protocol {
         Warning = 2,
         Information = 3,
         Hint = 4
+    }
+
+    public enum DiagnosticTag : int {
+        /// <summary>
+        /// Unused or unnecessary code.
+        /// 
+        /// Clients are allowed to render diagnostics with this tag faded out instead of having
+        /// an error squiggle.
+        /// </summary>
+        Unnecessary = 1,
+
+        /// <summary>
+        /// Deprecated or obsolete code.
+        ///
+        /// Clients are allowed to rendered diagnostics with this tag strike through.
+        /// </summary>
+        Deprecated = 2
     }
 }

--- a/src/Parsing/Impl/Ast/SourceLocationExtensions.cs
+++ b/src/Parsing/Impl/Ast/SourceLocationExtensions.cs
@@ -31,5 +31,8 @@ namespace Microsoft.Python.Parsing.Ast {
     public static class IndexSpanExtensions {
         public static SourceSpan ToSourceSpan(this IndexSpan span, ILocationConverter lc)
             => lc != null ? new SourceSpan(lc.IndexToLocation(span.Start), lc.IndexToLocation(span.End)) : default;
+        public static bool Contains(this IndexSpan span, IndexSpan other) {
+            return span.Start <= other.Start && other.End <= span.End;
+        }
     }
 }


### PR DESCRIPTION
Fixes #18.

made basic reporting working.

- [x] basic reporting
- [x] use correct message on diagnostic
- [x] Add support for the new unnecessary tag to have fading effect (https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#diagnostic)
- [x] check VS and vscode whether it supports new unnecessary tag spec
- [x] add tests

... I am splitting out code fix part to different PR
- [ ] add remove unused import code fix
- [ ] etc (might have more work item once I get to remove unused import such as grouping unused imports based on what gets removed together on 1 code fix and etc)
...

this is with latest lsp client ("vscode-languageclient@6.0.0-next.1") + latest vscode.
without it installed, you will get "..." rather than fading out.

![unusedimport](https://user-images.githubusercontent.com/1333179/67712246-dd926600-f980-11e9-824a-56e71feac4d7.gif)

...

to get new lsp client that supports fading, do this.

first, take changes in https://github.com/heejaechang/vscode-python/tree/newlspclient
and then do npm install and npm ci
