### PR TITLE
Porting PTVS LSClient

### DIFF
--- a/src/PLS.sln
+++ b/src/PLS.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Python.Analysis.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Python.Analysis.Caching.Tests", "Caching\Test\Microsoft.Python.Analysis.Caching.Tests.csproj", "{40CD3A74-B0B6-4A37-AE65-5B203C38D0E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests.LanguageServerClient", "UnitTests\LanguageServerClient\UnitTests.LanguageServerClient\UnitTests.LanguageServerClient.csproj", "{ECF43B73-5A46-4310-8B11-FFF2B098C9DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,10 @@ Global
 		{40CD3A74-B0B6-4A37-AE65-5B203C38D0E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40CD3A74-B0B6-4A37-AE65-5B203C38D0E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40CD3A74-B0B6-4A37-AE65-5B203C38D0E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECF43B73-5A46-4310-8B11-FFF2B098C9DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECF43B73-5A46-4310-8B11-FFF2B098C9DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECF43B73-5A46-4310-8B11-FFF2B098C9DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECF43B73-5A46-4310-8B11-FFF2B098C9DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,6 +108,7 @@ Global
 		{3BAB87E1-79FD-45D1-8564-CAF87D4D16CA} = {80AA38A1-3E82-4B87-BB21-FDEDD2CC87E6}
 		{42BD3C80-3E57-4847-8142-84F6B682EA8D} = {C465393D-145E-4695-A7DB-AF55951BD533}
 		{40CD3A74-B0B6-4A37-AE65-5B203C38D0E2} = {80AA38A1-3E82-4B87-BB21-FDEDD2CC87E6}
+		{ECF43B73-5A46-4310-8B11-FFF2B098C9DF} = {80AA38A1-3E82-4B87-BB21-FDEDD2CC87E6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABC12ED7-0EC8-4219-8A14-A058F7942D92}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/IPythonLanguageClientContext.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/IPythonLanguageClientContext.cs
@@ -1,0 +1,34 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Python.Analysis.Core.Interpreter;
+
+namespace UnitTests.LanguageServerClient {
+    public interface IPythonLanguageClientContext : ICloneable {
+        string ContentTypeName { get; }
+
+        string RootPath { get; }
+        InterpreterConfiguration InterpreterConfiguration { get; }
+
+        IEnumerable<string> SearchPaths { get; }
+
+        event EventHandler InterpreterChanged;
+        event EventHandler SearchPathsChanged;
+        event EventHandler Closed;
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/Mocks/MockLanguageClientBroker.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/Mocks/MockLanguageClientBroker.cs
@@ -1,0 +1,71 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using StreamJsonRpc;
+
+namespace UnitTests.LanguageServerClient.Mocks {
+    /// <summary>
+    /// Minimal version of the broker used by VS
+    /// (which is internal and so we can't instantiate).
+    /// Note that this requires StreamJsonRpc to run, which in turn depends on
+    /// a lot of other dlls that are normally available in VS install, but that
+    /// need to be referenced by the test project in order to run outside VS.
+    /// </summary>
+    public class MockLanguageClientBroker : ILanguageClientBroker {
+        private JsonRpc _rpc;
+
+        public async Task LoadAsync(ILanguageClientMetadata metadata, ILanguageClient client) {
+            if (client == null) {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            client.StartAsync += Client_StartAsync;
+            await client.OnLoadedAsync();
+        }
+
+        private async Task Client_StartAsync(object sender, EventArgs args) {
+            var client = (ILanguageClient)sender;
+            var connection = await client.ActivateAsync(new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token);
+            await InitializeAsync(client, connection);
+        }
+
+        private async Task InitializeAsync(ILanguageClient client, Connection connection) {
+            var messageHandler = new HeaderDelimitedMessageHandler(connection.Writer, connection.Reader);
+            _rpc = new JsonRpc(messageHandler, this) {
+                CancelLocallyInvokedMethodsWhenConnectionIsClosed = true
+            };
+
+            _rpc.StartListening();
+
+            (client as ILanguageClientCustomMessage2)?.AttachForCustomMessageAsync(_rpc);
+
+            var initParam = new InitializeParams {
+                ProcessId = Process.GetCurrentProcess().Id,
+                InitializationOptions = client.InitializationOptions
+            };
+
+            await _rpc.InvokeWithParameterObjectAsync(Methods.Initialize.Name, initParam, cancellationToken: CancellationToken.None);
+            await _rpc.NotifyWithParameterObjectAsync(Methods.Initialized.Name, new InitializedParams());
+            await client.OnServerInitializedAsync();
+        }
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClient.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClient.cs
@@ -1,0 +1,273 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Python.Core.Disposables;
+using Microsoft.Python.Parsing;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.LanguageServerClient {
+    /// <summary>
+    /// Implementation of the language server client.
+    /// </summary>
+    /// <remarks>
+    /// See documentation at https://docs.microsoft.com/en-us/visualstudio/extensibility/adding-an-lsp-extension?view=vs-2019
+    /// </remarks>
+    public class PythonLanguageClient : ILanguageClient, ILanguageClientCustomMessage2, IDisposable {
+        private readonly JoinableTaskContext _joinableTaskContext;
+        private readonly IPythonLanguageClientContext _clientContext;
+        private readonly DisposableBag _disposables;
+        private PythonLanguageServer _server;
+        private JsonRpc _rpc;
+
+        private static readonly List<PythonLanguageClient> _languageClients = new List<PythonLanguageClient>();
+
+        private PythonLanguageClient(
+            JoinableTaskContext joinableTaskContext,
+            IPythonLanguageClientContext clientContext
+        ) {
+            _joinableTaskContext = joinableTaskContext ?? throw new ArgumentNullException(nameof(joinableTaskContext));
+            _clientContext = clientContext ?? throw new ArgumentNullException(nameof(clientContext));
+            _disposables = new DisposableBag(GetType().Name);
+
+            _clientContext.Closed += OnClosed;
+
+            _disposables.Add(() => {
+                _clientContext.Closed -= OnClosed;
+            });
+
+            if (clientContext is IDisposable disposable) {
+                _disposables.Add(disposable);
+            }
+
+            CustomMessageTarget = new PythonLanguageClientCustomTarget();
+        }
+
+        public static async Task EnsureLanguageClientAsync(
+            JoinableTaskContext joinableTaskContext,
+            IPythonLanguageClientContext clientContext,
+            ILanguageClientBroker broker
+        ) {
+            if (clientContext == null) {
+                throw new ArgumentNullException(nameof(clientContext));
+            }
+
+            if (broker == null) {
+                throw new ArgumentNullException(nameof(broker));
+            }
+
+            PythonLanguageClient client = null;
+            lock (_languageClients) {
+                if (!_languageClients.Any(lc => lc.ContentTypeName == clientContext.ContentTypeName)) {
+                    client = new PythonLanguageClient(joinableTaskContext, clientContext);
+                    _languageClients.Add(client);
+                }
+            }
+
+            if (client != null) {
+                await broker.LoadAsync(new PythonLanguageClientMetadata(null, clientContext.ContentTypeName), client);
+            }
+        }
+
+        public static PythonLanguageClient FindLanguageClient(string contentTypeName) {
+            if (contentTypeName == null) {
+                throw new ArgumentNullException(nameof(contentTypeName));
+            }
+
+            lock (_languageClients) {
+                return _languageClients.SingleOrDefault(lc => lc.ContentTypeName == contentTypeName);
+            }
+        }
+
+
+        public static void DisposeLanguageClient(string contentTypeName) {
+            if (contentTypeName == null) {
+                throw new ArgumentNullException(nameof(contentTypeName));
+            }
+
+            PythonLanguageClient client = null;
+            lock (_languageClients) {
+                client = _languageClients.SingleOrDefault(lc => lc.ContentTypeName == contentTypeName);
+                if (client != null) {
+                    _languageClients.Remove(client);
+                    client.Stop();
+                    client.Dispose();
+                }
+            }
+        }
+
+        public string ContentTypeName => _clientContext.ContentTypeName;
+
+        public string Name => "Python Language Extension";
+
+        public IEnumerable<string> ConfigurationSections {
+            get {
+                // Called by Microsoft.VisualStudio.LanguageServer.Client.RemoteLanguageServiceBroker.UpdateClientsWithConfigurationSettingsAsync
+                // Used to send LS WorkspaceDidChangeConfiguration notification
+                yield return "python";
+            }
+        }
+
+        // called from Microsoft.VisualStudio.LanguageServer.Client.RemoteLanguageClientInstance.InitializeAsync
+        // which sets Capabilities, RootPath, ProcessId, and InitializationOptions (to this property value)
+        // initParam.Capabilities.TextDocument.Rename = new DynamicRegistrationSetting(false); ??
+        // 
+        // in vscode, the equivalent is in src/client/activation/languageserver/analysisoptions
+        public object InitializationOptions { get; private set; }
+
+        // TODO: what do we do with this?
+        public IEnumerable<string> FilesToWatch => null;
+
+        public object MiddleLayer { get; private set; }
+
+        public object CustomMessageTarget { get; private set; }
+
+        public bool IsInitialized { get; private set; }
+
+        public event AsyncEventHandler<EventArgs> StartAsync;
+
+#pragma warning disable CS0067
+        public event AsyncEventHandler<EventArgs> StopAsync;
+#pragma warning restore CS0067
+
+        public async Task<Connection> ActivateAsync(CancellationToken token) {
+            if (_server == null) {
+                Debug.Fail("Should not have called StartAsync when _server is null.");
+                return null;
+            }
+
+            return await _server.ActivateAsync();
+        }
+
+        public async Task OnLoadedAsync() {
+            await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
+            var interpreterPath = _clientContext.InterpreterConfiguration?.InterpreterPath;
+            var version = _clientContext.InterpreterConfiguration?.Version;
+            var searchPaths = _clientContext.SearchPaths.ToList();
+            string rootPath = _clientContext.RootPath;
+
+            if (string.IsNullOrEmpty(interpreterPath)) {
+                throw new ArgumentException();
+            }
+
+            PythonLanguageVersion langVersion;
+            try {
+                langVersion = version.ToLanguageVersion();
+            } catch (InvalidOperationException) {
+                langVersion = PythonLanguageVersion.None;
+            }
+
+            _server = PythonLanguageServer.Create(_joinableTaskContext, langVersion);
+            if (_server == null) {
+                return;
+            }
+            _disposables.Add(_server);
+
+            InitializationOptions = _server.CreateInitializationOptions(
+                interpreterPath,
+                version.ToString(),
+                rootPath,
+                searchPaths
+            );
+
+            await StartAsync.InvokeAsync(this, EventArgs.Empty);
+        }
+
+        public Task OnServerInitializedAsync() {
+            IsInitialized = true;
+            return Task.CompletedTask;
+        }
+
+        public Task OnServerInitializeFailedAsync(Exception e) {
+            // MessageBox.Show(Strings.LanguageClientInitializeFailed.FormatUI(e), Strings.ProductTitle);
+            return Task.CompletedTask;
+        }
+
+        public Task AttachForCustomMessageAsync(JsonRpc rpc) {
+            _rpc = rpc;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() {
+            _disposables.TryDispose();
+        }
+
+        public Task InvokeTextDocumentDidOpenAsync(LSP.DidOpenTextDocumentParams request) {
+            if (_rpc == null) {
+                return Task.CompletedTask;
+            }
+
+            return _rpc.NotifyWithParameterObjectAsync("textDocument/didOpen", request);
+        }
+
+        public Task InvokeTextDocumentDidChangeAsync(LSP.DidChangeTextDocumentParams request) {
+            if (_rpc == null) {
+                return Task.CompletedTask;
+            }
+
+            return _rpc.NotifyWithParameterObjectAsync("textDocument/didChange", request);
+        }
+
+        public Task InvokeConfigurationChangeAsync(LSP.DidChangeConfigurationParams request) {
+            if (_rpc == null) {
+                return Task.CompletedTask;
+            }
+
+            return _rpc.NotifyWithParameterObjectAsync("workspace/didChangeConfiguration", request);
+        }
+
+
+        public Task<LSP.CompletionList> InvokeTextDocumentCompletionAsync(
+            LSP.CompletionParams request,
+            CancellationToken cancellationToken = default(CancellationToken)
+        ) {
+            if (_rpc == null) {
+                return Task.FromResult(new LSP.CompletionList());
+            }
+
+            return _rpc.InvokeWithParameterObjectAsync<LSP.CompletionList>("textDocument/completion", request);
+        }
+
+        public Task<TResult> InvokeWithParameterObjectAsync<TResult>(string targetName, object argument = null, CancellationToken cancellationToken = default) {
+            if (_rpc == null) {
+                return Task.FromResult(default(TResult));
+            }
+
+            return _rpc.InvokeWithParameterObjectAsync<TResult>(targetName, argument, cancellationToken);
+        }
+
+        private void Stop() {
+            // _site.GetUIThread().InvokeTaskSync(async () => {
+            //await StopAsync?.Invoke(this, EventArgs.Empty);
+            //   }, CancellationToken.None);
+            StopAsync?.Invoke(this, EventArgs.Empty).GetAwaiter().GetResult();
+        }
+
+        private void OnClosed(object sender, EventArgs e) {
+            PythonLanguageClient.DisposeLanguageClient(ContentTypeName);
+        }
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClientContextFixed.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClientContextFixed.cs
@@ -1,0 +1,56 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Python.Analysis.Core.Interpreter;
+
+namespace UnitTests.LanguageServerClient {
+    public class PythonLanguageClientContextFixed : IPythonLanguageClientContext {
+        public event EventHandler InterpreterChanged { add { } remove { } }
+        public event EventHandler SearchPathsChanged { add { } remove { } }
+        public event EventHandler Closed { add { } remove { } }
+
+        public PythonLanguageClientContextFixed(
+            string contentTypeName,
+            InterpreterConfiguration configuration,
+            string rootPath,
+            IEnumerable<string> searchPaths
+        ) {
+            ContentTypeName = contentTypeName ?? throw new ArgumentNullException(nameof(contentTypeName));
+            InterpreterConfiguration = configuration;
+            RootPath = rootPath;
+            SearchPaths = searchPaths;
+        }
+
+        public string ContentTypeName { get; }
+
+        public InterpreterConfiguration InterpreterConfiguration { get; }
+
+        public string RootPath { get; }
+
+        public IEnumerable<string> SearchPaths { get; }
+
+        public object Clone() {
+            return new PythonLanguageClientContextFixed(
+                ContentTypeName,
+                InterpreterConfiguration,
+                RootPath,
+                SearchPaths
+            );
+        }
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClientCustomTarget.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClientCustomTarget.cs
@@ -1,0 +1,66 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Diagnostics;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.LanguageServerClient {
+    internal class PythonLanguageClientCustomTarget {
+
+        public PythonLanguageClientCustomTarget() {
+
+        }
+
+        [JsonRpcMethod("telemetry/event")]
+        public void OnTelemetryEvent(JToken arg) {
+            var telemetry = arg as JObject;
+            if (telemetry != null) {
+                Trace.WriteLine(telemetry.ToString());
+            }
+        }
+
+        [JsonRpcMethod("python/beginProgress")]
+        public void OnBeginProgress() {
+        }
+
+        [JsonRpcMethod("python/reportProgress")]
+        public Task OnReportProgressAsync(JToken arg) {
+            //await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            //var msg = arg.ToString();
+            //var statusBar = _site.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+            //statusBar?.SetText(msg);
+            return Task.CompletedTask;
+        }
+
+        [JsonRpcMethod("python/endProgress")]
+        public Task OnEndProgressAsync() {
+            //await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            //var statusBar = _site.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+            //statusBar?.SetText("Python analysis done");
+            return Task.CompletedTask;
+        }
+
+        public string OnCustomRequest(string test) {
+            // Example of a request from server. Don't know if we have any of those.
+            return string.Empty;
+        }
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClientMetadata.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageClientMetadata.cs
@@ -1,0 +1,33 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.LanguageServer.Client;
+
+namespace UnitTests.LanguageServerClient {
+    internal class PythonLanguageClientMetadata : ILanguageClientMetadata {
+        public PythonLanguageClientMetadata(string clientName, string contentType) {
+            ClientName = clientName;
+            ContentType = contentType;
+        }
+
+        public string ClientName { get; }
+
+        public string ContentType { get; }
+
+        public IEnumerable<string> ContentTypes => new[] { ContentType };
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageServer.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageServer.cs
@@ -1,0 +1,40 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Python.Parsing;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+
+namespace UnitTests.LanguageServerClient {
+    public abstract class PythonLanguageServer : IDisposable {
+        public static PythonLanguageServer Create(JoinableTaskContext joinableTaskContext, PythonLanguageVersion version) {
+            if (PythonLanguageServerNodejs.IsPreferred(version)) {
+                return new PythonLanguageServerNodejs(joinableTaskContext);
+            }
+
+            return new PythonLanguageServerDotNetCore(joinableTaskContext);
+        }
+
+        public abstract Task<Connection> ActivateAsync();
+
+        public abstract object CreateInitializationOptions(string interpreterPath, string interpreterVersion, string rootPath, IEnumerable<string> searchPaths);
+
+        public abstract void Dispose();
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageServerDotNetCore.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageServerDotNetCore.cs
@@ -1,0 +1,244 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.LanguageServerClient {
+    public class PythonLanguageServerDotNetCore : PythonLanguageServer {
+        private readonly JoinableTaskContext _joinableTaskContext;
+        private const string ExeName = "Microsoft.Python.LanguageServer.exe";
+        private const string DllName = "Microsoft.Python.LanguageServer.dll";
+        private Process _process;
+
+        public PythonLanguageServerDotNetCore(JoinableTaskContext joinableTaskContext) {
+            _joinableTaskContext = joinableTaskContext ?? throw new ArgumentNullException(nameof(joinableTaskContext));
+        }
+
+
+        // Since VS is 32-bit process, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+        // gives us 32-bit program files so can't use that
+        private static string DotNetExeFilePath = Path.Combine(
+            @"C:\Program Files",
+            "dotnet",
+            "dotnet.exe"
+        );
+
+
+        public async override Task<Connection> ActivateAsync() {
+            await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
+            var serverFolderPath = GetServerLocation();
+
+            await Task.Yield();
+
+            var info = CreateStartInfo(serverFolderPath);
+
+            if (_process != null) {
+                throw new Exception("need to dispose of old server first");
+            }
+
+            _process = new Process {
+                StartInfo = info
+            };
+
+            if (_process.Start()) {
+                return new Connection(_process.StandardOutput.BaseStream, _process.StandardInput.BaseStream);
+            }
+
+            return null;
+        }
+
+        public override object CreateInitializationOptions(string interpreterPath, string interpreterVersion, string rootPath, IEnumerable<string> searchPaths) {
+            var serverFolderPath = GetServerLocation();
+
+            return new PythonInitializationOptions {
+                interpreter = new PythonInitializationOptions.Interpreter {
+                    properties = new PythonInitializationOptions.Interpreter.InterpreterProperties {
+                        InterpreterPath = interpreterPath,
+                        Version = interpreterVersion,
+                        DatabasePath = serverFolderPath,
+                    }
+                },
+                searchPaths = searchPaths?.ToArray() ?? new string[0],
+                typeStubSearchPaths = new[] {
+                        Path.Combine(serverFolderPath, "Typeshed")
+                    },
+                excludeFiles = new[] {
+                        "**/Lib/**",
+                        "**/site-packages/**",
+                        "**/node_modules",
+                        "**/bower_components",
+                        "**/.git",
+                        "**/.svn",
+                        "**/.hg",
+                        "**/CVS",
+                        "**/.DS_Store",
+                        "**/.git/objects/**",
+                        "**/.git/subtree-cache/**",
+                        "**/node_modules/*/**",
+                        ".vscode/*.py",
+                        "**/site-packages/**/*.py"
+                    },
+                rootPathOverride = rootPath
+            };
+        }
+
+        private static ProcessStartInfo CreateStartInfo(string folderPath) {
+            var serverDllFilePath = Path.Combine(folderPath, DllName);
+            var serverExeFilePath = Path.Combine(folderPath, ExeName);
+
+            if (File.Exists(serverExeFilePath)) {
+                return new ProcessStartInfo {
+                    FileName = serverExeFilePath,
+                    WorkingDirectory = folderPath,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+            } else if (File.Exists(serverDllFilePath)) {
+                return new ProcessStartInfo {
+                    FileName = DotNetExeFilePath,
+                    WorkingDirectory = folderPath,
+                    Arguments = '"' + serverDllFilePath + '"',
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+            } else {
+                Debug.Fail("Could not find language server exe or dll");
+                throw new FileNotFoundException("Could not find language server exe or dll", serverDllFilePath);
+            }
+        }
+
+        private string GetServerLocation() {
+            // For testing, allow to specify via env var the location
+            // of an extracted language server
+            var lsExtractedFolderPath = Environment.GetEnvironmentVariable("PTVS_DOTNETCORE_SERVER_LOCATION");
+            if (Directory.Exists(lsExtractedFolderPath)) {
+                return lsExtractedFolderPath;
+            }
+
+            if (!_joinableTaskContext.IsOnMainThread) {
+                throw new InvalidOperationException("Must be called from main thread.");
+            }
+
+            //var shell = _site.GetService<SVsShell, IVsShell>();
+            //shell.GetProperty((int)__VSSPROPID4.VSSPROPID_LocalAppDataDir, out object localAppDataFolderPath);
+
+            //lsExtractedFolderPath = Path.Combine((string)localAppDataFolderPath, "PythonLanguageServer");
+            //if (!Directory.Exists(lsExtractedFolderPath)) {
+            //    ExtractToFolder(lsExtractedFolderPath);
+            //}
+
+            return lsExtractedFolderPath;
+        }
+
+        public static void ExtractToFolder(string lsExtractedFolderPath) {
+            var lsZipFolderPath = Path.GetDirectoryName(typeof(PythonLanguageServerDotNetCore).Assembly.Location);
+            var lsZipFileName = string.Format(CultureInfo.InvariantCulture, "Python-Language-Server-win-{0}.zip", Environment.Is64BitOperatingSystem ? "x64" : "x86");
+            var lsZipFilePath = Path.Combine(lsZipFolderPath, lsZipFileName);
+
+            if (File.Exists(lsZipFilePath)) {
+                ZipFile.ExtractToDirectory(lsZipFilePath, lsExtractedFolderPath);
+            } else {
+                throw new FileNotFoundException("Python Language Server archive file not found.", lsZipFilePath);
+            }
+        }
+
+        public override void Dispose() {
+            if (_process != null) {
+                try {
+                    _process.Kill();
+                } catch (InvalidOperationException) { } catch (NotSupportedException) { }
+
+                _process.WaitForExit();
+                _process.Dispose();
+                _process = null;
+            }
+        }
+
+        /// <summary>
+        /// Required layout for the initializationOptions member of initializeParams
+        /// Match PythonInitializationOptions in https://github.com/microsoft/python-language-server/blob/master/src/LanguageServer/Impl/Protocol/Classes.cs
+        /// </summary>
+        [Serializable]
+        public sealed class PythonInitializationOptions {
+            [Serializable]
+            public struct Interpreter {
+                public sealed class InterpreterProperties {
+                    public string Version;
+                    public string InterpreterPath;
+                    public string DatabasePath;
+                }
+                public InterpreterProperties properties;
+            }
+            public Interpreter interpreter;
+
+            /// <summary>
+            /// Paths to search when attempting to resolve module imports.
+            /// </summary>
+            public string[] searchPaths = Array.Empty<string>();
+
+            /// <summary>
+            /// Paths to search for module stubs.
+            /// </summary>
+            public string[] typeStubSearchPaths = Array.Empty<string>();
+
+            /// <summary>
+            /// Glob pattern of files and folders to exclude from loading
+            /// into the Python analysis engine.
+            /// </summary>
+            public string[] excludeFiles = Array.Empty<string>();
+
+            /// <summary>
+            /// Glob pattern of files and folders under the root folder that
+            /// should be loaded into the Python analysis engine.
+            /// </summary>
+            public string[] includeFiles = Array.Empty<string>();
+
+            /// <summary>
+            /// Path to a writable folder where analyzer can cache its data.
+            /// </summary>
+            public string cacheFolderPath;
+
+            /// <summary>
+            /// Root path override (used by PTVS).
+            /// </summary>
+            public string rootPathOverride;
+        }
+
+        public sealed class InformationDisplayOptions {
+            public string preferredFormat;
+            public bool trimDocumentationLines;
+            public int maxDocumentationLineLength;
+            public bool trimDocumentationText;
+            public int maxDocumentationTextLength;
+            public int maxDocumentationLines;
+        }
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageServerNodejs.cs
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/PythonLanguageServerNodejs.cs
@@ -1,0 +1,218 @@
+﻿// Python Tools for Visual Studio
+// Copyright(c) Microsoft Corporation
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+// IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Python.Parsing;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.Win32;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.LanguageServerClient {
+    internal class PythonLanguageServerNodejs : PythonLanguageServer {
+        private readonly JoinableTaskContext _joinableTaskContext;
+        private Process _process;
+
+        public PythonLanguageServerNodejs(JoinableTaskContext joinableTaskContext) {
+            _joinableTaskContext = joinableTaskContext ?? throw new ArgumentNullException(nameof(joinableTaskContext));
+        }
+
+        private static bool IsEnabled => IsEnvVarEnabled("PTVS_NODE_SERVER_ENABLED");
+
+        private static bool IsForcedOnPython2 => IsEnvVarEnabled("PTVS_NODE_SERVER_FORCED_ON_PYTHON2");
+
+        public static bool IsPreferred(PythonLanguageVersion version) {
+            if (!IsEnabled) {
+                return false;
+            }
+
+            if (IsForcedOnPython2) {
+                return true;
+            }
+
+            return version >= PythonLanguageVersion.V30 || version == PythonLanguageVersion.None;
+        }
+
+        public async override Task<Connection> ActivateAsync() {
+            await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
+            var nodePath = GetNodeExecutablePath();
+            if (!File.Exists(nodePath)) {
+                throw new FileNotFoundException("Node.js was not found. It is required to run the language server.");
+            }
+
+            var serverFolderPath = GetServerLocation();
+            if (!Directory.Exists(serverFolderPath)) {
+                throw new FileNotFoundException("Node.js based language server was not found.");
+            }
+
+            var serverFilePath = Path.Combine(serverFolderPath, @"server\server.bundle.js");
+            if (!File.Exists(serverFilePath)) {
+                throw new FileNotFoundException("Node.js based language server server, server.bundle.js was not found.");
+            }
+
+            await Task.Yield();
+
+            var info = new ProcessStartInfo {
+                FileName = nodePath,
+                WorkingDirectory = serverFolderPath,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                Arguments = serverFilePath,
+            };
+
+            _process = new Process {
+                StartInfo = info
+            };
+
+            if (_process.Start()) {
+                return new Connection(_process.StandardOutput.BaseStream, _process.StandardInput.BaseStream);
+            }
+
+            return null;
+        }
+
+        public override object CreateInitializationOptions(string interpreterPath, string interpreterVersion, string rootPath, IEnumerable<string> searchPaths) {
+            return new PythonInitializationOptions {
+                analysis = null,
+                pythonPath = interpreterPath,
+                disableLanguageServices = false,
+                openFilesOnly = false,
+                venvPath = null,
+                useLibraryCodeForTypes = true,
+            };
+        }
+
+        private static string GetServerLocation() {
+            // At some point, we'll bundle it and return the install location
+            // but for now, to allow for testing, location is retrieved via
+            // environment variable.
+            var folderPath = Environment.GetEnvironmentVariable("PTVS_NODE_SERVER_LOCATION");
+            if (Directory.Exists(folderPath)) {
+                return folderPath;
+            }
+
+            return null;
+        }
+
+        private static bool IsEnvVarEnabled(string variable) {
+            var val = Environment.GetEnvironmentVariable(variable);
+            if (string.IsNullOrEmpty(val)) {
+                return false;
+            }
+
+            return val != "0" && string.Compare(val, "false", StringComparison.OrdinalIgnoreCase) != 0;
+        }
+
+        private string GetNodeExecutablePath() {
+            string filePath;
+
+            // Prefer the node executable from the server folder, if there is one
+            var serverFolderPath = GetServerLocation();
+            if (Directory.Exists(serverFolderPath)) {
+                filePath = Path.Combine(serverFolderPath, "node.exe");
+                if (File.Exists(filePath)) {
+                    return filePath;
+                }
+            }
+
+            // For development convenience, allow use of global node.js install
+            if (Environment.Is64BitOperatingSystem) {
+                filePath = GetNodePathFromRegistry(RegistryView.Registry64);
+                if (File.Exists(filePath)) {
+                    return filePath;
+                }
+            }
+
+            filePath = GetNodePathFromRegistry(RegistryView.Registry32);
+            if (File.Exists(filePath)) {
+                return filePath;
+            }
+
+            return null;
+        }
+
+        private static string GetNodePathFromRegistry(RegistryView view) {
+            using (var root = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view))
+            using (var key = root.OpenSubKey("Software\\Node.js")) {
+                var installPath = key.GetValue("InstallPath", null) as string;
+                if (Directory.Exists(installPath)) {
+                    var filePath = Path.Combine(installPath, "node.exe");
+                    if (File.Exists(filePath)) {
+                        return filePath;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public override void Dispose() {
+            if (_process != null) {
+                try {
+                    _process.Kill();
+                } catch (InvalidOperationException) { } catch (NotSupportedException) { }
+
+                _process.WaitForExit();
+                _process.Dispose();
+                _process = null;
+            }
+        }
+
+        [Serializable]
+        public sealed class PythonInitializationOptions {
+            [Serializable]
+            public class AnalysisOptions {
+                /// <summary>
+                /// Paths to look for typeshed modules.
+                /// </summary>
+                public string[] typeshedPaths = Array.Empty<string>();
+            }
+            public AnalysisOptions analysis;
+
+            /// <summary>
+            /// Path to Python, you can use a custom version of Python.
+            /// </summary>
+            public string pythonPath;
+
+            /// <summary>
+            /// Path to folder with a list of Virtual Environments.
+            /// </summary>
+            public string venvPath;
+
+            /// <summary>
+            /// Disables type completion, definitions, and references.
+            /// </summary>
+            public bool disableLanguageServices;
+
+            /// <summary>
+            /// Report errors only for currently-open files.
+            /// </summary>
+            public bool openFilesOnly;
+
+            /// <summary>
+            /// Use library implementations to extract type information when type stub is not present.
+            /// </summary>
+            public bool useLibraryCodeForTypes;
+        }
+    }
+}

--- a/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/UnitTests.LanguageServerClient.csproj
+++ b/src/UnitTests/LanguageServerClient/UnitTests.LanguageServerClient/UnitTests.LanguageServerClient.csproj
@@ -1,0 +1,38 @@
+﻿<Project>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>NU1701</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
+  <Import Project="..\..\..\..\build\NetStandard.settings" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup>
+    <PackageReference Include="Ben.Demystifier" Version="0.1.4" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="MicroBuild.Core" Version="0.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="16.4.280" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="16.4.30" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="16.4.30" />
+    <PackageReference Include="StreamJsonRpc" Version="2.2.53" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Analysis\Core\Impl\Microsoft.Python.Analysis.Core.csproj" />
+    <ProjectReference Include="..\..\..\Parsing\Impl\Microsoft.Python.Parsing.csproj" />
+  </ItemGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="..\..\..\..\build\NetStandard.targets" />
+</Project>


### PR DESCRIPTION

Initial changes around integration LS testing.
I needed a new test project for mock language server client code.

- currently left code around setting environment variables for choosing which type LS to startup
- added code to kill the server process 