### PR TITLE
Look into PATH for python if not provided in initialization options

### DIFF
--- a/src/Core/Impl/IO/PathUtils.cs
+++ b/src/Core/Impl/IO/PathUtils.cs
@@ -518,5 +518,30 @@ namespace Microsoft.Python.Core.IO {
         }
 
         public static string NormalizePathAndTrim(string path) => TrimEndSeparator(NormalizePath(path));
+
+        public static string LookPath(IFileSystem fs, string exeName) {
+            var path = Environment.GetEnvironmentVariable("PATH");
+            if (string.IsNullOrWhiteSpace(path)) {
+                return null;
+            }
+
+            foreach (var p in path.Split(Path.PathSeparator)) {
+                var x = Path.Combine(p, exeName);
+
+                if (IsWindows) {
+                    x += ".exe"; // TODO: other extensions?
+                }
+
+                if (!fs.FileExists(x)) {
+                    continue;
+                }
+
+                // TODO: check executable on non-Windows platforms.
+
+                return x;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Python.Analysis;
@@ -138,10 +139,24 @@ namespace Microsoft.Python.LanguageServer.Implementation {
             _services.AddService(new RunningDocumentTable(_services));
             _rdt = _services.GetService<IRunningDocumentTable>();
 
-            Version.TryParse(initializationOptions?.interpreter.properties?.Version, out var version);
+            var interpeterPath = initializationOptions?.interpreter.properties?.InterpreterPath;
+            Version version = null;
+
+            if (!string.IsNullOrWhiteSpace(interpeterPath)) {
+                Version.TryParse(initializationOptions?.interpreter.properties?.Version, out version);
+            } else {
+                var fs = _services.GetService<IFileSystem>();
+                var exePath = PathUtils.LookPath(fs, "python");
+                if (exePath != null && TryGetPythonVersion(exePath, out version)) {
+                    _log?.Log(TraceEventType.Information, Resources.UsingPythonFromPATH);
+                    interpeterPath = exePath;
+                } else {
+                    interpeterPath = null;
+                }
+            }
 
             var configuration = new InterpreterConfiguration(
-                interpreterPath: initializationOptions?.interpreter.properties?.InterpreterPath,
+                interpreterPath: interpeterPath,
                 version: version
             );
             _services.AddService(new ModuleDatabase(_services));
@@ -285,6 +300,39 @@ namespace Microsoft.Python.LanguageServer.Implementation {
                 _log?.Log(TraceEventType.Information, Resources.Done);
                 _log?.Log(TraceEventType.Information, Resources.AnalysisRestarted);
             }).DoNotWait();
+        }
+
+        private bool TryGetPythonVersion(string exePath, out Version version) {
+            var startInfo = new ProcessStartInfo {
+                FileName = exePath,
+                Arguments = "-c \"import sys; print('{}.{}.{}'.format(*sys.version_info))\"",
+                UseShellExecute = false,
+                ErrorDialog = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            var output = string.Empty;
+
+            try {
+                using (var process = new Process()) {
+                    process.StartInfo = startInfo;
+                    process.ErrorDataReceived += (s, e) => { };
+
+                    process.Start();
+                    process.BeginErrorReadLine();
+
+                    output = process.StandardOutput.ReadToEnd();
+
+                    return Version.TryParse(output, out version);
+                }
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
+                version = null;
+                return false;
+            }
         }
         #endregion
     }

--- a/src/LanguageServer/Impl/Implementation/Server.cs
+++ b/src/LanguageServer/Impl/Implementation/Server.cs
@@ -303,36 +303,32 @@ namespace Microsoft.Python.LanguageServer.Implementation {
         }
 
         private bool TryGetPythonVersion(string exePath, out Version version) {
-            var startInfo = new ProcessStartInfo {
-                FileName = exePath,
-                Arguments = "-c \"import sys; print('{}.{}.{}'.format(*sys.version_info))\"",
-                UseShellExecute = false,
-                ErrorDialog = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8,
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            };
-
-            var output = string.Empty;
-
             try {
-                using (var process = new Process()) {
-                    process.StartInfo = startInfo;
-                    process.ErrorDataReceived += (s, e) => { };
+                using var process = new Process {
+                    StartInfo = new ProcessStartInfo {
+                        FileName = exePath,
+                        Arguments = "-c \"import sys; print('{}.{}.{}'.format(*sys.version_info))\"",
+                        UseShellExecute = false,
+                        ErrorDialog = false,
+                        CreateNoWindow = true,
+                        StandardOutputEncoding = Encoding.UTF8,
+                        RedirectStandardInput = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true
+                    }
+                };
 
-                    process.Start();
-                    process.BeginErrorReadLine();
+                process.ErrorDataReceived += (s, e) => { };
+                process.Start();
+                process.BeginErrorReadLine();
 
-                    output = process.StandardOutput.ReadToEnd();
+                var output = process.StandardOutput.ReadToEnd();
 
-                    return Version.TryParse(output, out version);
-                }
-            } catch (Exception ex) when (!ex.IsCriticalException()) {
-                version = null;
-                return false;
-            }
+                return Version.TryParse(output, out version);
+            } catch (Exception ex) when (!ex.IsCriticalException()) { }
+
+            version = null;
+            return false;
         }
         #endregion
     }

--- a/src/LanguageServer/Impl/Resources.Designer.cs
+++ b/src/LanguageServer/Impl/Resources.Designer.cs
@@ -187,6 +187,15 @@ namespace Microsoft.Python.LanguageServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No interpreter specified, using Python from PATH..
+        /// </summary>
+        internal static string UsingPythonFromPATH {
+            get {
+                return ResourceManager.GetString("UsingPythonFromPATH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Workspace root: {0}.
         /// </summary>
         internal static string WorkspaceRoot {

--- a/src/LanguageServer/Impl/Resources.resx
+++ b/src/LanguageServer/Impl/Resources.resx
@@ -159,6 +159,9 @@
   <data name="RenameVariable_CannotRename" xml:space="preserve">
     <value>Cannot rename</value>
   </data>
+  <data name="UsingPythonFromPATH" xml:space="preserve">
+    <value>No interpreter specified, using Python from PATH.</value>
+  </data>
   <data name="WorkspaceRoot" xml:space="preserve">
     <value>Workspace root: {0}</value>
   </data>


### PR DESCRIPTION
If no interpreter is specified, fall back to finding the first `python` binary in `PATH`. This should eliminate the last "required" initialization option.

@MoerkerkeLander, I'd appreciate it if you could try this build.

Updates #1938.
Fixes #469.