### PR TITLE
Add more members to PythonLanguageVersion enum

### DIFF
--- a/src/Parsing/Impl/PythonLanguageVersion.cs
+++ b/src/Parsing/Impl/PythonLanguageVersion.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Python.Parsing {
         V36 = 0x0306,
         V37 = 0x0307,
         V38 = 0x0308,
-        V39 = 0x0309
+        V39 = 0x0309,
+        V310 = 0x030a,
+        V311 = 0x030b,
     }
 
     public static class PythonLanguageVersionExtensions {


### PR DESCRIPTION
PTVS has a dependency on this enum, and we are adding support for Python 3.10, so this enum needs to be updated.