### PR TITLE
Remove imports from symbols

### DIFF
--- a/src/LanguageServer/Impl/Indexing/SymbolIndexWalker.cs
+++ b/src/LanguageServer/Impl/Indexing/SymbolIndexWalker.cs
@@ -124,28 +124,6 @@ namespace Microsoft.Python.LanguageServer.Indexing {
             }
         }
 
-        public override bool Walk(ImportStatement node) {
-            foreach (var (nameNode, nameString) in node.Names.Zip(node.AsNames, (name, asName) => asName != null ? (asName, asName.Name) : ((Node)name, name.MakeString()))) {
-                var span = nameNode.GetSpan(_ast);
-                _stack.AddSymbol(new HierarchicalSymbol(nameString, SymbolKind.Module, span, existInAllVariable: ExistInAllVariable(nameString)));
-            }
-
-            return false;
-        }
-
-        public override bool Walk(FromImportStatement node) {
-            if (node.IsFromFuture) {
-                return false;
-            }
-
-            foreach (var name in node.Names.Zip(node.AsNames, (name, asName) => asName ?? name)) {
-                var span = name.GetSpan(_ast);
-                _stack.AddSymbol(new HierarchicalSymbol(name.Name, SymbolKind.Module, span, existInAllVariable: ExistInAllVariable(name.Name)));
-            }
-
-            return false;
-        }
-
         public override bool Walk(AssignmentStatement node) {
             WalkIfNotLibraryMode(node.Right);
 

--- a/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
+++ b/src/LanguageServer/Test/SymbolIndexWalkerTests.cs
@@ -196,14 +196,7 @@ from os.path import ( join as osjoin2, exists as osexists, expanduser )
 ";
 
             var symbols = WalkSymbols(code);
-            symbols.Should().BeEquivalentToWithStrictOrdering(new[] {
-                new HierarchicalSymbol("sys", SymbolKind.Module, new SourceSpan(1, 8, 1, 11)),
-                new HierarchicalSymbol("np", SymbolKind.Module, new SourceSpan(2, 17, 2, 19)),
-                new HierarchicalSymbol("osjoin", SymbolKind.Module, new SourceSpan(3, 29, 3, 35)),
-                new HierarchicalSymbol("osjoin2", SymbolKind.Module, new SourceSpan(4, 31, 4, 38)),
-                new HierarchicalSymbol("osexists", SymbolKind.Module, new SourceSpan(4, 50, 4, 58)),
-                new HierarchicalSymbol("expanduser", SymbolKind.Module, new SourceSpan(4, 60, 4, 70)),
-            });
+            symbols.Should().BeEmpty();
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Don't walk imports when indexing symbols. I did this originally to match the old behavior, but it's not very useful for the outline to be cluttered with imports and this matches the behavior of other languages.

Not urgent to merge (want someone to see how this looks in the outline), but wanted to have this available.

Closes #612.
Fixes #1931.