### PR TITLE
Don't lint "no-method-argument" until user types (

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Symbols/FunctionEvaluator.cs
@@ -133,6 +133,11 @@ namespace Microsoft.Python.Analysis.Analyzer.Symbols {
                 return;
             }
 
+            // Error in parameters, don't lint
+            if (FunctionDefinition.Body == null) {
+                return;
+            }
+
             // Otherwise, functions defined in classes must have at least one argument
             if (parameters.IsNullOrEmpty()) {
                 var funcLoc = Eval.GetLocation(FunctionDefinition.NameExpression);

--- a/src/Analysis/Ast/Test/LintNoMethodArgumentTests.cs
+++ b/src/Analysis/Ast/Test/LintNoMethodArgumentTests.cs
@@ -122,5 +122,15 @@ class Test(type):
             var analysis = await GetAnalysisAsync(code);
             analysis.Diagnostics.Should().BeEmpty();
         }
+
+        [TestMethod, Priority(0)]
+        public async Task NoDiagnosticNoParameters() {
+            const string code = @"
+class test:
+    def walk
+";
+            var analysis = await GetAnalysisAsync(code);
+            analysis.Diagnostics.Should().BeEmpty();
+        }
     }
 }


### PR DESCRIPTION
Fixes #1695 

Figured I should clean that up.

When there is an error in parameters, `FunctionDefinition.Body` will be null, parameters field is never null. 