### PR TITLE
Track codeAction RPC time and count

### DIFF
--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -217,12 +217,11 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         [JsonRpcMethod("textDocument/codeAction")]
         public async Task<CodeAction[]> CodeAction(JToken token, CancellationToken cancellationToken) {
-            using (var timer = _requestTimer.Time("textDocument/codeAction")) {
-                await _prioritizer.DefaultPriorityAsync(cancellationToken);
-                var actions = await _server.CodeAction(ToObject<CodeActionParams>(token), cancellationToken);
-                timer.AddMeasure("count", actions?.Length ?? 0);
-                return actions;
-            }
+            using var timer = _requestTimer.Time("textDocument/codeAction");
+            await _prioritizer.DefaultPriorityAsync(cancellationToken);
+            var actions = await _server.CodeAction(ToObject<CodeActionParams>(token), cancellationToken);
+            timer.AddMeasure("count", actions?.Length ?? 0);
+            return actions;
         }
 
         //[JsonRpcMethod("textDocument/codeLens")]

--- a/src/LanguageServer/Impl/LanguageServer.cs
+++ b/src/LanguageServer/Impl/LanguageServer.cs
@@ -217,8 +217,12 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         [JsonRpcMethod("textDocument/codeAction")]
         public async Task<CodeAction[]> CodeAction(JToken token, CancellationToken cancellationToken) {
-            await _prioritizer.DefaultPriorityAsync(cancellationToken);
-            return await _server.CodeAction(ToObject<CodeActionParams>(token), cancellationToken);
+            using (var timer = _requestTimer.Time("textDocument/codeAction")) {
+                await _prioritizer.DefaultPriorityAsync(cancellationToken);
+                var actions = await _server.CodeAction(ToObject<CodeActionParams>(token), cancellationToken);
+                timer.AddMeasure("count", actions?.Length ?? 0);
+                return actions;
+            }
         }
 
         //[JsonRpcMethod("textDocument/codeLens")]


### PR DESCRIPTION
Since this is a longer call, send an event for it with the count.