### PR TITLE
Do not show non-module members as completion candidates in regular import statement

### DIFF
--- a/src/LanguageServer/Test/CompletionTests.cs
+++ b/src/LanguageServer/Test/CompletionTests.cs
@@ -1417,5 +1417,24 @@ class B(A):
 
             result.Completions.Where(item => item.insertText == "None").Should().HaveCount(1);
         }
+
+        [TestMethod, Priority(0)]
+        public async Task ImportDotMembers() {
+            var appUri = TestData.GetTestSpecificUri("app.py");
+            await TestData.CreateTestSpecificFileAsync(Path.Combine("package", "__init__.py"), "badvar1 = 3.141");
+            await TestData.CreateTestSpecificFileAsync(Path.Combine("package", "m1", "__init__.py"), "badvar2 = 123");
+            await TestData.CreateTestSpecificFileAsync(Path.Combine("package", "m2", "__init__.py"), "badvar3 = 'str'");
+
+            await CreateServicesAsync(PythonVersions.LatestAvailable3X);
+            var rdt = Services.GetService<IRunningDocumentTable>();
+            var doc = rdt.OpenDocument(appUri, "import package.");
+
+            await Services.GetService<IPythonAnalyzer>().WaitForCompleteAnalysisAsync();
+            var analysis = await doc.GetAnalysisAsync(Timeout.Infinite);
+            var cs = new CompletionSource(new PlainTextDocumentationSource(), ServerSettings.completion, Services);
+
+            var result = cs.GetCompletions(analysis, new SourceLocation(1, 16));
+            result.Should().OnlyHaveLabels("m1", "m2");
+        }
     }
 }


### PR DESCRIPTION
Fixes #1647.

The completion context was correct (ImportStatement), however we were offering non-module members, which are only valid when using `from something import ...`, and not `import ...`. Filter them out.

Now:

![image](https://user-images.githubusercontent.com/5341706/67133087-1cc1f980-f1c0-11e9-9eb0-dccf0ed9267a.png)

![image](https://user-images.githubusercontent.com/5341706/67133090-20ee1700-f1c0-11e9-9d60-6c8ea291708c.png)
