### PR TITLE
Log parse exceptions instead of just throwing them away

### DIFF
--- a/src/Analysis/Ast/Impl/Modules/PythonModule.cs
+++ b/src/Analysis/Ast/Impl/Modules/PythonModule.cs
@@ -313,7 +313,16 @@ namespace Microsoft.Python.Analysis.Modules {
             _linkedParseCts = CancellationTokenSource.CreateLinkedTokenSource(_disposeToken.CancellationToken, _parseCts.Token);
 
             ContentState = State.Parsing;
-            _parsingTask = Task.Run(() => Parse(_linkedParseCts.Token), _linkedParseCts.Token);
+            _parsingTask = Task.Run(() => ParseAndLogExceptions(_linkedParseCts.Token), _linkedParseCts.Token);
+        }
+
+        private void ParseAndLogExceptions(CancellationToken cancellationToken) {
+            try {
+                Parse(cancellationToken);
+            } catch (Exception ex) when (!(ex is OperationCanceledException)) {
+                Log?.Log(TraceEventType.Warning, $"Exception while parsing {FilePath}: {ex}");
+                throw;
+            }
         }
 
         private void Parse(CancellationToken cancellationToken) {


### PR DESCRIPTION
Debugging for #1776.

Doesn't fix the core issue that we're spawning tasks we can't keep track of, but helps trying to find the crashes.