### PR TITLE
Send root URI as workspace/configuration scope

### DIFF
--- a/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
+++ b/src/LanguageServer/Impl/LanguageServer.Lifetime.cs
@@ -74,7 +74,10 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                     }
                     var args = new ConfigurationParams {
                         items = new[] {
-                            new ConfigurationItem { section = "python" }
+                            new ConfigurationItem {
+                                scopeUri = _initParams.rootUri,
+                                section = "python"
+                            }
                         }
                     };
                     var configs = await _rpc.InvokeWithParameterObjectAsync<JToken>("workspace/configuration", args, cancellationToken);


### PR DESCRIPTION
For #1776.

Send the workspace root URI as the scope of the workspace configuration request. This may be needed to pick up some workspace-specific configuration.