### PR TITLE
Disable caching regardless of user level

### DIFF
--- a/src/LanguageServer/Impl/LanguageServer.Configuration.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Configuration.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Python.LanguageServer.Implementation {
 
         private AnalysisCachingLevel GetAnalysisCachingLevel(JToken analysisKey) {
             // TODO: Remove this one caching is working at any level again.
+            // https://github.com/microsoft/python-language-server/issues/1758
             return AnalysisCachingLevel.None;
 
             // var s = GetSetting(analysisKey, "cachingLevel", DefaultCachingLevel);

--- a/src/LanguageServer/Impl/LanguageServer.Configuration.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Configuration.cs
@@ -185,17 +185,20 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         private const string DefaultCachingLevel = "None";
 
         private AnalysisCachingLevel GetAnalysisCachingLevel(JToken analysisKey) {
-            var s = GetSetting(analysisKey, "cachingLevel", DefaultCachingLevel);
-            
-            if (string.IsNullOrWhiteSpace(s) || s.EqualsIgnoreCase("Default")) {
-                s = DefaultCachingLevel;
-            }
+            // TODO: Remove this one caching is working at any level again.
+            return AnalysisCachingLevel.None;
 
-            if (s.EqualsIgnoreCase("System")) {
-                return AnalysisCachingLevel.System;
-            }
-
-            return s.EqualsIgnoreCase("Library") ? AnalysisCachingLevel.Library : AnalysisCachingLevel.None;
+            // var s = GetSetting(analysisKey, "cachingLevel", DefaultCachingLevel);
+            // 
+            // if (string.IsNullOrWhiteSpace(s) || s.EqualsIgnoreCase("Default")) {
+            //     s = DefaultCachingLevel;
+            // }
+            // 
+            // if (s.EqualsIgnoreCase("System")) {
+            //     return AnalysisCachingLevel.System;
+            // }
+            // 
+            // return s.EqualsIgnoreCase("Library") ? AnalysisCachingLevel.Library : AnalysisCachingLevel.None;
         }
     }
 }


### PR DESCRIPTION
For #1758.

Since caching does not currently work at _any_ level, disable it regardless of the user setting for now until it's working properly to prevent looping on users who have changed the setting.

This should be reverted in #1757.