### PR TITLE
Do not lock module database when working with database files

### DIFF
--- a/src/Analysis/Ast/Impl/Caching/Definitions/IModuleDatabaseService.cs
+++ b/src/Analysis/Ast/Impl/Caching/Definitions/IModuleDatabaseService.cs
@@ -44,10 +44,5 @@ namespace Microsoft.Python.Analysis.Caching {
         /// Determines if module analysis exists in the storage.
         /// </summary>
         bool ModuleExistsInStorage(string moduleName, string filePath);
-
-        /// <summary>
-        /// Clear cached data.
-        /// </summary>
-        void Clear();
     }
 }

--- a/src/Caching/Impl/ModuleDatabase.cs
+++ b/src/Caching/Impl/ModuleDatabase.cs
@@ -115,10 +115,8 @@ namespace Microsoft.Python.Analysis.Caching {
 
             for (var retries = 50; retries > 0; --retries) {
                 try {
-                    lock (_lock) {
-                        var dbPath = FindDatabaseFile(moduleName, filePath);
-                        return !string.IsNullOrEmpty(dbPath);
-                    }
+                    var dbPath = FindDatabaseFile(moduleName, filePath);
+                    return !string.IsNullOrEmpty(dbPath);
                 } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
                     Thread.Sleep(10);
                 }

--- a/src/Caching/Impl/ModuleDatabase.cs
+++ b/src/Caching/Impl/ModuleDatabase.cs
@@ -124,12 +124,6 @@ namespace Microsoft.Python.Analysis.Caching {
             return false;
         }
 
-        public void Clear() {
-            lock (_lock) {
-                _dependencies.Clear();
-            }
-        }
-
         private void StoreModuleAnalysis(IDocumentAnalysis analysis, CancellationToken cancellationToken = default) {
             var cachingLevel = GetCachingLevel();
             if (cachingLevel == AnalysisCachingLevel.None) {

--- a/src/Caching/Impl/ModuleDatabase.cs
+++ b/src/Caching/Impl/ModuleDatabase.cs
@@ -144,26 +144,24 @@ namespace Microsoft.Python.Analysis.Caching {
 
             Exception ex = null;
             for (var retries = 50; retries > 0; --retries) {
-                lock (_lock) {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    try {
-                        if (!_fs.DirectoryExists(CacheFolder)) {
-                            _fs.CreateDirectory(CacheFolder);
-                        }
-
-                        cancellationToken.ThrowIfCancellationRequested();
-                        using (var db = new LiteDatabase(Path.Combine(CacheFolder, $"{model.UniqueId}.db"))) {
-                            var modules = db.GetCollection<ModuleModel>("modules");
-                            modules.Upsert(model);
-                            return;
-                        }
-                    } catch (Exception ex1) when (ex1 is IOException || ex1 is UnauthorizedAccessException) {
-                        ex = ex1;
-                        Thread.Sleep(10);
-                    } catch (Exception ex2) {
-                        ex = ex2;
-                        break;
+                cancellationToken.ThrowIfCancellationRequested();
+                try {
+                    if (!_fs.DirectoryExists(CacheFolder)) {
+                        _fs.CreateDirectory(CacheFolder);
                     }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    using (var db = new LiteDatabase(Path.Combine(CacheFolder, $"{model.UniqueId}.db"))) {
+                        var modules = db.GetCollection<ModuleModel>("modules");
+                        modules.Upsert(model);
+                        return;
+                    }
+                } catch (Exception ex1) when (ex1 is IOException || ex1 is UnauthorizedAccessException) {
+                    ex = ex1;
+                    Thread.Sleep(10);
+                } catch (Exception ex2) {
+                    ex = ex2;
+                    break;
                 }
             }
 


### PR DESCRIPTION
For #1601.

These locks effectively do nothing.

- `ModuleExistsInStorage` would still be affected by the ordering of DB creation and checking regardless of the lock. Realistically, the file system is preventing internal race conditions, so we don't have to.
- `StoreModuleAnalysis` creates the LiteDB instances, but LiteDB has internal file locking mechanisms, so we don't need to repeat that here either.

`_lock` protects the dependency dictionary (as it's not a concurrent one), so can't just be removed.