### PR TITLE
CONTRIBUTING.md: correct the default clone path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 
 ```shell
 git clone https://github.com/Microsoft/python-language-server.git
-cd src/LanguageServer/Impl
+cd python-language-server/src/LanguageServer/Impl
 dotnet build
 ```
 


### PR DESCRIPTION
Only a tiny change. After cloning a repository, a new directory named by the repository is created. So it is required to enter that directory first.