### PR TITLE
Do not attempt to walk null body in EvaluateCall

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/Evaluation/FunctionCallEvaluator.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Evaluation/FunctionCallEvaluator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Python.Analysis.Analyzer.Evaluation {
             // Open scope and declare parameters
             using (_eval.OpenScope(_declaringModule, _function, out _)) {
                 args.DeclareParametersInScope(_eval);
-                _function.Body.Walk(this);
+                _function.Body?.Walk(this);
             }
             return _result;
         }


### PR DESCRIPTION
Fixes #1768.

The body may be null (not present), so cannot have `Walk` called on it. Matches other instances of `Body?.Walk` in other parts of the code.