### PR TITLE
Add __init__ parameters to class completion documentation

### DIFF
--- a/src/Analysis/Ast/Impl/Caching/StubCache.cs
+++ b/src/Analysis/Ast/Impl/Caching/StubCache.cs
@@ -23,7 +23,7 @@ using Microsoft.Python.Core.Logging;
 
 namespace Microsoft.Python.Analysis.Caching {
     internal sealed class StubCache : IStubCache {
-        private const int _stubCacheFormatVersion = 3;
+        private const int _stubCacheFormatVersion = 4;
 
         private readonly IFileSystem _fs;
         private readonly ILogger _log;

--- a/src/Analysis/Ast/Impl/scrape_module.py
+++ b/src/Analysis/Ast/Impl/scrape_module.py
@@ -309,6 +309,9 @@ class Signature(object):
             # We have a property
             self.decorators = '@property',
             self.fullsig = self.name + "(" + ", ".join(self._defaults) + ")"
+
+        if scope_alias == "__Object__" and name == "__init__":
+            self.fullsig = "__init__(self)"
         
         self.fullsig = (
             self.fullsig or

--- a/src/LanguageServer/Impl/Completion/CompletionItemSource.cs
+++ b/src/LanguageServer/Impl/Completion/CompletionItemSource.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Python.LanguageServer.Completion {
                 // Place regular items first, advanced entries last
                 sortText = char.IsLetter(text, 0) ? "1" : "2",
                 kind = kind,
-                documentation = !t.IsUnknown() ? _docSource.GetHover(label ?? text, member, self) : null,
+                documentation = !t.IsUnknown() ? _docSource.GetHover(label ?? text, member, self, true) : null,
                 // Custom fields used by the LS extensions that may modify
                 // the completion list. Not passed to the client.
                 Member = member,

--- a/src/LanguageServer/Impl/Definitions/IDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Definitions/IDocumentationSource.cs
@@ -20,8 +20,8 @@ using Microsoft.Python.LanguageServer.Protocol;
 namespace Microsoft.Python.LanguageServer {
     public interface IDocumentationSource {
         InsertTextFormat DocumentationFormat { get; }
-        MarkupContent GetHover(string name, IMember member, IPythonType self = null);
-        string GetSignatureString(IPythonFunctionType ft, IPythonType self, out (IndexSpan, IParameterInfo)[] parameterSpans, int overloadIndex = 0, string name = null);
+        MarkupContent GetHover(string name, IMember member, IPythonType self = null, bool includeClassInit = false);
+        string GetSignatureString(IPythonFunctionType ft, IPythonType self, out (IndexSpan, IParameterInfo)[] parameterSpans, int overloadIndex = 0, string name = null, bool noReturn = false);
         MarkupContent FormatParameterDocumentation(IParameterInfo parameter);
         MarkupContent FormatDocumentation(string documentation);
     }

--- a/src/LanguageServer/Impl/Sources/DocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/DocumentationSource.cs
@@ -23,7 +23,7 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.LanguageServer.Sources {
     internal abstract class DocumentationSource {
-        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, out (IndexSpan, IParameterInfo)[] parameterSpans, int overloadIndex = 0, string funcName = null) {
+        public string GetSignatureString(IPythonFunctionType ft, IPythonType self, out (IndexSpan, IParameterInfo)[] parameterSpans, int overloadIndex = 0, string funcName = null, bool noReturn = false) {
             funcName = funcName ?? ft.Name;
             var o = ft.Overloads[overloadIndex];
 
@@ -82,10 +82,12 @@ namespace Microsoft.Python.LanguageServer.Sources {
 
             builder.Append(')');
 
-            var returnDoc = o.GetReturnDocumentation(self);
-            if (!string.IsNullOrWhiteSpace(returnDoc)) {
-                builder.Append(" -> ");
-                builder.Append(returnDoc);
+            if (!noReturn) {
+                var returnDoc = o.GetReturnDocumentation(self);
+                if (!string.IsNullOrWhiteSpace(returnDoc)) {
+                    builder.Append(" -> ");
+                    builder.Append(returnDoc);
+                }
             }
 
             parameterSpans = spans.ToArray();

--- a/src/LanguageServer/Impl/Sources/HoverSource.cs
+++ b/src/LanguageServer/Impl/Sources/HoverSource.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             }
             switch (v.Value) {
                 case IPythonClassType cls when cls.ClassDefinition == scope:
-                    return hoverPosition  > cls.ClassDefinition.HeaderIndex;
+                    return hoverPosition > cls.ClassDefinition.HeaderIndex;
                 case IPythonFunctionType ft when ft.FunctionDefinition == scope:
                     return hoverPosition > ft.FunctionDefinition.HeaderIndex;
                 case IPythonPropertyType prop when prop.FunctionDefinition == scope:

--- a/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
     internal sealed class MarkdownDocumentationSource : DocumentationSource, IDocumentationSource {
         public InsertTextFormat DocumentationFormat => InsertTextFormat.PlainText;
 
-        public MarkupContent GetHover(string name, IMember member, IPythonType self) {
+        public MarkupContent GetHover(string name, IMember member, IPythonType self, bool includeClassInit = false) {
             // We need to tell between instance and type.
             var type = member.GetPythonType();
             if (type.IsUnknown()) {
@@ -41,16 +41,26 @@ namespace Microsoft.Python.LanguageServer.Sources {
             var typeDoc = !string.IsNullOrEmpty(type.Documentation) ? $"\n---\n{type.MarkdownDoc()}" : string.Empty;
             switch (type) {
                 case IPythonPropertyType prop:
-                    text = GetPropertyHoverString(prop);
+                    text = GetPropertyString(prop);
                     break;
 
                 case IPythonFunctionType ft:
-                    text = GetFunctionHoverString(ft, self);
+                    text = GetFunctionString(ft, self);
                     break;
 
                 case IPythonClassType cls:
                     var clsDoc = !string.IsNullOrEmpty(cls.Documentation) ? $"\n---\n{cls.MarkdownDoc()}" : string.Empty;
-                    text = $"```\nclass {cls.Name}\n```{clsDoc}";
+
+                    var sig = string.Empty;
+
+                    if (includeClassInit) {
+                        var init = cls.GetMember<IPythonFunctionType>("__init__");
+                        if (init != null) {
+                            sig = GetSignatureString(init, null, out var _, 0, "", true);
+                        }
+                    }
+
+                    text = $"```\nclass {cls.Name}{sig}\n```{clsDoc}";
                     break;
 
                 case IPythonModule mod:
@@ -67,7 +77,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             };
         }
 
-        public MarkupContent FormatDocumentation(string documentation) 
+        public MarkupContent FormatDocumentation(string documentation)
             => new MarkupContent { kind = MarkupKind.Markdown, value = DocstringConverter.ToMarkdown(documentation) };
 
         public MarkupContent FormatParameterDocumentation(IParameterInfo parameter) {
@@ -79,13 +89,13 @@ namespace Microsoft.Python.LanguageServer.Sources {
             return new MarkupContent { kind = MarkupKind.Markdown, value = text };
         }
 
-        private string GetPropertyHoverString(IPythonPropertyType prop, int overloadIndex = 0) {
+        private string GetPropertyString(IPythonPropertyType prop) {
             var decTypeString = prop.DeclaringType != null ? $"{prop.DeclaringType.Name}." : string.Empty;
             var propDoc = !string.IsNullOrEmpty(prop.Documentation) ? $"\n---\n{prop.MarkdownDoc()}" : string.Empty;
             return $"```\n{decTypeString}\n```{propDoc}";
         }
 
-        private string GetFunctionHoverString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0) {
+        private string GetFunctionString(IPythonFunctionType ft, IPythonType self, int overloadIndex = 0) {
             var sigString = GetSignatureString(ft, self, out _, overloadIndex);
             var decTypeString = ft.DeclaringType != null ? $"{ft.DeclaringType.Name}." : string.Empty;
             var funcDoc = !string.IsNullOrEmpty(ft.Documentation) ? $"\n---\n{ft.MarkdownDoc()}" : string.Empty;

--- a/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
@@ -51,16 +51,20 @@ namespace Microsoft.Python.LanguageServer.Sources {
                 case IPythonClassType cls:
                     var clsDoc = !string.IsNullOrEmpty(cls.Documentation) ? $"\n---\n{cls.MarkdownDoc()}" : string.Empty;
 
+                    string className;
                     var sig = string.Empty;
 
                     if (includeClassInit) {
+                        className = cls.Name;
                         var init = cls.GetMember<IPythonFunctionType>("__init__");
                         if (init != null) {
                             sig = GetSignatureString(init, null, out var _, 0, "", true);
                         }
+                    } else {
+                        className = "class " + cls.Name;
                     }
 
-                    text = $"```\n{cls.Name}{sig}\n```{clsDoc}";
+                    text = $"```\n{className}{sig}\n```{clsDoc}";
                     break;
 
                 case IPythonModule mod:

--- a/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/MarkdownDocumentationSource.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
                         }
                     }
 
-                    text = $"```\nclass {cls.Name}{sig}\n```{clsDoc}";
+                    text = $"```\n{cls.Name}{sig}\n```{clsDoc}";
                     break;
 
                 case IPythonModule mod:

--- a/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
     internal sealed class PlainTextDocumentationSource : DocumentationSource, IDocumentationSource {
         public InsertTextFormat DocumentationFormat => InsertTextFormat.PlainText;
 
-        public MarkupContent GetHover(string name, IMember member, IPythonType self) {
+        public MarkupContent GetHover(string name, IMember member, IPythonType self, bool includeClassInit = false) {
             // We need to tell between instance and type.
             var type = member.GetPythonType();
             if (type.IsUnknown()) {
@@ -50,7 +50,17 @@ namespace Microsoft.Python.LanguageServer.Sources {
 
                 case IPythonClassType cls:
                     var clsDoc = !string.IsNullOrEmpty(cls.Documentation) ? $"\n\n{cls.PlaintextDoc()}" : string.Empty;
-                    text = $"class {cls.Name}{clsDoc}";
+
+                    var sig = string.Empty;
+
+                    if (includeClassInit) {
+                        var init = cls.GetMember<IPythonFunctionType>("__init__");
+                        if (init != null) {
+                            sig = GetSignatureString(init, null, out var _, 0, "", true);
+                        }
+                    }
+
+                    text = $"class {cls.Name}{sig}{clsDoc}";
                     break;
 
                 case IPythonModule mod:
@@ -67,7 +77,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
             };
         }
 
-        public MarkupContent FormatDocumentation(string documentation) 
+        public MarkupContent FormatDocumentation(string documentation)
             => new MarkupContent { kind = MarkupKind.PlainText, value = documentation };
 
         public MarkupContent FormatParameterDocumentation(IParameterInfo parameter) {

--- a/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Python.LanguageServer.Sources {
                         }
                     }
 
-                    text = $"class {cls.Name}{sig}{clsDoc}";
+                    text = $"{cls.Name}{sig}{clsDoc}";
                     break;
 
                 case IPythonModule mod:

--- a/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
+++ b/src/LanguageServer/Impl/Sources/PlainTextDocumentationSource.cs
@@ -51,16 +51,20 @@ namespace Microsoft.Python.LanguageServer.Sources {
                 case IPythonClassType cls:
                     var clsDoc = !string.IsNullOrEmpty(cls.Documentation) ? $"\n\n{cls.PlaintextDoc()}" : string.Empty;
 
+                    string className;
                     var sig = string.Empty;
 
                     if (includeClassInit) {
+                        className = cls.Name;
                         var init = cls.GetMember<IPythonFunctionType>("__init__");
                         if (init != null) {
                             sig = GetSignatureString(init, null, out var _, 0, "", true);
                         }
+                    } else {
+                        className = "class " + cls.Name;
                     }
 
-                    text = $"{cls.Name}{sig}{clsDoc}";
+                    text = $"{className}{sig}{clsDoc}";
                     break;
 
                 case IPythonModule mod:

--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -127,12 +127,16 @@ class oar(list):
         [TestMethod]
         public async Task OverrideInit3X() {
             const string code = @"
-class Test():
+class A:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class Test(A):
     def __
 ";
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion, Services);
-            var result = cs.GetCompletions(analysis, new SourceLocation(3, 10));
+            var result = cs.GetCompletions(analysis, new SourceLocation(7, 10));
 
             result.Should().HaveItem("__init__")
                 .Which.Should().HaveInsertText($"__init__(self, *args, **kwargs):{Environment.NewLine}    super().__init__(*args, **kwargs)")

--- a/src/LanguageServer/Test/HoverTests.cs
+++ b/src/LanguageServer/Test/HoverTests.cs
@@ -63,7 +63,7 @@ string = str
             hover.Should().BeNull();
 
             hover = hs.GetHover(analysis, new SourceLocation(4, 7));
-            hover.contents.value.Should().Be("C\n\nClass C is awesome");
+            hover.contents.value.Should().Be("class C\n\nClass C is awesome");
 
             hover = hs.GetHover(analysis, new SourceLocation(6, 9));
             hover.contents.value.Should().Be("C.method(a: int, b) -> float\n\nReturns a float!!!");
@@ -78,7 +78,7 @@ string = str
             hover.contents.value.Should().Be("y: int");
 
             hover = hs.GetHover(analysis, new SourceLocation(15, 2));
-            hover.contents.value.Should().StartWith("str\n\nstr(object='') -> str");
+            hover.contents.value.Should().StartWith("class str\n\nstr(object='') -> str");
         }
 
         [DataRow(false)]
@@ -93,7 +93,7 @@ datetime.datetime.now().day
             var hs = new HoverSource(new PlainTextDocumentationSource());
 
             AssertHover(hs, analysis, new SourceLocation(3, 2), "module datetime*", new SourceSpan(3, 1, 3, 9));
-            AssertHover(hs, analysis, new SourceLocation(3, 11), "datetime*", new SourceSpan(3, 9, 3, 18));
+            AssertHover(hs, analysis, new SourceLocation(3, 11), "class datetime*", new SourceSpan(3, 9, 3, 18));
             AssertHover(hs, analysis, new SourceLocation(3, 20), @"datetime.now(tz: tzinfo) -> datetime*", new SourceSpan(3, 18, 3, 22));
         }
 
@@ -136,8 +136,8 @@ class Derived(Base):
 ";
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var hs = new HoverSource(new PlainTextDocumentationSource());
-            AssertHover(hs, analysis, new SourceLocation(3, 19), "Base*", new SourceSpan(3, 18, 3, 22));
-            AssertHover(hs, analysis, new SourceLocation(8, 8), "Derived*", new SourceSpan(8, 8, 8, 12));
+            AssertHover(hs, analysis, new SourceLocation(3, 19), "class Base*", new SourceSpan(3, 18, 3, 22));
+            AssertHover(hs, analysis, new SourceLocation(8, 8), "class Derived*", new SourceSpan(8, 8, 8, 12));
         }
 
         [TestMethod, Priority(0)]

--- a/src/LanguageServer/Test/HoverTests.cs
+++ b/src/LanguageServer/Test/HoverTests.cs
@@ -63,7 +63,7 @@ string = str
             hover.Should().BeNull();
 
             hover = hs.GetHover(analysis, new SourceLocation(4, 7));
-            hover.contents.value.Should().Be("class C\n\nClass C is awesome");
+            hover.contents.value.Should().Be("C\n\nClass C is awesome");
 
             hover = hs.GetHover(analysis, new SourceLocation(6, 9));
             hover.contents.value.Should().Be("C.method(a: int, b) -> float\n\nReturns a float!!!");
@@ -78,7 +78,7 @@ string = str
             hover.contents.value.Should().Be("y: int");
 
             hover = hs.GetHover(analysis, new SourceLocation(15, 2));
-            hover.contents.value.Should().StartWith("class str\n\nstr(object='') -> str");
+            hover.contents.value.Should().StartWith("str\n\nstr(object='') -> str");
         }
 
         [DataRow(false)]
@@ -93,7 +93,7 @@ datetime.datetime.now().day
             var hs = new HoverSource(new PlainTextDocumentationSource());
 
             AssertHover(hs, analysis, new SourceLocation(3, 2), "module datetime*", new SourceSpan(3, 1, 3, 9));
-            AssertHover(hs, analysis, new SourceLocation(3, 11), "class datetime*", new SourceSpan(3, 9, 3, 18));
+            AssertHover(hs, analysis, new SourceLocation(3, 11), "datetime*", new SourceSpan(3, 9, 3, 18));
             AssertHover(hs, analysis, new SourceLocation(3, 20), @"datetime.now(tz: tzinfo) -> datetime*", new SourceSpan(3, 18, 3, 22));
         }
 
@@ -136,8 +136,8 @@ class Derived(Base):
 ";
             var analysis = await GetAnalysisAsync(code, PythonVersions.LatestAvailable3X);
             var hs = new HoverSource(new PlainTextDocumentationSource());
-            AssertHover(hs, analysis, new SourceLocation(3, 19), "class Base*", new SourceSpan(3, 18, 3, 22));
-            AssertHover(hs, analysis, new SourceLocation(8, 8), "class Derived*", new SourceSpan(8, 8, 8, 12));
+            AssertHover(hs, analysis, new SourceLocation(3, 19), "Base*", new SourceSpan(3, 18, 3, 22));
+            AssertHover(hs, analysis, new SourceLocation(8, 8), "Derived*", new SourceSpan(8, 8, 8, 12));
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Fixes #1173.
Fixes #1701.

Adds class `__init__` parameters to the completion documentation, if possible. Also, fixes the scraper to not output the wrong `__init__` function signature for `object`. And, remove the `class` keyword prefix, as it's inconsistent with hovers and other completions and ends up breaking syntax highlighting.

No DB version bump needed for the scraper change, as we do not store the builtins module which contains `object`.