### PR TITLE
Do not double-walk try and while statement bodies

### DIFF
--- a/src/Analysis/Ast/Impl/Analyzer/AnalysisWalker.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/AnalysisWalker.cs
@@ -85,18 +85,12 @@ namespace Microsoft.Python.Analysis.Analyzer {
         public override bool Walk(ImportStatement node) => ImportHandler.HandleImport(node);
         public override bool Walk(NonlocalStatement node) => NonLocalHandler.HandleNonLocal(node);
 
-        public override bool Walk(TryStatement node) {
-            TryExceptHandler.HandleTryExcept(node);
-            return base.Walk(node);
-        }
+        public override bool Walk(TryStatement node) => TryExceptHandler.HandleTryExcept(node);
 
-        public override bool Walk(WhileStatement node) {
-            LoopHandler.HandleWhile(node);
-            return base.Walk(node);
-        }
+        public override bool Walk(WhileStatement node) => LoopHandler.HandleWhile(node);
 
         public override bool Walk(WithStatement node) {
-            WithHandler.HandleWith(node);
+            WithHandler.HandleWith(node); // HandleWith does not walk the body.
             return base.Walk(node);
         }
         #endregion

--- a/src/Analysis/Ast/Impl/Analyzer/Handlers/LoopHandler.cs
+++ b/src/Analysis/Ast/Impl/Analyzer/Handlers/LoopHandler.cs
@@ -44,9 +44,10 @@ namespace Microsoft.Python.Analysis.Analyzer.Handlers {
             return false;
         }
 
-        public void HandleWhile(WhileStatement node) {
+        public bool HandleWhile(WhileStatement node) {
             node.Body?.Walk(Walker);
             node.ElseStatement?.Walk(Walker);
+            return false;
         }
     }
 }

--- a/src/Analysis/Ast/Test/ImportTests.cs
+++ b/src/Analysis/Ast/Test/ImportTests.cs
@@ -219,6 +219,22 @@ x = f()
         }
 
         [TestMethod, Priority(0)]
+        public async Task UnresolvedImportInTry() {
+            var analysis = await GetAnalysisAsync(@"
+def foo():
+    try:
+        import nonexistent
+    except:
+        pass
+");
+            analysis.Diagnostics.Should().HaveCount(1);
+            var d = analysis.Diagnostics.First();
+            d.ErrorCode.Should().Be(ErrorCodes.UnresolvedImport);
+            d.SourceSpan.Should().Be(4, 16, 4, 27);
+            d.Message.Should().Be(Resources.ErrorUnresolvedImport.FormatInvariant("nonexistent"));
+        }
+
+        [TestMethod, Priority(0)]
         public async Task FromFuture() {
             var analysis = await GetAnalysisAsync(@"from __future__ import print_function", PythonVersions.LatestAvailable2X);
             analysis.Diagnostics.Should().BeEmpty();


### PR DESCRIPTION
Fixes #1775.

Try and while blocks were being walked twice, producing double diagnostics for code inside, as well as a likely performance hit from doing the same thing twice.

Need to run some more tests to make sure this isn't a regression (since I'm effectively removing a whole lot of walking on very common syntactic blocks).