### PR TITLE
enable tiered compilation and use latest C# lang version

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -20,7 +20,6 @@ using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Python.Analysis.Caching;
 using Microsoft.Python.Analysis.Dependencies;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Documents;
@@ -36,7 +35,7 @@ using Microsoft.Python.Parsing.Ast;
 
 namespace Microsoft.Python.Analysis.Analyzer {
     public sealed class PythonAnalyzer : IPythonAnalyzer, IDisposable {
-        private readonly IServiceManager _services;
+        private readonly IServiceContainer _services;
         private readonly IDependencyResolver<AnalysisModuleKey, PythonAnalyzerEntry> _dependencyResolver;
         private readonly Dictionary<AnalysisModuleKey, PythonAnalyzerEntry> _analysisEntries = new Dictionary<AnalysisModuleKey, PythonAnalyzerEntry>();
         private readonly DisposeToken _disposeToken = DisposeToken.Create<PythonAnalyzer>();
@@ -51,7 +50,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private PythonAnalyzerSession _nextSession;
         private bool _forceGCOnNextSession;
 
-        public PythonAnalyzer(IServiceManager services) {
+        public PythonAnalyzer(IServiceContainer services) {
             _services = services;
             _log = services.GetService<ILogger>();
             _dependencyResolver = new DependencyResolver<AnalysisModuleKey, PythonAnalyzerEntry>();

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private PythonAnalyzerSession _nextSession;
         private bool _forceGCOnNextSession;
 
-        public PythonAnalyzer(IServiceManager services, string cacheFolderPath = null) {
+        public PythonAnalyzer(IServiceManager services) {
             _services = services;
             _log = services.GetService<ILogger>();
             _dependencyResolver = new DependencyResolver<AnalysisModuleKey, PythonAnalyzerEntry>();
@@ -59,9 +59,6 @@ namespace Microsoft.Python.Analysis.Analyzer {
             _startNextSession = StartNextSession;
 
             _progress = new ProgressReporter(services.GetService<IProgressService>());
-
-            _services.AddService(new CacheFolderService(_services, cacheFolderPath));
-            _services.AddService(new StubCache(_services));
         }
 
         public void Dispose() {

--- a/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/PythonAnalyzerSession.cs
@@ -29,7 +29,6 @@ using Microsoft.Python.Analysis.Modules;
 using Microsoft.Python.Analysis.Types;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.Logging;
-using Microsoft.Python.Core.Services;
 using Microsoft.Python.Core.Testing;
 using Microsoft.Python.Parsing.Ast;
 
@@ -42,7 +41,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         private readonly PythonAnalyzerEntry _entry;
         private readonly Action<Task> _startNextSession;
         private readonly CancellationToken _analyzerCancellationToken;
-        private readonly IServiceManager _services;
+        private readonly IServiceContainer _services;
         private readonly IDiagnosticsService _diagnosticsService;
         private readonly IProgressReporter _progress;
         private readonly IPythonAnalyzer _analyzer;
@@ -65,7 +64,7 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public int Version { get; }
         public int AffectedEntriesCount { get; }
 
-        public PythonAnalyzerSession(IServiceManager services,
+        public PythonAnalyzerSession(IServiceContainer services,
             IProgressReporter progress,
             Action<Task> startNextSession,
             CancellationToken analyzerCancellationToken,

--- a/src/Analysis/Ast/Impl/Caching/CacheFolders.cs
+++ b/src/Analysis/Ast/Impl/Caching/CacheFolders.cs
@@ -28,9 +28,7 @@ namespace Microsoft.Python.Analysis.Caching {
 
         public string CacheFolder { get; }
 
-        public string GetFileNameFromContent(string content) {
-            return content.GetHashString();
-        }
+        public string GetFileNameFromContent(string content) => content.GetHashString();
 
         private static string GetCacheFolder(IServiceContainer services) {
             var platform = services.GetService<IOSPlatform>();

--- a/src/Analysis/Ast/Impl/Caching/CacheFolders.cs
+++ b/src/Analysis/Ast/Impl/Caching/CacheFolders.cs
@@ -16,8 +16,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Python.Core;
 using Microsoft.Python.Core.Logging;
 using Microsoft.Python.Core.OS;
@@ -31,12 +29,7 @@ namespace Microsoft.Python.Analysis.Caching {
         public string CacheFolder { get; }
 
         public string GetFileNameFromContent(string content) {
-            // File name depends on the content so we can distinguish between different versions.
-            using (var hash = SHA256.Create()) {
-                return Convert
-                    .ToBase64String(hash.ComputeHash(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(content)))
-                    .Replace('/', '_').Replace('+', '-');
-            }
+            return content.GetHashString();
         }
 
         private static string GetCacheFolder(IServiceContainer services) {

--- a/src/Analysis/Ast/Impl/Caching/CacheService.cs
+++ b/src/Analysis/Ast/Impl/Caching/CacheService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Python.Analysis.Caching {
             }
 
             if (cacheFolderPath != null && !fs.DirectoryExists(cacheFolderPath)) {
-                log?.Log(TraceEventType.Warning, Resources.Specified_cache_folder_0_does_not_exist_Switching_to_default.FormatUI(cacheFolderPath));
+                log?.Log(TraceEventType.Warning, Resources.Invalid_0_CacheFolder.FormatUI(cacheFolderPath));
                 cacheFolderPath = null;
             }
 

--- a/src/Analysis/Ast/Impl/Caching/CacheService.cs
+++ b/src/Analysis/Ast/Impl/Caching/CacheService.cs
@@ -1,0 +1,46 @@
+﻿// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Diagnostics;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.IO;
+using Microsoft.Python.Core.Logging;
+using Microsoft.Python.Core.Services;
+
+namespace Microsoft.Python.Analysis.Caching {
+    /// <summary>
+    /// Register caching services for the given cache folder path 
+    /// </summary>
+    public static class CacheService {
+        public static void Register(IServiceManager services, string cacheFolderPath) {
+            var log = services.GetService<ILogger>();
+            var fs = services.GetService<IFileSystem>();
+
+            // this is not thread safe. this is not supposed to be called concurrently
+            var cachingService = services.GetService<ICacheFolderService>();
+            if (cachingService != null) {
+                return;
+            }
+
+            if (cacheFolderPath != null && !fs.DirectoryExists(cacheFolderPath)) {
+                log?.Log(TraceEventType.Warning, Resources.Specified_cache_folder_0_does_not_exist_Switching_to_default.FormatUI(cacheFolderPath));
+                cacheFolderPath = null;
+            }
+
+            services.AddService(new CacheFolderService(services, cacheFolderPath));
+            services.AddService(new StubCache(services));
+        }
+    }
+}

--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis</AssemblyName>
   </PropertyGroup>
@@ -9,7 +9,7 @@
       1701, 1702 - "You may need to supply assembly policy"
     -->
     <NoWarn>1701;1702;$(NoWarn)</NoWarn>
-    <LangVersion>7.2</LangVersion>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <Import Project="..\..\..\..\build\NetStandard.settings" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis</AssemblyName>
   </PropertyGroup>

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -268,6 +268,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specified cache folder (&apos;{0}&apos;) does not exist. Switching to default..
+        /// </summary>
+        internal static string Invalid_0_CacheFolder {
+            get {
+                return ResourceManager.GetString("Invalid_0_CacheFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The first argument to NewType must be a string..
         /// </summary>
         internal static string NewTypeFirstArgument {
@@ -327,15 +336,6 @@ namespace Microsoft.Python.Analysis {
         internal static string ReturnInInit {
             get {
                 return ResourceManager.GetString("ReturnInInit", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specified cache folder (&apos;{0}&apos;) does not exist. Switching to default..
-        /// </summary>
-        internal static string Specified_cache_folder_0_does_not_exist_Switching_to_default {
-            get {
-                return ResourceManager.GetString("Specified_cache_folder_0_does_not_exist_Switching_to_default", resourceCulture);
             }
         }
         

--- a/src/Analysis/Ast/Impl/Resources.Designer.cs
+++ b/src/Analysis/Ast/Impl/Resources.Designer.cs
@@ -331,6 +331,15 @@ namespace Microsoft.Python.Analysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specified cache folder (&apos;{0}&apos;) does not exist. Switching to default..
+        /// </summary>
+        internal static string Specified_cache_folder_0_does_not_exist_Switching_to_default {
+            get {
+                return ResourceManager.GetString("Specified_cache_folder_0_does_not_exist_Switching_to_default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The first argument to TypeVar must be a string..
         /// </summary>
         internal static string TypeVarFirstArgumentNotString {

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -222,7 +222,7 @@
   <data name="Analysis_PositionalOnlyArgumentNamed" xml:space="preserve">
     <value>Positional only argument '{0}' may not be named.</value>
   </data>
-  <data name="Specified_cache_folder_0_does_not_exist_Switching_to_default" xml:space="preserve">
+  <data name="Invalid_0_CacheFolder" xml:space="preserve">
     <value>Specified cache folder ('{0}') does not exist. Switching to default.</value>
   </data>
 </root>

--- a/src/Analysis/Ast/Impl/Resources.resx
+++ b/src/Analysis/Ast/Impl/Resources.resx
@@ -222,4 +222,7 @@
   <data name="Analysis_PositionalOnlyArgumentNamed" xml:space="preserve">
     <value>Positional only argument '{0}' may not be named.</value>
   </data>
+  <data name="Specified_cache_folder_0_does_not_exist_Switching_to_default" xml:space="preserve">
+    <value>Specified cache folder ('{0}') does not exist. Switching to default.</value>
+  </data>
 </root>

--- a/src/Analysis/Ast/Test/AnalysisTestBase.cs
+++ b/src/Analysis/Ast/Test/AnalysisTestBase.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Python.Analysis.Analyzer;
+using Microsoft.Python.Analysis.Caching;
 using Microsoft.Python.Analysis.Core.Interpreter;
 using Microsoft.Python.Analysis.Diagnostics;
 using Microsoft.Python.Analysis.Documents;
@@ -83,7 +84,9 @@ namespace Microsoft.Python.Analysis.Tests {
             }
 
             TestLogger.Log(TraceEventType.Information, "Create PythonAnalyzer");
-            var analyzer = new PythonAnalyzer(sm, stubCacheFolderPath);
+
+            CacheService.Register(sm, stubCacheFolderPath);
+            var analyzer = new PythonAnalyzer(sm);
             sm.AddService(analyzer);
 
             TestLogger.Log(TraceEventType.Information, "Create PythonInterpreter");

--- a/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
+++ b/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Core</AssemblyName>
   </PropertyGroup>
@@ -9,7 +9,7 @@
       1701, 1702 - "You may need to supply assembly policy"
     -->
     <NoWarn>1701;1702;$(NoWarn)</NoWarn>
-    <LangVersion>7.2</LangVersion>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <Import Project="..\..\..\..\build\NetStandard.settings" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
+++ b/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Core</AssemblyName>
   </PropertyGroup>

--- a/src/Caching/Impl/Microsoft.Python.Analysis.Caching.csproj
+++ b/src/Caching/Impl/Microsoft.Python.Analysis.Caching.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis.Caching</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Caching</AssemblyName>
   </PropertyGroup>

--- a/src/Caching/Impl/Microsoft.Python.Analysis.Caching.csproj
+++ b/src/Caching/Impl/Microsoft.Python.Analysis.Caching.csproj
@@ -9,7 +9,7 @@
       1701, 1702 - "You may need to supply assembly policy"
     -->
     <NoWarn>1701;1702;$(NoWarn)</NoWarn>
-    <LangVersion>7.2</LangVersion>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <Import Project="..\..\..\build\NetStandard.settings" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Core/Impl/Extensions/StringExtensions.cs
+++ b/src/Core/Impl/Extensions/StringExtensions.cs
@@ -19,6 +19,8 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Python.Core.Text;
 
@@ -311,6 +313,20 @@ namespace Microsoft.Python.Core {
                     hash = hash * 31 + c;
                 }
                 return hash;
+            }
+        }
+
+        /// <summary>
+        /// return string representation of hash of the input string.
+        /// 
+        /// the string representation of the hash is in the form where it can be used in a file system.
+        /// </summary>
+        public static string GetHashString(this string input) {
+            // File name depends on the content so we can distinguish between different versions.
+            using (var hash = SHA256.Create()) {
+                return Convert
+                    .ToBase64String(hash.ComputeHash(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(input)))
+                    .Replace('/', '_').Replace('+', '-');
             }
         }
     }

--- a/src/Core/Impl/Microsoft.Python.Core.csproj
+++ b/src/Core/Impl/Microsoft.Python.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Python.Core</RootNamespace>
     <AssemblyName>Microsoft.Python.Core</AssemblyName>
   </PropertyGroup>
@@ -9,7 +9,7 @@
       1701, 1702 - "You may need to supply assembly policy"
     -->
     <NoWarn>1701;1702;$(NoWarn)</NoWarn>
-    <LangVersion>7.3</LangVersion>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <Import Project="..\..\..\build\NetStandard.settings" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Core/Impl/Microsoft.Python.Core.csproj
+++ b/src/Core/Impl/Microsoft.Python.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Core</RootNamespace>
     <AssemblyName>Microsoft.Python.Core</AssemblyName>
   </PropertyGroup>

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -107,10 +107,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _initParams = @params;
             _log = _services.GetService<ILogger>();
 
-            var initializationOptions = _initParams?.initializationOptions;
-            CacheService.Register(_services, initializationOptions?.cacheFolderPath);
-
-            var root = initializationOptions?.rootPathOverride ?? _initParams?.rootUri?.ToAbsolutePath() ?? _initParams?.rootPath;
+            var root = _initParams?.initializationOptions?.rootPathOverride ?? _initParams?.rootUri?.ToAbsolutePath() ?? _initParams?.rootPath;
             if (!string.IsNullOrEmpty(root)) {
                 Root = PathUtils.NormalizePathAndTrim(root);
             }

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -107,7 +107,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _initParams = @params;
             _log = _services.GetService<ILogger>();
 
-            var root = _initParams?.initializationOptions?.rootPathOverride ?? _initParams?.rootUri?.ToAbsolutePath() ?? _initParams?.rootPath;
+            var initializationOptions = _initParams?.initializationOptions;
+            CacheService.Register(_services, initializationOptions?.cacheFolderPath);
+
+            var root = initializationOptions?.rootPathOverride ?? _initParams?.rootUri?.ToAbsolutePath() ?? _initParams?.rootPath;
             if (!string.IsNullOrEmpty(root)) {
                 Root = PathUtils.NormalizePathAndTrim(root);
             }
@@ -123,14 +126,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
             _services.AddService(new DiagnosticsService(_services));
 
-            var cacheFolderPath = initializationOptions?.cacheFolderPath;
-            var fs = _services.GetService<IFileSystem>();
-            if (cacheFolderPath != null && !fs.DirectoryExists(cacheFolderPath)) {
-                _log?.Log(TraceEventType.Warning, Resources.Error_InvalidCachePath);
-                cacheFolderPath = null;
-            }
-
-            var analyzer = new PythonAnalyzer(_services, cacheFolderPath);
+            var analyzer = new PythonAnalyzer(_services);
             _services.AddService(analyzer);
 
             analyzer.AnalysisComplete += OnAnalysisComplete;

--- a/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
@@ -58,14 +58,14 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         private void EnableProfileOptimization() {
-            var cachService = _services.GetService<ICacheFolderService>();
-            if (cachService == null) {
+            var cacheService = _services.GetService<ICacheFolderService>();
+            if (cacheService == null) {
                 return;
             }
 
             try {
                 // create directory for profile optimization
-                var path = Path.Combine(cachService.CacheFolder, "Profiles");
+                var path = Path.Combine(cacheService.CacheFolder, "Profiles");
                 Directory.CreateDirectory(path);
 
                 ProfileOptimization.SetProfileRoot(path);

--- a/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             using (await _prioritizer.InitializePriorityAsync(cancellationToken)) {
                 // Force the next handled request to be "initialized", where the work actually happens.
                 _initializedPriorityTask = _prioritizer.InitializePriorityAsync(default);
-                return await _server.InitializeAsync(_initParams, cancellationToken);
+                var result = await _server.InitializeAsync(_initParams, cancellationToken);
+
+                EnableProfileOptimization();
+                return result;
             }
         }
 
@@ -51,8 +54,6 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
                 await _server.InitializedAsync(ToObject<InitializedParams>(token), cancellationToken, userConfiguredPaths);
                 await _rpc.NotifyAsync("python/languageServerStarted");
-
-                EnableProfileOptimization();
             }
         }
 

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         private readonly CancellationTokenSource _shutdownCts = new CancellationTokenSource();
         private readonly AnalysisOptionsProvider _optionsProvider = new AnalysisOptionsProvider();
 
-        private IServiceContainer _services;
+        private IServiceManager _services;
         private Server _server;
         private ILogger _logger;
         private ITelemetryService _telemetry;

--- a/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
+++ b/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
@@ -11,7 +11,7 @@
         <DebugType>portable</DebugType>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <NoWarn>1701;1702;$(NoWarn)</NoWarn>
-        <LangVersion>7.2</LangVersion>
+      <TieredCompilation>true</TieredCompilation>
       </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
       <CodeAnalysisRuleSet>..\..\PLS.ruleset</CodeAnalysisRuleSet>

--- a/src/LanguageServer/Impl/Optimization/IProfileOptimizationService.cs
+++ b/src/LanguageServer/Impl/Optimization/IProfileOptimizationService.cs
@@ -1,0 +1,28 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Runtime;
+
+namespace Microsoft.Python.LanguageServer.Optimization {
+    /// <summary>
+    /// Service to enable profile based optimization
+    /// 
+    /// See <see cref="ProfileOptimization" /> for more detail
+    /// </summary>
+    internal interface IProfileOptimizationService {
+        void Profile(string name);
+    }
+}

--- a/src/LanguageServer/Impl/Optimization/ProfileOptimizationService.cs
+++ b/src/LanguageServer/Impl/Optimization/ProfileOptimizationService.cs
@@ -1,0 +1,47 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.IO;
+using System.Runtime;
+using Microsoft.Python.Analysis.Caching;
+using Microsoft.Python.Core;
+using Microsoft.Python.Core.IO;
+
+namespace Microsoft.Python.LanguageServer.Optimization {
+    internal sealed class ProfileOptimizationService : IProfileOptimizationService {
+        public ProfileOptimizationService(IServiceContainer services) {
+            var fileSystem = services.GetService<IFileSystem>();
+            var cacheService = services.GetService<ICacheFolderService>();
+            if (fileSystem == null || cacheService == null) {
+                return;
+            }
+
+            try {
+                // create directory for profile optimization
+                var path = Path.Combine(cacheService.CacheFolder, "Profiles");
+                fileSystem.CreateDirectory(path);
+
+                ProfileOptimization.SetProfileRoot(path);
+            } catch {
+                // ignore any issue with profiling
+            }
+        }
+
+        public void Profile(string name) {
+            ProfileOptimization.StartProfile(name);
+        }
+    }
+}

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -19,6 +19,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime;
+using Microsoft.Python.Core;
 using Microsoft.Python.Core.IO;
 using Microsoft.Python.Core.OS;
 using Microsoft.Python.Core.Services;
@@ -78,7 +79,7 @@ namespace Microsoft.Python.LanguageServer.Server {
         private static void EnableProfileOptimization() {
             try {
                 // create directory for profile optimization
-                var path = Path.Combine(Path.GetTempPath(), "PythonLanguageServer", "Profiles");
+                var path = Path.Combine(Path.GetTempPath(), "PythonLanguageServer", GetUserName(), "Profiles");
                 Directory.CreateDirectory(path);
 
                 ProfileOptimization.SetProfileRoot(path);
@@ -86,6 +87,11 @@ namespace Microsoft.Python.LanguageServer.Server {
             } catch {
                 // ignore any issue with profiling
             }
+        }
+
+        private static string GetUserName() {
+            var userName = Environment.UserName ?? "NoName";
+            return userName.GetHashString();
         }
 
         private static void CheckDebugMode() {

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -18,8 +18,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime;
-using Microsoft.Python.Core;
 using Microsoft.Python.Core.IO;
 using Microsoft.Python.Core.OS;
 using Microsoft.Python.Core.Services;
@@ -33,8 +31,6 @@ namespace Microsoft.Python.LanguageServer.Server {
     internal static class Program {
         public static void Main(string[] args) {
             CheckDebugMode();
-
-            EnableProfileOptimization();
 
             using (CoreShell.Create()) {
                 var services = CoreShell.Current.ServiceManager;
@@ -74,24 +70,6 @@ namespace Microsoft.Python.LanguageServer.Server {
                     token.WaitHandle.WaitOne();
                 }
             }
-        }
-
-        private static void EnableProfileOptimization() {
-            try {
-                // create directory for profile optimization
-                var path = Path.Combine(Path.GetTempPath(), "PythonLanguageServer", GetUserName(), "Profiles");
-                Directory.CreateDirectory(path);
-
-                ProfileOptimization.SetProfileRoot(path);
-                ProfileOptimization.StartProfile("profile");
-            } catch {
-                // ignore any issue with profiling
-            }
-        }
-
-        private static string GetUserName() {
-            var userName = Environment.UserName ?? "NoName";
-            return userName.GetHashString();
         }
 
         private static void CheckDebugMode() {

--- a/src/LanguageServer/Impl/Program.cs
+++ b/src/LanguageServer/Impl/Program.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime;
 using Microsoft.Python.Core.IO;
 using Microsoft.Python.Core.OS;
 using Microsoft.Python.Core.Services;
@@ -31,6 +32,9 @@ namespace Microsoft.Python.LanguageServer.Server {
     internal static class Program {
         public static void Main(string[] args) {
             CheckDebugMode();
+
+            EnableProfileOptimization();
+
             using (CoreShell.Create()) {
                 var services = CoreShell.Current.ServiceManager;
 
@@ -68,6 +72,19 @@ namespace Microsoft.Python.LanguageServer.Server {
                     // Wait for the "exit" request, it will terminate the process.
                     token.WaitHandle.WaitOne();
                 }
+            }
+        }
+
+        private static void EnableProfileOptimization() {
+            try {
+                // create directory for profile optimization
+                var path = Path.Combine(Path.GetTempPath(), "PythonLanguageServer", "Profiles");
+                Directory.CreateDirectory(path);
+
+                ProfileOptimization.SetProfileRoot(path);
+                ProfileOptimization.StartProfile("profile");
+            } catch {
+                // ignore any issue with profiling
             }
         }
 

--- a/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
+++ b/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Python.Parsing</RootNamespace>
     <AssemblyName>Microsoft.Python.Parsing</AssemblyName>
   </PropertyGroup>
@@ -9,7 +9,7 @@
       1701, 1702 - "You may need to supply assembly policy"
     -->
     <NoWarn>1701;1702;$(NoWarn)</NoWarn>
-    <LangVersion>7.2</LangVersion>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <Import Project="..\..\..\build\NetStandard.settings" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
+++ b/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Parsing</RootNamespace>
     <AssemblyName>Microsoft.Python.Parsing</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
and take advantage of ProfileOptimization (https://docs.microsoft.com/en-us/dotnet/api/system.runtime.profileoptimization?view=netcore-3.0) to make starting time faster 

some experiment user did on the web - https://www.dotnetperls.com/profileoptimization

...

confirmed that background JIT (multicore jit) and tiered compilation are enabled using perfview with background jit option

![image](https://user-images.githubusercontent.com/1333179/67820236-aa7dce80-fa75-11e9-87f4-f05edcfb7d9d.png)

and confirmed things like parsing, analysis code is concurrently jitted from BG.
also, as vscode is used longer, I see more tiered compilation happens.

for now, I added profile optimization only on startup code path, but it is not actually limited to start-up scenario, one can put it any place where we want concurrent jit with different profile name such as "find all references" or "rename" and etc if there are bunch of code that needs to be jitted lazily.