### PR TITLE
Bschnurr/Microsoft.Python.Parsing nuget publish

### DIFF
--- a/src/Analysis/Ast/Impl/Microsoft-Python-Analysis.nuspec
+++ b/src/Analysis/Ast/Impl/Microsoft-Python-Analysis.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft-Python-Analysis</id>
+    <id>Microsoft.Python.Analysis</id>
     <version>$version$</version>
     <title>Microsoft Python Static Analysis</title>
     <authors>Microsoft</authors>

--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -1023,11 +1023,6 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <ItemGroup>
-    <None Update="Microsoft-Python-Analysis.nuspec">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\..\..\build\NetStandard.targets" />
 </Project>

--- a/src/LanguageServer/Impl/Python-Language-Server.nuspec
+++ b/src/LanguageServer/Impl/Python-Language-Server.nuspec
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Microsoft Python Language Server</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright (c) 2018-2019</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>Python;VS Code</tags>
   </metadata>
   <files>

--- a/src/Parsing/Impl/Microsoft-Python-Parsing.nuspec
+++ b/src/Parsing/Impl/Microsoft-Python-Parsing.nuspec
@@ -1,7 +1,7 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.Python.Analysis</id>
+    <id>Microsoft.Python.Parsing</id>
     <version>$version$</version>
     <title>Microsoft Python Static Analysis</title>
     <authors>Microsoft</authors>
@@ -10,7 +10,7 @@
     <licenseUrl>https://github.com/Microsoft/python-language-server/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/python-language-server</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Microsoft Python Static Code Analysis Engine</description>
+    <description>Microsoft Python Parsing Library</description>
     <releaseNotes>Initial release.</releaseNotes>
     <copyright>Copyright (c) 2018-2019</copyright>
     <tags>Python</tags>
@@ -20,10 +20,6 @@
   </metadata>
   <files>
     <file src="Microsoft.Python.Core.dll" target="lib\netstandard2.0\Microsoft.Python.Core.dll" />
-    <file src="Microsoft.Python.Analysis.Core.dll" target="lib\netstandard2.0\Microsoft.Python.Analysis.Core.dll" />
     <file src="Microsoft.Python.Parsing.dll" target="lib\netstandard2.0\Microsoft.Python.Parsing.dll" />
-    <file src="Microsoft.Python.Analysis.dll" target="lib\netstandard2.0\Microsoft.Python.Analysis.dll" />
-    <file src="get_search_paths.py" target="lib\netstandard2.0\get_search_paths.py" />
-    <file src="scrape_module.py" target="lib\netstandard2.0\scrape_module.py" />
   </files>
 </package>

--- a/src/Parsing/Impl/Microsoft-Python-Parsing.nuspec
+++ b/src/Parsing/Impl/Microsoft-Python-Parsing.nuspec
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Microsoft Python Parsing Library</description>
     <releaseNotes>Initial release.</releaseNotes>
-    <copyright>Copyright (c) 2018-2019</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>Python</tags>
     <dependencies>
       <dependency id="Microsoft.Extensions.FileSystemGlobbing" version="2.2" />

--- a/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
+++ b/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
@@ -35,6 +35,11 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <None Update="Microsoft-Python-Parsing.nuspec">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\..\build\NetStandard.targets" />
 </Project>

--- a/src/Publish/SignLayout.csproj
+++ b/src/Publish/SignLayout.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup Condition="$(SignPackage)">
     <SignFiles Include="$(OutputPath)\Python-Language-Server-*.nupkg" />
-    <SignFiles Include="$(OutputPath)\Microsoft-Python-Analysis-*.nupkg" />
+    <SignFiles Include="$(OutputPath)\Microsoft.Python.Analysis*.nupkg" />
   </ItemGroup>
 
   <Target Name="_CheckFiles" BeforeTargets="SignFiles">

--- a/src/Publish/SignLayout.csproj
+++ b/src/Publish/SignLayout.csproj
@@ -8,7 +8,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <SignEngine Condition="$(SignEngine) == ''">false</SignEngine>
+    <SignParse Condition="$(SignParse) == ''">false</SignParse>
     <SignServer Condition="$(SignServer) == ''">false</SignServer>
     <SignPackage Condition="$(SignPackage) == ''">false</SignPackage>
   </PropertyGroup>
@@ -26,11 +26,9 @@
   <Target Name="CoreCompile" />
   <Target Name="CopyFilesToOutputDirectory" />
 
-  <ItemGroup Condition="$(SignEngine)">
+  <ItemGroup Condition="$(SignParse)">
     <SignFiles Include="$(OutputPath)\Microsoft.Python.Core.dll" />
     <SignFiles Include="$(OutputPath)\Microsoft.Python.Parsing.dll" />
-    <SignFiles Include="$(OutputPath)\Microsoft.Python.Analysis.Core.dll" />
-    <SignFiles Include="$(OutputPath)\Microsoft.Python.Analysis.dll" />
   </ItemGroup>
 
   <ItemGroup Condition="$(SignServer)">

--- a/src/Publish/SignLayout.csproj
+++ b/src/Publish/SignLayout.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup Condition="$(SignPackage)">
     <SignFiles Include="$(OutputPath)\Python-Language-Server-*.nupkg" />
-    <SignFiles Include="$(OutputPath)\Microsoft.Python.Analysis*.nupkg" />
+    <SignFiles Include="$(OutputPath)\Microsoft.Python.Parsing*.nupkg" />
   </ItemGroup>
 
   <Target Name="_CheckFiles" BeforeTargets="SignFiles">

--- a/src/Publish/SignLayout.csproj
+++ b/src/Publish/SignLayout.csproj
@@ -8,7 +8,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <SignParse Condition="$(SignParse) == ''">false</SignParse>
+    <SignParser Condition="$(SignParser) == ''">false</SignParser>
     <SignServer Condition="$(SignServer) == ''">false</SignServer>
     <SignPackage Condition="$(SignPackage) == ''">false</SignPackage>
   </PropertyGroup>
@@ -26,7 +26,7 @@
   <Target Name="CoreCompile" />
   <Target Name="CopyFilesToOutputDirectory" />
 
-  <ItemGroup Condition="$(SignParse)">
+  <ItemGroup Condition="$(SignParser)">
     <SignFiles Include="$(OutputPath)\Microsoft.Python.Core.dll" />
     <SignFiles Include="$(OutputPath)\Microsoft.Python.Parsing.dll" />
   </ItemGroup>


### PR DESCRIPTION
- Bundling Microsoft.Python.Parsing into a nuget package for PTVS
- Removing the old Anaylsis nuget bundle
- Updating copywrite info to pass nuget push command verification
https://aka.ms/Microsoft-NuGet-Compliance
- Updating signing to sign Microsoft.Python.Parsing package instead of analysis
