### PR TITLE
Add loose fuzzy matching for workspace symbol queries

### DIFF
--- a/src/LanguageServer/Impl/Indexing/SymbolIndex.cs
+++ b/src/LanguageServer/Impl/Indexing/SymbolIndex.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Python.LanguageServer.Indexing {
                 var sym = symAndPar.symbol;
                 return DecorateWithParentsName((sym.Children ?? Enumerable.Empty<HierarchicalSymbol>()).ToList(), sym.Name);
             });
-            return treeSymbols.Where(sym => sym.symbol.Name.ContainsOrdinal(query, ignoreCase: true))
+            return treeSymbols.Where(sym => FuzzyMatch(query, sym.symbol.Name))
                               .Select(sym => new FlatSymbol(sym.symbol.Name, sym.symbol.Kind, path, sym.symbol.SelectionRange, sym.parentName, sym.symbol._existInAllVariable));
         }
 
@@ -113,6 +113,20 @@ namespace Microsoft.Python.LanguageServer.Indexing {
 
         public void Dispose() {
             _disposables.TryDispose();
+        }
+
+        private bool FuzzyMatch(string pattern, string name) {
+            var patternPos = 0;
+            var namePos = 0;
+
+            while (patternPos < pattern.Length && namePos < name.Length) {
+                if (char.ToLowerInvariant(pattern[patternPos]) == char.ToLowerInvariant(name[namePos])) {
+                    patternPos++;
+                }
+                namePos++;
+            }
+
+            return patternPos == pattern.Length;
         }
     }
 }

--- a/src/LanguageServer/Impl/Indexing/SymbolIndex.cs
+++ b/src/LanguageServer/Impl/Indexing/SymbolIndex.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Python.LanguageServer.Indexing {
             _disposables.TryDispose();
         }
 
-        private bool FuzzyMatch(string pattern, string name) {
+        private static bool FuzzyMatch(string pattern, string name) {
             var patternPos = 0;
             var namePos = 0;
 

--- a/src/LanguageServer/Test/SymbolIndexTests.cs
+++ b/src/LanguageServer/Test/SymbolIndexTests.cs
@@ -161,6 +161,23 @@ namespace Microsoft.Python.LanguageServer.Tests {
         }
 
         [TestMethod, Priority(0)]
+        public async Task IndexWorkspaceSymbolsFuzzyAsync() {
+            const string code = @"class FXoo(object):
+    def foxo(self, x): ...";
+
+            using (var index = MakeSymbolIndex()) {
+                var path = TestData.GetDefaultModulePath();
+                index.Add(path, DocumentWithAst(code));
+
+                var symbols = await index.WorkspaceSymbolsAsync("foo", maxSymbols);
+                symbols.Should().BeEquivalentToWithStrictOrdering(new[] {
+                    new FlatSymbol("FXoo", SymbolKind.Class, path, new SourceSpan(1, 7, 1, 11)),
+                    new FlatSymbol("foxo", SymbolKind.Method, path, new SourceSpan(2, 9, 2, 13), "FXoo"),
+                });
+            }
+        }
+
+        [TestMethod, Priority(0)]
         public void MarkAsPendingWaitsForUpdates() {
             using (var index = MakeSymbolIndex()) {
                 var path = TestData.GetDefaultModulePath();


### PR DESCRIPTION
Fixes #697. Modified version of https://github.com/microsoft/python-language-server/issues/697#issuecomment-597587009 (with case insensitivity).