### PR TITLE
Update NuGet deps and consolidate

### DIFF
--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="get_search_paths.py">

--- a/src/Analysis/Ast/Test/Microsoft.Python.Analysis.Tests.csproj
+++ b/src/Analysis/Ast/Test/Microsoft.Python.Analysis.Tests.csproj
@@ -23,8 +23,8 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">

--- a/src/Caching/Test/Microsoft.Python.Analysis.Caching.Tests.csproj
+++ b/src/Caching/Test/Microsoft.Python.Analysis.Caching.Tests.csproj
@@ -17,7 +17,7 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="NewtonSoft.Json" Version="12.0.1" />
+    <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Analysis\Ast\Impl\Microsoft.Python.Analysis.csproj" />

--- a/src/Core/Impl/Microsoft.Python.Core.csproj
+++ b/src/Core/Impl/Microsoft.Python.Core.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/Core/Test/Microsoft.Python.Core.Tests.csproj
+++ b/src/Core/Test/Microsoft.Python.Core.Tests.csproj
@@ -27,8 +27,8 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">

--- a/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
+++ b/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
@@ -29,9 +29,9 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
-        <PackageReference Include="NewtonSoft.Json" Version="12.0.2" />
-        <PackageReference Include="StreamJsonRpc" Version="2.1.55" />
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0" />
+        <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
+        <PackageReference Include="StreamJsonRpc" Version="2.2.34" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\Analysis\Ast\Impl\Microsoft.Python.Analysis.csproj" />

--- a/src/LanguageServer/Test/Microsoft.Python.LanguageServer.Tests.csproj
+++ b/src/LanguageServer/Test/Microsoft.Python.LanguageServer.Tests.csproj
@@ -23,8 +23,8 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">

--- a/src/Parsing/Test/Microsoft.Python.Parsing.Tests.csproj
+++ b/src/Parsing/Test/Microsoft.Python.Parsing.Tests.csproj
@@ -27,8 +27,8 @@
     <None Remove="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">


### PR DESCRIPTION
For #1776.

Newtonsoft JSON dep was mismatched between assemblies. Updating everything (globbing should match versions with .NET Core 3.0) to make sure we're consolidated.